### PR TITLE
Make sure landlord-migrate runs before octane starts

### DIFF
--- a/docker/s6-overlay/s6-rc.d/laravel-octane/dependencies
+++ b/docker/s6-overlay/s6-rc.d/laravel-octane/dependencies
@@ -1,1 +1,2 @@
 runas-user
+landlord-migrate


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Before we transition to separating migrations, they should run before Octane starts here.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
