### PR TITLE
[AIDAPP-50] Enhance the labels used for Service Requests

### DIFF
--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/CreateServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/CreateServiceRequest.php
@@ -67,7 +67,8 @@ class CreateServiceRequest extends CreateRecord
                     ->relationship('division', 'name')
                     ->label('Division')
                     ->required()
-                    ->exists((new Division())->getTable(), 'id'),
+                    ->exists((new Division())->getTable(), 'id')
+                    ->default(auth()->user()->teams()->count() ? auth()->user()->teams[0]?->division?->id : ''),
                 Select::make('status_id')
                     ->relationship('status', 'name')
                     ->label('Status')
@@ -105,15 +106,15 @@ class CreateServiceRequest extends CreateRecord
                     ->maxLength(255)
                     ->columnSpanFull(),
                 Textarea::make('close_details')
-                    ->label('Close Details/Description')
+                    ->label('Description')
                     ->nullable()
                     ->string()
-                    ->columnSpanFull(),
+                    ->columnSpan(1),
                 Textarea::make('res_details')
-                    ->label('Internal Service Request Details')
+                    ->label('Internal Details')
                     ->nullable()
                     ->string()
-                    ->columnSpanFull(),
+                    ->columnSpan(1),
                 EducatableSelect::make('respondent')
                     ->label('Related To')
                     ->required()

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/CreateServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/CreateServiceRequest.php
@@ -68,7 +68,7 @@ class CreateServiceRequest extends CreateRecord
                     ->label('Division')
                     ->required()
                     ->exists((new Division())->getTable(), 'id')
-                    ->default(auth()->user()->teams()->count() ? auth()->user()->teams[0]?->division?->id : ''),
+                    ->default(auth()->user()->teams()->count() ? auth()->user()?->teams()->first()?->division?->id : ''),
                 Select::make('status_id')
                     ->relationship('status', 'name')
                     ->label('Status')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/EditServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/EditServiceRequest.php
@@ -118,15 +118,15 @@ class EditServiceRequest extends EditRecord
                     ->maxLength(255)
                     ->columnSpanFull(),
                 Textarea::make('close_details')
-                    ->label('Close Details/Description')
+                    ->label('Description')
                     ->nullable()
                     ->string()
-                    ->columnSpanFull(),
+                    ->columnSpan(1),
                 Textarea::make('res_details')
-                    ->label('Internal Service Request Details')
+                    ->label('Internal Details')
                     ->nullable()
                     ->string()
-                    ->columnSpanFull(),
+                    ->columnSpan(1),
                 EducatableSelect::make('respondent')
                     ->label('Related To')
                     ->required(),

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ViewServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ViewServiceRequest.php
@@ -80,13 +80,11 @@ class ViewServiceRequest extends ViewRecord
                             )
                             ->label('Type'),
                         TextEntry::make('close_details')
-                            ->label('Close Details/Description')
-
-                            ->columnSpanFull(),
+                            ->label('Description')
+                            ->columnSpan(1),
                         TextEntry::make('res_details')
-                            ->label('Internal Service Request Details')
-
-                            ->columnSpanFull(),
+                            ->label('Internal Details')
+                            ->columnSpan(1),
                         TextEntry::make('respondent')
                             ->label('Related To')
                             ->color('primary')

--- a/app-modules/service-management/tests/ServiceRequest/ViewServiceRequestTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ViewServiceRequestTest.php
@@ -68,9 +68,9 @@ test('The correct details are displayed on the ViewServiceRequest page', functio
                 $serviceRequest->priority->name,
                 'Type',
                 $serviceRequest->priority->type->name,
-                'Close Details/Description',
+                'Description',
                 $serviceRequest->close_details,
-                'Internal Service Request Details',
+                'Internal Details',
                 $serviceRequest->res_details,
             ]
         );


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-

### Technical Description

> Describe your changes in detail. This should include technical/architectural decisions and reasoning, if applicable.
>In Service request creation some label names (Close/Description to "Description " and Internal Service Request Details to "Internal Details") has been renamed and display of Description and Internal Details 50/50 display now. In Division dropdown Logged in user's team default division will be auto selected if user's team belongs to any division.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
