### PR TITLE
[AIDAPP-61] Default logo for image in emails is broken

### DIFF
--- a/resources/views/vendor/mail/html/header.blade.php
+++ b/resources/views/vendor/mail/html/header.blade.php
@@ -53,7 +53,7 @@
                      style="height: 75px; max-height: 75px; max-width: 100vw;"
                      alt="{{ config('app.name') }}">
             @else
-                <img src="{{ Vite::asset('resources/images/default-logo-light.png') }}"
+                <img src="{{ url(Vite::asset('resources/images/default-logo-light.png')) }}"
                      style="height: 75px; max-height: 75px; max-width: 100vw;"
                      alt="{{ config('app.name') }}">
             @endif


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-61

### Technical Description

> Describe your changes in detail. This should include technical/architectural decisions and reasoning, if applicable.
> Added the url() function in header.blade.php to fix default image not displaying in emails. 
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
