### PR TITLE
[AIDAPP-64]: Unable to embed knowledge portal

### DIFF
--- a/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
+++ b/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
@@ -203,13 +203,14 @@ class ManagePortalSettings extends SettingsPage
                                             ->state(function () {
                                                 $code = resolve(GeneratePortalEmbedCode::class)->handle(PortalType::KnowledgeManagement);
 
-                                                return <<<EOD
+                                                $state = <<<EOD
                                                 ```
                                                 {$code}
                                                 ```
                                                 EOD;
+
+                                                return str($state)->markdown()->toHtmlString();
                                             })
-                                            ->markdown()
                                             ->copyable()
                                             ->copyableState(fn () => resolve(GeneratePortalEmbedCode::class)->handle(PortalType::KnowledgeManagement))
                                             ->copyMessage('Copied!')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestFormResource/Pages/EditServiceRequestForm.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestFormResource/Pages/EditServiceRequestForm.php
@@ -74,13 +74,14 @@ class EditServiceRequestForm extends EditRecord
                             ->state(function (ServiceRequestForm $serviceRequestForm) {
                                 $code = resolve(GenerateSubmissibleEmbedCode::class)->handle($serviceRequestForm);
 
-                                return <<<EOD
+                                $state = <<<EOD
                                 ```
                                 {$code}
                                 ```
                                 EOD;
+
+                                return str($state)->markdown()->toHtmlString();
                             })
-                            ->markdown()
                             ->copyable()
                             ->copyableState(fn (ServiceRequestForm $serviceRequestForm) => resolve(GenerateSubmissibleEmbedCode::class)->handle($serviceRequestForm))
                             ->copyMessage('Copied!')

--- a/app-modules/survey/src/Filament/Resources/SurveyResource/Pages/EditSurvey.php
+++ b/app-modules/survey/src/Filament/Resources/SurveyResource/Pages/EditSurvey.php
@@ -76,13 +76,14 @@ class EditSurvey extends EditRecord
                             ->state(function (Survey $survey) {
                                 $code = resolve(GenerateSubmissibleEmbedCode::class)->handle($survey);
 
-                                return <<<EOD
+                                $state = <<<EOD
                                 ```
                                 {$code}
                                 ```
                                 EOD;
+
+                                return str($state)->markdown()->toHtmlString();
                             })
-                            ->markdown()
                             ->copyable()
                             ->copyableState(fn (Survey $survey) => resolve(GenerateSubmissibleEmbedCode::class)->handle($survey))
                             ->copyMessage('Copied!')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-64

### Technical Description

Fixes the display of the Knowledge Portal Embed code display. Does the same for Survey and Service Request Forms.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
