### PR TITLE
[AIDAPP-79]: Enhance Addons label in Global Settings

### DIFF
--- a/app/Filament/Pages/ManageLicenseSettings.php
+++ b/app/Filament/Pages/ManageLicenseSettings.php
@@ -124,7 +124,7 @@ class ManageLicenseSettings extends SettingsPage
                                 ->required(),
                         ]
                     ),
-                Section::make('Addons')
+                Section::make('Enabled Features')
                     ->columns()
                     ->schema(
                         [


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-79

### Technical Description

Updated the `Addons` label in `ManageLicenseSettings` to `Enabled Features`. 
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
