### PR TITLE
[AIDAPP-82]: Forget the disks after setting config values

### DIFF
--- a/app/Multitenancy/Tasks/SwitchS3FilesystemTask.php
+++ b/app/Multitenancy/Tasks/SwitchS3FilesystemTask.php
@@ -37,6 +37,7 @@
 namespace App\Multitenancy\Tasks;
 
 use Spatie\Multitenancy\Models\Tenant;
+use Illuminate\Support\Facades\Storage;
 use Spatie\Multitenancy\Tasks\SwitchTenantTask;
 use App\Multitenancy\DataTransferObjects\TenantConfig;
 
@@ -119,5 +120,7 @@ class SwitchS3FilesystemTask implements SwitchTenantTask
             'filesystems.disks.s3.throw' => $throw,
             'filesystems.disks.s3.root' => $root,
         ]);
+
+        Storage::forgetDisk('s3');
     }
 }

--- a/app/Multitenancy/Tasks/SwitchS3PublicFilesystemTask.php
+++ b/app/Multitenancy/Tasks/SwitchS3PublicFilesystemTask.php
@@ -37,6 +37,7 @@
 namespace App\Multitenancy\Tasks;
 
 use Spatie\Multitenancy\Models\Tenant;
+use Illuminate\Support\Facades\Storage;
 use Spatie\Multitenancy\Tasks\SwitchTenantTask;
 use App\Multitenancy\DataTransferObjects\TenantConfig;
 
@@ -119,5 +120,7 @@ class SwitchS3PublicFilesystemTask implements SwitchTenantTask
             'filesystems.disks.s3-public.throw' => $throw,
             'filesystems.disks.s3-public.root' => $root,
         ]);
+
+        Storage::forgetDisk('s3-public');
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-82

### Technical Description

Clears the Storage facade after we set the filesystem config so settings are not shared between Tenants.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
