### PR TITLE
[AIDAPP-83]: Add configurability of email from name

### DIFF
--- a/app-modules/integration-aws-ses-event-handling/src/Filament/Pages/ManageAmazonSesSettings.php
+++ b/app-modules/integration-aws-ses-event-handling/src/Filament/Pages/ManageAmazonSesSettings.php
@@ -36,11 +36,19 @@
 
 namespace AidingApp\IntegrationAwsSesEventHandling\Filament\Pages;
 
+use Throwable;
 use App\Models\User;
+use App\Models\Tenant;
 use Filament\Forms\Form;
 use Filament\Pages\SettingsPage;
+use Illuminate\Support\Facades\DB;
+use Filament\Support\Exceptions\Halt;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\TextInput;
+
+use function Filament\Support\is_app_url;
+
+use Filament\Support\Facades\FilamentView;
 use App\Filament\Clusters\ProductIntegrations;
 use AidingApp\IntegrationAwsSesEventHandling\Settings\SesSettings;
 
@@ -75,7 +83,115 @@ class ManageAmazonSesSettings extends SettingsPage
                     ->schema([
                         TextInput::make('configuration_set')
                             ->label('Configuration Set'),
+                        TextInput::make('fromAddress')
+                            ->label('From Address')
+                            ->email()
+                            ->required(),
+                        TextInput::make('fromName')
+                            ->label('From Name')
+                            ->string()
+                            ->maxLength(150)
+                            ->required(),
                     ]),
             ]);
+    }
+
+    public function save(): void
+    {
+        try {
+            $this->beginDatabaseTransaction();
+            DB::connection('landlord')->beginTransaction();
+
+            $this->callHook('beforeValidate');
+
+            $data = $this->form->getState();
+
+            $this->callHook('afterValidate');
+
+            $data = $this->mutateFormDataBeforeSave($data);
+
+            $this->callHook('beforeSave');
+
+            $this->saveTenantData(
+                emailFrom: $data['fromAddress'],
+                emailName: $data['fromName'],
+            );
+
+            unset($data['fromAddress'], $data['fromName']);
+
+            $settings = app(static::getSettings());
+
+            $settings->fill($data);
+            $settings->save();
+
+            $this->callHook('afterSave');
+
+            $this->commitDatabaseTransaction();
+            DB::connection('landlord')->commit();
+        } catch (Halt $exception) {
+            if ($exception->shouldRollbackDatabaseTransaction()) {
+                $this->rollBackDatabaseTransaction();
+                DB::connection('landlord')->rollBack();
+            } else {
+                $this->commitDatabaseTransaction();
+                DB::connection('landlord')->commit();
+            }
+
+            return;
+        } catch (Throwable $exception) {
+            $this->rollBackDatabaseTransaction();
+            DB::connection('landlord')->rollBack();
+
+            throw $exception;
+        }
+
+        $this->rememberData();
+
+        $this->getSavedNotification()?->send();
+
+        if ($redirectUrl = $this->getRedirectUrl()) {
+            $this->redirect($redirectUrl, navigate: FilamentView::hasSpaMode() && is_app_url($redirectUrl));
+        }
+    }
+
+    protected function fillForm(): void
+    {
+        $this->callHook('beforeFill');
+
+        $settings = app(static::getSettings());
+
+        /** @var Tenant $tenant */
+        $tenant = Tenant::current();
+
+        /** @var TenantConfig $config */
+        $config = $tenant->config;
+
+        $data = $this->mutateFormDataBeforeFill(
+            [
+                ...$settings->toArray(),
+                'fromAddress' => $config->mail->fromAddress,
+                'fromName' => $config->mail->fromName,
+            ]
+        );
+
+        $this->form->fill($data);
+
+        $this->callHook('afterFill');
+    }
+
+    protected function saveTenantData(string $emailFrom, string $emailName): void
+    {
+        /** @var Tenant $tenant */
+        $tenant = Tenant::current();
+
+        /** @var TenantConfig $config */
+        $config = $tenant->config;
+
+        $config->mail->fromAddress = $emailFrom;
+        $config->mail->fromName = $emailName;
+
+        $tenant->config = $config;
+
+        $tenant->save();
     }
 }

--- a/app-modules/notification/src/Notifications/Messages/MailMessage.php
+++ b/app-modules/notification/src/Notifications/Messages/MailMessage.php
@@ -36,6 +36,7 @@
 
 namespace AidingApp\Notification\Notifications\Messages;
 
+use Laravel\Pennant\Feature;
 use App\Models\NotificationSetting;
 use Illuminate\Notifications\Messages\MailMessage as BaseMailMessage;
 
@@ -58,6 +59,15 @@ class MailMessage extends BaseMailMessage
 
     public function settings(?NotificationSetting $setting): static
     {
+        if (Feature::active('notification-settings-from-name')) {
+            if (! empty($setting->from_name)) {
+                $this->from(
+                    address: config('mail.from.address'),
+                    name: $setting->from_name,
+                );
+            }
+        }
+
         $this->viewData = [
             $this->viewData,
             'settings' => $setting,

--- a/app-modules/notification/tests/Features/NotificationFromNameTest.php
+++ b/app-modules/notification/tests/Features/NotificationFromNameTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\User;
+use App\Models\NotificationSetting;
+use Illuminate\Support\Facades\Notification;
+use AidingApp\Notification\Tests\Features\TestEmailSettingFromNameNotification;
+
+it('sets the mail from name based on settings fromName if set', function () {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $notificationSetting = new NotificationSetting();
+
+    $notificationSetting->from_name = fake()->name();
+
+    $notification = new TestEmailSettingFromNameNotification($notificationSetting);
+
+    $user->notify($notification);
+
+    Notification::assertSentTo(
+        $user,
+        function (TestEmailSettingFromNameNotification $notification, array $channels) use ($notificationSetting, $user) {
+            $mailMessage = $notification->toMail($user);
+
+            return $mailMessage->from[1] === $notificationSetting->from_name;
+        }
+    );
+});

--- a/app-modules/notification/tests/Features/NotificationFromNameTest.php
+++ b/app-modules/notification/tests/Features/NotificationFromNameTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Models\User;
 use App\Models\NotificationSetting;
 use Illuminate\Support\Facades\Notification;

--- a/app-modules/notification/tests/Features/TestEmailSettingFromNameNotification.php
+++ b/app-modules/notification/tests/Features/TestEmailSettingFromNameNotification.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AidingApp\Notification\Tests\Features;
+
+use App\Models\NotificationSetting;
+use AidingApp\Notification\Notifications\BaseNotification;
+use AidingApp\Notification\Notifications\EmailNotification;
+use AidingApp\Notification\Notifications\Messages\MailMessage;
+use AidingApp\Notification\Notifications\Concerns\EmailChannelTrait;
+
+class TestEmailSettingFromNameNotification extends BaseNotification implements EmailNotification
+{
+    use EmailChannelTrait;
+
+    public function __construct(
+        public NotificationSetting $setting,
+    ) {}
+
+    public function toEmail(object $notifiable): MailMessage
+    {
+        return MailMessage::make()
+            ->settings($this->setting)
+            ->subject('Test Subject')
+            ->greeting('Test Greeting')
+            ->content('This is a test email')
+            ->salutation('Test Salutation');
+    }
+}

--- a/app-modules/notification/tests/Features/TestEmailSettingFromNameNotification.php
+++ b/app-modules/notification/tests/Features/TestEmailSettingFromNameNotification.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AidingApp\Notification\Tests\Features;
 
 use App\Models\NotificationSetting;

--- a/app/Filament/Resources/NotificationSettingResource/Forms/NotificationSettingForm.php
+++ b/app/Filament/Resources/NotificationSettingResource/Forms/NotificationSettingForm.php
@@ -34,51 +34,39 @@
 </COPYRIGHT>
 */
 
-namespace App\Models;
+namespace App\Filament\Resources\NotificationSettingResource\Forms;
 
-use Spatie\MediaLibrary\HasMedia;
-use AidingApp\Division\Models\Division;
-use Spatie\MediaLibrary\InteractsWithMedia;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Filament\Forms\Form;
+use Laravel\Pennant\Feature;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use App\Filament\Forms\Components\ColorSelect;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 
-/**
- * @mixin IdeHelperNotificationSetting
- */
-class NotificationSetting extends BaseModel implements HasMedia
+class NotificationSettingForm
 {
-    use InteractsWithMedia;
-    use SoftDeletes;
-
-    protected $fillable = [
-        'from_name',
-        'name',
-        'primary_color',
-        'related_to_id',
-        'related_to_type',
-    ];
-
-    public function registerMediaCollections(): void
+    public function form(Form $form): Form
     {
-        $this->addMediaCollection('logo')
-            ->singleFile();
-    }
-
-    public function settings(): HasMany
-    {
-        return $this->hasMany(NotificationSettingPivot::class);
-    }
-
-    public function divisions(): MorphToMany
-    {
-        return $this->morphedByMany(
-            related: Division::class,
-            name: 'related_to',
-            table: 'notification_settings_pivot'
-        )
-            ->using(NotificationSettingPivot::class)
-            ->withPivot('id')
-            ->withTimestamps();
+        return $form
+            ->columns(1)
+            ->schema([
+                TextInput::make('name')
+                    ->string()
+                    ->required()
+                    ->autocomplete(false),
+                TextInput::make('from_name')
+                    ->string()
+                    ->maxLength(150)
+                    ->autocomplete(false)
+                    ->visible(Feature::active('notification-settings-from-name')),
+                Textarea::make('description')
+                    ->string(),
+                ColorSelect::make('primary_color'),
+                SpatieMediaLibraryFileUpload::make('logo')
+                    ->disk('s3')
+                    ->collection('logo')
+                    ->visibility('private')
+                    ->image(),
+            ]);
     }
 }

--- a/app/Filament/Resources/NotificationSettingResource/Pages/CreateNotificationSetting.php
+++ b/app/Filament/Resources/NotificationSettingResource/Pages/CreateNotificationSetting.php
@@ -37,12 +37,9 @@
 namespace App\Filament\Resources\NotificationSettingResource\Pages;
 
 use Filament\Forms\Form;
-use Filament\Forms\Components\Textarea;
-use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
-use App\Filament\Forms\Components\ColorSelect;
 use App\Filament\Resources\NotificationSettingResource;
-use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use App\Filament\Resources\NotificationSettingResource\Forms\NotificationSettingForm;
 
 class CreateNotificationSetting extends CreateRecord
 {
@@ -50,21 +47,6 @@ class CreateNotificationSetting extends CreateRecord
 
     public function form(Form $form): Form
     {
-        return $form
-            ->columns(1)
-            ->schema([
-                TextInput::make('name')
-                    ->string()
-                    ->required()
-                    ->autocomplete(false),
-                Textarea::make('description')
-                    ->string(),
-                ColorSelect::make('primary_color'),
-                SpatieMediaLibraryFileUpload::make('logo')
-                    ->disk('s3')
-                    ->collection('logo')
-                    ->visibility('private')
-                    ->image(),
-            ]);
+        return resolve(NotificationSettingForm::class)->form($form);
     }
 }

--- a/app/Filament/Resources/NotificationSettingResource/Pages/EditNotificationSetting.php
+++ b/app/Filament/Resources/NotificationSettingResource/Pages/EditNotificationSetting.php
@@ -38,12 +38,9 @@ namespace App\Filament\Resources\NotificationSettingResource\Pages;
 
 use Filament\Forms\Form;
 use Filament\Actions\DeleteAction;
-use Filament\Forms\Components\Textarea;
-use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
-use App\Filament\Forms\Components\ColorSelect;
 use App\Filament\Resources\NotificationSettingResource;
-use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use App\Filament\Resources\NotificationSettingResource\Forms\NotificationSettingForm;
 
 class EditNotificationSetting extends EditRecord
 {
@@ -51,22 +48,7 @@ class EditNotificationSetting extends EditRecord
 
     public function form(Form $form): Form
     {
-        return $form
-            ->columns(1)
-            ->schema([
-                TextInput::make('name')
-                    ->string()
-                    ->required()
-                    ->autocomplete(false),
-                Textarea::make('description')
-                    ->string(),
-                ColorSelect::make('primary_color'),
-                SpatieMediaLibraryFileUpload::make('logo')
-                    ->disk('s3')
-                    ->collection('logo')
-                    ->visibility('private')
-                    ->image(),
-            ]);
+        return resolve(NotificationSettingForm::class)->form($form);
     }
 
     protected function getHeaderActions(): array

--- a/app/Multitenancy/DataTransferObjects/TenantMailConfig.php
+++ b/app/Multitenancy/DataTransferObjects/TenantMailConfig.php
@@ -43,7 +43,7 @@ class TenantMailConfig extends Data
     public function __construct(
         public TenantMailersConfig $mailers,
         public string $mailer = 'smtp',
-        public string $fromAddress = 'noreply@aiding.app',
+        public string $fromAddress = 'no-reply@aiding.app',
         public string $fromName = 'Aiding App™',
     ) {}
 }

--- a/config/health.php
+++ b/config/health.php
@@ -99,7 +99,7 @@ return [
             'to' => env('HEALTH_CHECK_TO_EMAIL', 'your@example.com'),
 
             'from' => [
-                'address' => env('MAIL_FROM_ADDRESS', 'noreply@aiding.app'),
+                'address' => env('MAIL_FROM_ADDRESS', 'no-reply@aiding.app'),
                 'name' => env('MAIL_FROM_NAME', 'Aiding App™'),
             ],
         ],

--- a/config/mail.php
+++ b/config/mail.php
@@ -131,7 +131,7 @@ return [
     */
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDRESS', 'noreply@aiding.app'),
+        'address' => env('MAIL_FROM_ADDRESS', 'no-reply@aiding.app'),
         'name' => env('MAIL_FROM_NAME', 'Aiding App™'),
     ],
 

--- a/database/migrations/2024_06_03_173514_add_from_column_to_notification_settings_table.php
+++ b/database/migrations/2024_06_03_173514_add_from_column_to_notification_settings_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('notification_settings', function (Blueprint $table) {
+            $table->string('from_name')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('notification_settings', function (Blueprint $table) {
+            $table->dropColumn('from_name');
+        });
+    }
+};

--- a/database/migrations/2024_06_03_173514_add_from_column_to_notification_settings_table.php
+++ b/database/migrations/2024_06_03_173514_add_from_column_to_notification_settings_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2024_06_03_173540_data_activate_notification_settings_from_name_column.php
+++ b/database/migrations/2024_06_03_173540_data_activate_notification_settings_from_name_column.php
@@ -1,0 +1,16 @@
+<?php
+
+use Laravel\Pennant\Feature;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Feature::activate('notification-settings-from-name');
+    }
+
+    public function down(): void
+    {
+        Feature::deactivate('notification-settings-from-name');
+    }
+};

--- a/database/migrations/2024_06_03_173540_data_activate_notification_settings_from_name_column.php
+++ b/database/migrations/2024_06_03_173540_data_activate_notification_settings_from_name_column.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Laravel\Pennant\Feature;
 use Illuminate\Database\Migrations\Migration;
 

--- a/database/migrations/2024_06_03_183502_seed_manage_ses_settings_permission.php
+++ b/database/migrations/2024_06_03_183502_seed_manage_ses_settings_permission.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        $groupId = (string) Str::orderedUuid();
+
+        DB::table('permission_groups')
+            ->insert(
+                [
+                    'id' => $groupId,
+                    'name' => 'Amazon SES',
+                    'created_at' => now(),
+                ]
+            );
+
+        DB::table('permissions')->insert(
+            [
+                'id' => (string) Str::orderedUuid(),
+                'group_id' => $groupId,
+                'guard_name' => 'web',
+                'name' => 'amazon-ses.manage_ses_settings',
+                'created_at' => now(),
+            ]
+        );
+    }
+
+    public function down(): void
+    {
+        DB::table('permissions')
+            ->where('name', 'amazon-ses.manage_ses_settings')
+            ->delete();
+
+        DB::table('permission_groups')
+            ->where('name', 'Amazon SES')
+            ->delete();
+    }
+};

--- a/database/migrations/2024_06_03_183502_seed_manage_ses_settings_permission.php
+++ b/database/migrations/2024_06_03_183502_seed_manage_ses_settings_permission.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Migrations\Migration;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-83

### Technical Description

> Adds same configuration that was implemented on AdvisingApp in order to allow admins to configure the email "from name" either globally or per Notification Setting.

### Screenshots (if appropriate)

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
