### PR TITLE
[AIDAPP-115]: Setting division when creating a knowledge article produces an error

### DIFF
--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/CreateKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/CreateKnowledgeBaseItem.php
@@ -109,6 +109,7 @@ class CreateKnowledgeBaseItem extends CreateRecord
                             ->exists((new KnowledgeBaseCategory())->getTable(), (new KnowledgeBaseCategory())->getKeyName()),
                         Select::make('division')
                             ->label('Division')
+                            ->multiple()
                             ->relationship('division', 'name')
                             ->searchable(['name', 'code'])
                             ->preload()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/EditKnowledgeBaseItemMetadata.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/EditKnowledgeBaseItemMetadata.php
@@ -99,6 +99,7 @@ class EditKnowledgeBaseItemMetadata
                         ->exists((new KnowledgeBaseCategory())->getTable(), (new KnowledgeBaseCategory())->getKeyName()),
                     Select::make('division')
                         ->label('Division')
+                        ->multiple()
                         ->relationship('division', 'name')
                         ->searchable(['name', 'code'])
                         ->preload()


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-115

### Technical Description

Fixes the Division select box during KB item create and edit to match the relationship type.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
