### PR TITLE
[AIDAPP-135]: Add tag for dependencies to avoid caching of assets as they change from release to release

### DIFF
--- a/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
+++ b/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
@@ -48,7 +48,7 @@ class GenerateSubmissibleEmbedCode
         return match ($submissible::class) {
             ServiceRequestForm::class => (function () use ($submissible) {
                 /** @var ServiceRequestForm $submissible */
-                $scriptUrl = url('js/widgets/service-request-form/aiding-app-service-request-form-widget.js?');
+                $scriptUrl = url('js/widgets/service-request-form/aiding-app-service-request-form-widget.js?v=' . app('current-commit'));
                 $formDefinitionUrl = URL::to(
                     URL::signedRoute(
                         name: 'service-request-forms.define',

--- a/app-modules/portal/src/Actions/GeneratePortalEmbedCode.php
+++ b/app-modules/portal/src/Actions/GeneratePortalEmbedCode.php
@@ -46,7 +46,7 @@ class GeneratePortalEmbedCode
     {
         return match ($portal) {
             PortalType::KnowledgeManagement => (function () {
-                $scriptUrl = url('js/portals/knowledge-management/aiding-app-knowledge-management-portal.js?');
+                $scriptUrl = url('js/portals/knowledge-management/aiding-app-knowledge-management-portal.js?v=' . app('current-commit'));
 
                 $portalAccessUrl = route('portal.knowledge-management.show');
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -45,6 +45,7 @@ use function Sentry\configureScope;
 
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Process;
 use Illuminate\Support\ServiceProvider;
 use Filament\Actions\Imports\Jobs\ImportCsv;
 use Filament\Actions\Exports\Jobs\PrepareCsvExport;
@@ -102,6 +103,18 @@ class AppServiceProvider extends ServiceProvider
 
         $this->app->singleton(PermissionMigrationCreator::class, function ($app) {
             return new PermissionMigrationCreator($app['files'], $app->basePath('stubs'));
+        });
+
+        $this->app->singleton('current-commit', function ($app) {
+            $commitProcess = Process::run('git log --pretty="%h" -n1 HEAD');
+
+            if ($commitProcess->successful()) {
+                return rtrim($commitProcess->output());
+            }
+
+            report($commitProcess->errorOutput());
+
+            return null;
         });
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-135

### Technical Description

> Takes the same approach as was introduced in Advising App to append the commit hash as a query parameter to the portal script.

### Screenshots (if appropriate)

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
