### PR TITLE
[AIDAPP-157]: Creation of AidingApp Tenant Failed

### DIFF
--- a/app/Http/Requests/Tenants/CreateTenantRequest.php
+++ b/app/Http/Requests/Tenants/CreateTenantRequest.php
@@ -57,7 +57,6 @@ class CreateTenantRequest extends FormRequest
             'limits.resetDate' => ['required', 'string', 'date_format:m-d'],
             'addons' => ['required', 'array'],
             'addons.onlineForms' => ['required', 'boolean'],
-            'addons.onlineSurveys' => ['required', 'boolean'],
             'addons.serviceManagement' => ['required', 'boolean'],
             'addons.knowledgeManagement' => ['required', 'boolean'],
             'addons.realtimeChat' => ['required', 'boolean'],


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-157

### Technical Description

This removes `onlineSurveys` as a required field in `CreateTenantRequest`. As `onlineSurveys` is no longer an Addon in AidingApp and was removed on the Olympus side and in the Addon DTO here.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
