### PR TITLE
[AIDAPP-150]: Setting a favicon or logo should not be possible when KB is disabled

### DIFF
--- a/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
+++ b/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
@@ -143,6 +143,7 @@ class ManagePortalSettings extends SettingsPage
                         SpatieMediaLibraryFileUpload::make('favicon')
                             ->collection('portal_favicon')
                             ->visibility('private')
+                            ->visible(Gate::check(Feature::KnowledgeManagement->getGateName()))
                             ->acceptedFileTypes([
                                 'image/png',
                                 'image/jpeg',
@@ -161,7 +162,7 @@ class ManagePortalSettings extends SettingsPage
                             ->model(
                                 SettingsProperty::getInstance('portal.logo'),
                             )
-                            ->visible(PennantFeature::active('portal-logo')),
+                            ->visible(Gate::check(Feature::KnowledgeManagement->getGateName()) && PennantFeature::active('portal-logo')),
                         Actions::make([
                             Action::make('view')
                                 ->url(fn () => route('portal.knowledge-management.show'))

--- a/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
+++ b/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
@@ -143,7 +143,7 @@ class ManagePortalSettings extends SettingsPage
                         SpatieMediaLibraryFileUpload::make('favicon')
                             ->collection('portal_favicon')
                             ->visibility('private')
-                            ->visible(Gate::check(Feature::KnowledgeManagement->getGateName()))
+                            ->visible(fn (Get $get) => $get('knowledge_management_portal_enabled'))
                             ->acceptedFileTypes([
                                 'image/png',
                                 'image/jpeg',
@@ -162,7 +162,7 @@ class ManagePortalSettings extends SettingsPage
                             ->model(
                                 SettingsProperty::getInstance('portal.logo'),
                             )
-                            ->visible(Gate::check(Feature::KnowledgeManagement->getGateName()) && PennantFeature::active('portal-logo')),
+                            ->visible(fn (Get $get) => $get('knowledge_management_portal_enabled') && PennantFeature::active('portal-logo')),
                         Actions::make([
                             Action::make('view')
                                 ->url(fn () => route('portal.knowledge-management.show'))


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-150

### Technical Description

> Describe your changes in detail. This should include technical/architectural decisions and reasoning, if applicable.
> Setting a favicon or logo should not be possible when KB is disabled

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
