### PR TITLE
[AIDAPP-169]: Introduce ability to filter by Organization within service requests

### DIFF
--- a/app-modules/contact/src/Models/Contact.php
+++ b/app-modules/contact/src/Models/Contact.php
@@ -113,6 +113,7 @@ class Contact extends BaseAuthenticatable implements Auditable, Subscribable, Ed
         'postal',
         'assigned_to_id',
         'created_by_id',
+        'organization_id',
     ];
 
     protected $casts = [

--- a/app-modules/contact/src/Models/Contact.php
+++ b/app-modules/contact/src/Models/Contact.php
@@ -113,7 +113,6 @@ class Contact extends BaseAuthenticatable implements Auditable, Subscribable, Ed
         'postal',
         'assigned_to_id',
         'created_by_id',
-        'organization_id',
     ];
 
     protected $casts = [

--- a/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
@@ -145,25 +145,22 @@ test('can filter service request by organization', function () {
 
     $organizations = Organization::factory()->count(10)->create();
 
-    $organizationServiceRequests = ServiceRequest::factory()
-        ->count(10)
-        ->state(function () use ($organizations) {
-            return [
-                'respondent_id' => Contact::factory()
-                    ->state(['organization_id' => $organizations->random()->id])
-                    ->create()
-                    ->id,
-            ];
-        })
+    $organization = $organizations->first();
+
+    $serviceRequestsInOrganization = ServiceRequest::factory()
+        ->count(3)
+        ->for(Contact::factory()->state(['organization_id' => $organization->id]), 'respondent')
         ->create();
 
-    $organization = $organizationServiceRequests->first()->respondent->organizations;
+    $serviceRequestsNotInOrganization = ServiceRequest::factory()
+        ->count(3)
+        ->create();
 
     livewire(ListServiceRequests::class)
-        ->assertCanSeeTableRecords($organizationServiceRequests)
+        ->assertCanSeeTableRecords($serviceRequestsInOrganization->merge($serviceRequestsNotInOrganization))
         ->filterTable('organizations', $organization->id)
         ->assertCanSeeTableRecords(
-            $organizationServiceRequests->where('respondent.organizations.id', $organization->id)
+            $serviceRequestsInOrganization
         )
-        ->assertCanNotSeeTableRecords($organizationServiceRequests->where('respondent.organizations.id', '!=', $organization->id));
+        ->assertCanNotSeeTableRecords($serviceRequestsNotInOrganization);
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-169

### Technical Description

> Added filter by organization in List Service Request Page.

### Screenshots

According to the screenshot below, the Service Request is filtered by the Organization.
![image](https://github.com/canyongbs/aidingapp/assets/170341684/b5e27c8a-46be-4303-8fdf-b5e6be8f00c7)

### Any deployment steps required?

> No

### Are any Feature Flags Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
