### PR TITLE
[AIDAPP-178] Remove lock icon from service requests that are not in a closed state

### DIFF
--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ViewServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ViewServiceRequest.php
@@ -236,7 +236,7 @@ class ViewServiceRequest extends ViewRecord
                 ->color('gray')
                 ->tooltip('This service request is locked as status is closed.')
                 ->disabled()
-                ->visible(fn (ServiceRequest $record) => fn (ServiceRequest $record) => $record->status?->classification === SystemServiceRequestClassification::Closed ? false : true)
+                ->visible(fn (ServiceRequest $record) => $record->status?->classification === SystemServiceRequestClassification::Closed ? true : false)
                 ->iconButton(),
         ];
     }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-178

### Technical Description

> Fixed the lock service request icon display on view service request page. 

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
> No

### Are any Feature Flags Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
