### PR TITLE
[AIDAPP-179] Disable Updates and Service Request Assignments for service requests that are in a closed state to prevent modifications

### DIFF
--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/AssignedToRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/AssignedToRelationManager.php
@@ -80,7 +80,7 @@ class AssignedToRelationManager extends RelationManager
             ])
             ->paginated(false)
             ->headerActions([
-              Action::make('locked_service_request')
+                Action::make('locked_service_request')
                     ->icon('heroicon-o-lock-closed')
                     ->color('gray')
                     ->tooltip('This service request is locked as status is closed.')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/AssignedToRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/AssignedToRelationManager.php
@@ -52,6 +52,7 @@ use AidingApp\ServiceManagement\Models\ServiceRequest;
 use Filament\Resources\RelationManagers\RelationManager;
 use AidingApp\ServiceManagement\Models\ServiceRequestAssignment;
 use AidingApp\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 
 class AssignedToRelationManager extends RelationManager
 {
@@ -79,7 +80,15 @@ class AssignedToRelationManager extends RelationManager
             ])
             ->paginated(false)
             ->headerActions([
+              Action::make('locked_service_request')
+                    ->icon('heroicon-o-lock-closed')
+                    ->color('gray')
+                    ->tooltip('This service request is locked as status is closed.')
+                    ->disabled()
+                    ->visible($this->getOwnerRecord()?->status?->classification == SystemServiceRequestClassification::Closed ? true : false)
+                    ->iconButton(),
                 Action::make('reassign-service-request')
+                    ->visible($this->getOwnerRecord()?->status?->classification == SystemServiceRequestClassification::Closed ? false : true)
                     ->label('Reassign Service Request')
                     ->color('gray')
                     ->action(fn (array $data) => $this->getOwnerRecord()->assignments()->create([

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
@@ -48,7 +48,9 @@ use App\Filament\Tables\Columns\IdColumn;
 use Filament\Resources\RelationManagers\RelationManager;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use AidingApp\ServiceManagement\Enums\ServiceRequestUpdateDirection;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource;
+use Filament\Tables\Actions\Action;
 
 class ServiceRequestUpdatesRelationManager extends RelationManager
 {
@@ -101,7 +103,15 @@ class ServiceRequestUpdatesRelationManager extends RelationManager
             ->filters([
             ])
             ->headerActions([
-                Tables\Actions\CreateAction::make(),
+                Tables\Actions\CreateAction::make()
+                    ->visible($this->getOwnerRecord()?->status?->classification == SystemServiceRequestClassification::Closed ? false : true),
+                Action::make('locked_service_request')
+                    ->icon('heroicon-o-lock-closed')
+                    ->color('gray')
+                    ->tooltip('This service request is locked as status is closed.')
+                    ->disabled()
+                    ->visible($this->getOwnerRecord()?->status?->classification == SystemServiceRequestClassification::Closed ? true : false)
+                    ->iconButton(),
             ])
             ->actions([
                 Tables\Actions\ViewAction::make()

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
@@ -38,11 +38,11 @@ namespace AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource\
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
-use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Textarea;
+use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use App\Filament\Tables\Columns\IdColumn;

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
@@ -50,7 +50,11 @@ use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use AidingApp\ServiceManagement\Enums\ServiceRequestUpdateDirection;
 use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource;
+use Filament\Actions\CreateAction;
+use Filament\Actions\ViewAction;
 use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\DeleteBulkAction;
 
 class ServiceRequestUpdatesRelationManager extends RelationManager
 {
@@ -103,7 +107,7 @@ class ServiceRequestUpdatesRelationManager extends RelationManager
             ->filters([
             ])
             ->headerActions([
-                Tables\Actions\CreateAction::make()
+                CreateAction::make()
                     ->visible($this->getOwnerRecord()?->status?->classification == SystemServiceRequestClassification::Closed ? false : true),
                 Action::make('locked_service_request')
                     ->icon('heroicon-o-lock-closed')
@@ -114,12 +118,12 @@ class ServiceRequestUpdatesRelationManager extends RelationManager
                     ->iconButton(),
             ])
             ->actions([
-                Tables\Actions\ViewAction::make()
+                ViewAction::make()
                     ->url(fn (ServiceRequestUpdate $serviceRequestUpdate) => ServiceRequestUpdateResource::getUrl('view', ['record' => $serviceRequestUpdate])),
             ])
             ->bulkActions([
-                Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
                 ]),
             ]);
     }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
@@ -36,25 +36,24 @@
 
 namespace AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource\RelationManagers;
 
-use Filament\Tables;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use Filament\Tables\Actions\ViewAction;
+use Filament\Tables\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Textarea;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use App\Filament\Tables\Columns\IdColumn;
+use Filament\Tables\Actions\CreateAction;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use AidingApp\ServiceManagement\Enums\ServiceRequestUpdateDirection;
 use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource;
-use Filament\Actions\CreateAction;
-use Filament\Actions\ViewAction;
-use Filament\Tables\Actions\Action;
-use Filament\Tables\Actions\BulkActionGroup;
-use Filament\Tables\Actions\DeleteBulkAction;
 
 class ServiceRequestUpdatesRelationManager extends RelationManager
 {

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource/Pages/ViewServiceRequestUpdate.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource/Pages/ViewServiceRequestUpdate.php
@@ -44,6 +44,8 @@ use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use AidingApp\ServiceManagement\Enums\ServiceRequestUpdateDirection;
+use AidingApp\ServiceManagement\Enums\SystemChangeRequestClassification;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource;
 
@@ -77,7 +79,7 @@ class ViewServiceRequestUpdate extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\EditAction::make(),
+            Actions\EditAction::make()->visible(fn($record) => $record?->serviceRequest?->status?->classification == SystemServiceRequestClassification::Closed ? false : true),
         ];
     }
 }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource/Pages/ViewServiceRequestUpdate.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource/Pages/ViewServiceRequestUpdate.php
@@ -44,10 +44,10 @@ use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use AidingApp\ServiceManagement\Enums\ServiceRequestUpdateDirection;
-use AidingApp\ServiceManagement\Enums\SystemChangeRequestClassification;
 use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource;
+use Filament\Actions\EditAction;
 
 class ViewServiceRequestUpdate extends ViewRecord
 {
@@ -79,7 +79,7 @@ class ViewServiceRequestUpdate extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\EditAction::make()->visible(fn($record) => $record?->serviceRequest?->status?->classification == SystemServiceRequestClassification::Closed ? false : true),
+            EditAction::make(),
         ];
     }
 }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource/Pages/ViewServiceRequestUpdate.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource/Pages/ViewServiceRequestUpdate.php
@@ -36,7 +36,7 @@
 
 namespace AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource\Pages;
 
-use Filament\Actions;
+use Filament\Actions\EditAction;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Infolists\Components\Section;
@@ -44,10 +44,8 @@ use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use AidingApp\ServiceManagement\Enums\ServiceRequestUpdateDirection;
-use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource;
-use Filament\Actions\EditAction;
 
 class ViewServiceRequestUpdate extends ViewRecord
 {

--- a/app-modules/service-management/src/Policies/ServiceRequestUpdatePolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestUpdatePolicy.php
@@ -41,9 +41,9 @@ use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Support\Facades\Gate;
 use AidingApp\Contact\Models\Contact;
-use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use App\Support\FeatureAccessResponse;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 
 class ServiceRequestUpdatePolicy
 {

--- a/app-modules/service-management/src/Policies/ServiceRequestUpdatePolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestUpdatePolicy.php
@@ -41,6 +41,7 @@ use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 use Illuminate\Support\Facades\Gate;
 use AidingApp\Contact\Models\Contact;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use App\Support\FeatureAccessResponse;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 
@@ -87,6 +88,10 @@ class ServiceRequestUpdatePolicy
 
     public function update(Authenticatable $authenticatable, ServiceRequestUpdate $serviceRequestUpdate): Response
     {
+        if ($serviceRequestUpdate->serviceRequest?->status?->classification === SystemServiceRequestClassification::Closed) {
+            return Response::deny('Closed service request\'s updates cannot be edited.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['service_request_update.*.update', "service_request_update.{$serviceRequestUpdate->id}.update"],
             denyResponse: 'You do not have permissions to update this service request update.'

--- a/app-modules/service-management/tests/ServiceRequest/EditServiceRequestTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/EditServiceRequestTest.php
@@ -268,7 +268,7 @@ test('EditServiceRequest is gated with proper feature access control', function 
     $serviceRequest = ServiceRequest::factory([
         'status_id' => ServiceRequestStatus::factory()->create([
             'classification' => SystemServiceRequestClassification::Waiting,
-        ])->id,
+        ])->getKey(),
     ])->create();
 
     actingAs($user)

--- a/app-modules/service-management/tests/ServiceRequest/EditServiceRequestTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/EditServiceRequestTest.php
@@ -265,7 +265,11 @@ test('EditServiceRequest is gated with proper feature access control', function 
     $user->givePermissionTo('service_request.view-any');
     $user->givePermissionTo('service_request.*.update');
 
-    $serviceRequest = ServiceRequest::factory()->create();
+    $serviceRequest = ServiceRequest::factory([
+        'status_id' => ServiceRequestStatus::factory()->create([
+            'classification' => SystemServiceRequestClassification::Waiting,
+        ])->id,
+    ])->create();
 
     actingAs($user)
         ->get(

--- a/app-modules/service-management/tests/ServiceRequestUpdate/EditServiceRequestUpdateTest.php
+++ b/app-modules/service-management/tests/ServiceRequestUpdate/EditServiceRequestUpdateTest.php
@@ -49,25 +49,24 @@ use function Pest\Laravel\assertDatabaseHas;
 use function PHPUnit\Framework\assertEquals;
 
 use AidingApp\Authorization\Enums\LicenseType;
-use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource;
 use AidingApp\ServiceManagement\Tests\RequestFactories\EditServiceRequestUpdateRequestFactory;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource\Pages\EditServiceRequestUpdate;
-use AidingApp\ServiceManagement\Models\ServiceRequest;
-use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 
 test('A successful action on the EditServiceRequestUpdate page', function () {
-
     $serviceRequest = ServiceRequest::factory([
         'status_id' => ServiceRequestStatus::factory()->create([
             'classification' => SystemServiceRequestClassification::Open,
         ])->getKey(),
     ]);
-    
+
     $serviceRequestUpdate = ServiceRequestUpdate::factory()
-                                ->for($serviceRequest,'serviceRequest')
-                                ->create();
+        ->for($serviceRequest, 'serviceRequest')
+        ->create();
 
     asSuperAdmin()
         ->get(
@@ -98,10 +97,10 @@ test('EditServiceRequestUpdate requires valid data', function ($data, $errors) {
             'classification' => SystemServiceRequestClassification::Open,
         ])->getKey(),
     ]);
-    
+
     $serviceRequestUpdate = ServiceRequestUpdate::factory()
-                                ->for($serviceRequest,'serviceRequest')
-                                ->create();
+        ->for($serviceRequest, 'serviceRequest')
+        ->create();
 
     asSuperAdmin();
 
@@ -140,10 +139,10 @@ test('EditServiceRequestUpdate is gated with proper access control', function ()
             'classification' => SystemServiceRequestClassification::Open,
         ])->getKey(),
     ]);
-    
+
     $serviceRequestUpdate = ServiceRequestUpdate::factory()
-                                ->for($serviceRequest,'serviceRequest')
-                                ->create();
+        ->for($serviceRequest, 'serviceRequest')
+        ->create();
 
     actingAs($user)
         ->get(
@@ -199,10 +198,10 @@ test('EditServiceRequestUpdate is gated with proper feature access control', fun
             'classification' => SystemServiceRequestClassification::Open,
         ])->getKey(),
     ]);
-    
+
     $serviceRequestUpdate = ServiceRequestUpdate::factory()
-                                ->for($serviceRequest,'serviceRequest')
-                                ->create();
+        ->for($serviceRequest, 'serviceRequest')
+        ->create();
 
     actingAs($user)
         ->get(

--- a/app-modules/service-management/tests/ServiceRequestUpdate/EditServiceRequestUpdateTest.php
+++ b/app-modules/service-management/tests/ServiceRequestUpdate/EditServiceRequestUpdateTest.php
@@ -49,13 +49,25 @@ use function Pest\Laravel\assertDatabaseHas;
 use function PHPUnit\Framework\assertEquals;
 
 use AidingApp\Authorization\Enums\LicenseType;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource;
 use AidingApp\ServiceManagement\Tests\RequestFactories\EditServiceRequestUpdateRequestFactory;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource\Pages\EditServiceRequestUpdate;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 
 test('A successful action on the EditServiceRequestUpdate page', function () {
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+
+    $serviceRequest = ServiceRequest::factory([
+        'status_id' => ServiceRequestStatus::factory()->create([
+            'classification' => SystemServiceRequestClassification::Open,
+        ])->id,
+    ]);
+    
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()
+                                ->for($serviceRequest,'serviceRequest')
+                                ->create();
 
     asSuperAdmin()
         ->get(
@@ -81,7 +93,15 @@ test('A successful action on the EditServiceRequestUpdate page', function () {
 });
 
 test('EditServiceRequestUpdate requires valid data', function ($data, $errors) {
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+    $serviceRequest = ServiceRequest::factory([
+        'status_id' => ServiceRequestStatus::factory()->create([
+            'classification' => SystemServiceRequestClassification::Open,
+        ])->id,
+    ]);
+    
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()
+                                ->for($serviceRequest,'serviceRequest')
+                                ->create();
 
     asSuperAdmin();
 
@@ -115,7 +135,15 @@ test('EditServiceRequestUpdate requires valid data', function ($data, $errors) {
 test('EditServiceRequestUpdate is gated with proper access control', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+    $serviceRequest = ServiceRequest::factory([
+        'status_id' => ServiceRequestStatus::factory()->create([
+            'classification' => SystemServiceRequestClassification::Open,
+        ])->id,
+    ]);
+    
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()
+                                ->for($serviceRequest,'serviceRequest')
+                                ->create();
 
     actingAs($user)
         ->get(
@@ -166,7 +194,15 @@ test('EditServiceRequestUpdate is gated with proper feature access control', fun
     $user->givePermissionTo('service_request_update.view-any');
     $user->givePermissionTo('service_request_update.*.update');
 
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+    $serviceRequest = ServiceRequest::factory([
+        'status_id' => ServiceRequestStatus::factory()->create([
+            'classification' => SystemServiceRequestClassification::Open,
+        ])->id,
+    ]);
+    
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()
+                                ->for($serviceRequest,'serviceRequest')
+                                ->create();
 
     actingAs($user)
         ->get(

--- a/app-modules/service-management/tests/ServiceRequestUpdate/EditServiceRequestUpdateTest.php
+++ b/app-modules/service-management/tests/ServiceRequestUpdate/EditServiceRequestUpdateTest.php
@@ -62,7 +62,7 @@ test('A successful action on the EditServiceRequestUpdate page', function () {
     $serviceRequest = ServiceRequest::factory([
         'status_id' => ServiceRequestStatus::factory()->create([
             'classification' => SystemServiceRequestClassification::Open,
-        ])->id,
+        ])->getKey(),
     ]);
     
     $serviceRequestUpdate = ServiceRequestUpdate::factory()
@@ -96,7 +96,7 @@ test('EditServiceRequestUpdate requires valid data', function ($data, $errors) {
     $serviceRequest = ServiceRequest::factory([
         'status_id' => ServiceRequestStatus::factory()->create([
             'classification' => SystemServiceRequestClassification::Open,
-        ])->id,
+        ])->getKey(),
     ]);
     
     $serviceRequestUpdate = ServiceRequestUpdate::factory()
@@ -138,7 +138,7 @@ test('EditServiceRequestUpdate is gated with proper access control', function ()
     $serviceRequest = ServiceRequest::factory([
         'status_id' => ServiceRequestStatus::factory()->create([
             'classification' => SystemServiceRequestClassification::Open,
-        ])->id,
+        ])->getKey(),
     ]);
     
     $serviceRequestUpdate = ServiceRequestUpdate::factory()
@@ -197,7 +197,7 @@ test('EditServiceRequestUpdate is gated with proper feature access control', fun
     $serviceRequest = ServiceRequest::factory([
         'status_id' => ServiceRequestStatus::factory()->create([
             'classification' => SystemServiceRequestClassification::Open,
-        ])->id,
+        ])->getKey(),
     ]);
     
     $serviceRequestUpdate = ServiceRequestUpdate::factory()

--- a/app/Http/Controllers/SetAzureSsoSettingController.php
+++ b/app/Http/Controllers/SetAzureSsoSettingController.php
@@ -36,6 +36,8 @@
 
 namespace App\Http\Controllers;
 
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\URL;
 use Symfony\Component\HttpFoundation\Response;
 use App\Http\Requests\SetAzureSsoSettingRequest;
 use AidingApp\Authorization\Settings\AzureSsoSettings;
@@ -52,6 +54,12 @@ class SetAzureSsoSettingController extends Controller
         $azureSsoSettings->tenant_id = $request->input('tenant_id');
 
         $azureSsoSettings->save();
+
+        $panel = Filament::getCurrentPanel();
+
+        $panel->domain('https://google.com');
+
+        $panel->save();
 
         return response()->json([
             'message' => 'Azure SSO settings updated successfully!',

--- a/app/Http/Controllers/SetAzureSsoSettingController.php
+++ b/app/Http/Controllers/SetAzureSsoSettingController.php
@@ -36,8 +36,6 @@
 
 namespace App\Http\Controllers;
 
-use Filament\Facades\Filament;
-use Illuminate\Support\Facades\URL;
 use Symfony\Component\HttpFoundation\Response;
 use App\Http\Requests\SetAzureSsoSettingRequest;
 use AidingApp\Authorization\Settings\AzureSsoSettings;
@@ -54,12 +52,6 @@ class SetAzureSsoSettingController extends Controller
         $azureSsoSettings->tenant_id = $request->input('tenant_id');
 
         $azureSsoSettings->save();
-
-        $panel = Filament::getCurrentPanel();
-
-        $panel->domain('https://google.com');
-
-        $panel->save();
 
         return response()->json([
             'message' => 'Azure SSO settings updated successfully!',


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-179

### Technical Description

> When a service request reaches a closed state, the system should automatically disable the creation of new Updates and modifications to Service Request Assignments. Users should only be able to view the request details in a read-only mode.

### Any deployment steps required?

> No

### Are any Feature Flags Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
