### PR TITLE
[AIDAPP-193]: Error is thrown due to rr file missing when setting up the project for the first time

### DIFF
--- a/docker/s6-overlay/scripts/fix-permissions
+++ b/docker/s6-overlay/scripts/fix-permissions
@@ -15,7 +15,9 @@ if [ "${FIX_PERMISSIONS:="false"}" == "true" ]; then
   find /var/www/html -type d -print0 | xargs -0 chmod 755
   find /var/www/html \( -path /var/www/html/docker -o -path /var/www/html/node_modules -o -path /var/www/html/vendor \) -prune -o -type f -print0 | xargs -0 chmod 644
   chmod -R ug+rwx /var/www/html/storage /var/www/html/bootstrap/cache
-  chmod 0755 /var/www/html/rr
+  if [ -e /var/www/html/rr ]; then
+    chmod 0755 /var/www/html/rr
+  fi
 
   echo "Ownership and permissions fixed!"
 else


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-193

### Technical Description

Fix error that is thrown during first time startup if `rr` is missing.

### Any deployment steps required?

No.

### Are any Feature Flags Added?

No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
