### PR TITLE
[AIDAPP-195]: Improve the label used to indicate copying or duplicating a knowledge base article

### DIFF
--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ListKnowledgeBaseItems.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ListKnowledgeBaseItems.php
@@ -119,7 +119,7 @@ class ListKnowledgeBaseItems extends ListRecords
             ->actions([
                 EditAction::make(),
                 ReplicateAction::make()
-                    ->label('Replicate')
+                    ->label('Duplicate')
                     ->form([
                         Section::make()
                             ->schema([
@@ -214,7 +214,7 @@ class ListKnowledgeBaseItems extends ListRecords
     {
         return [
             CreateAction::make()
-                ->disabled(fn (): bool => ! auth()->user()->can('knowledge_base_item.create'))
+                ->disabled(fn (): bool => !auth()->user()->can('knowledge_base_item.create'))
                 ->label('New Article')
                 ->modalHeading('New Article')
                 ->createAnother(false)

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ListKnowledgeBaseItems.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ListKnowledgeBaseItems.php
@@ -214,7 +214,7 @@ class ListKnowledgeBaseItems extends ListRecords
     {
         return [
             CreateAction::make()
-                ->disabled(fn (): bool => !auth()->user()->can('knowledge_base_item.create'))
+                ->disabled(fn (): bool => ! auth()->user()->can('knowledge_base_item.create'))
                 ->label('New Article')
                 ->modalHeading('New Article')
                 ->createAnother(false)


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-195

### Technical Description

> Change the knowledge management button label from 'Replicate' to 'Duplicate'

### Any deployment steps required?

> No.

### Are any Feature Flags Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
