### PR TITLE
[AIDAPP-210]: Generating a version tag for assets is failing

### DIFF
--- a/docker/s6-overlay/scripts/laravel-octane
+++ b/docker/s6-overlay/scripts/laravel-octane
@@ -5,12 +5,14 @@ set -e
 
 echo "Starting Laravel Octane..."
 
+USERNAME=$(id -nu "$PUID")
+
 if [ "${LARAVEL_OCTANE_WATCH:="false"}" == "true" ]; then
     echo "👉 Starting Laravel Octane in watch mode..."
 
     source "$NVM_DIR/nvm.sh"
 
-    php -d variables_order=EGPCS "$WEBUSER_HOME"/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=8000 --watch
+    s6-setuidgid "$USERNAME" php -d variables_order=EGPCS "$WEBUSER_HOME"/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=8000 --watch
 else
-    php -d variables_order=EGPCS "$WEBUSER_HOME"/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=8000
+    s6-setuidgid "$USERNAME" php -d variables_order=EGPCS "$WEBUSER_HOME"/artisan octane:start --server=roadrunner --host=0.0.0.0 --rpc-port=6001 --port=8000
 fi


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-210

### Technical Description

Fixes Octane to run as the `webuser` for better security and to prevent `git` dubious ownership.

### Any deployment steps required?

No

### Are any Feature Flags Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
