### PR TITLE
[AIDAPP-218] : Old flowbite svg is still referenced on Landlord page

### DIFF
--- a/resources/views/landlord.blade.php
+++ b/resources/views/landlord.blade.php
@@ -39,7 +39,7 @@
             <div class="mx-auto text-center">
                 <img
                     class="mx-auto mb-3 max-w-md"
-                    src="{{ Vite::asset('resources/svg/flowbite-500.svg') }}"
+                    src="{{ Vite::asset('resources/svg/canyongbs-500.svg') }}"
                     alt="Internal Server Error"
                 >
                 <h1 class="mb-3 text-5xl font-extrabold text-primary-600 dark:text-primary-500">


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-218

### Technical Description

> Old flowbite svg is still referenced on Landlord page - done

### Any deployment steps required?

> No.

### Are any Feature Flags Added?

> No.

__________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
