### PR TITLE
[AIDAPP-151]: Introduce the ability to configure the text shown for the cookie banner.

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 // @formatter:off
 // phpcs:ignoreFile
 /**

--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1,39 +1,5 @@
 <?php
 
-/*
-<COPYRIGHT>
-
-    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
-
-    Aiding App™ is licensed under the Elastic License 2.0. For more details,
-    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
-
-    Notice:
-
-    - You may not provide the software to third parties as a hosted or managed
-      service, where the service provides users with access to any substantial set of
-      the features or functionality of the software.
-    - You may not move, change, disable, or circumvent the license key functionality
-      in the software, and you may not remove or obscure any functionality in the
-      software that is protected by the license key.
-    - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
-      to applicable law.
-    - Canyon GBS LLC respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
-      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
-      vigorously.
-    - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS LLC.
-    - Use of this software implies agreement to the license terms and conditions as stated
-      in the Elastic License 2.0.
-
-    For more information or inquiries please visit our website at
-    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
-
-</COPYRIGHT>
-*/
-
 // @formatter:off
 // phpcs:ignoreFile
 /**

--- a/app-modules/portal/database/migrations/2024_08_14_201456_activate__gdpr_banner_customization.php
+++ b/app-modules/portal/database/migrations/2024_08_14_201456_activate__gdpr_banner_customization.php
@@ -2,11 +2,8 @@
 
 use App\Enums\FeatureFlag;
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         FeatureFlag::GdprBannerCustomization->activate();

--- a/app-modules/portal/database/migrations/2024_08_14_201456_activate__gdpr_banner_customization.php
+++ b/app-modules/portal/database/migrations/2024_08_14_201456_activate__gdpr_banner_customization.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Enums\FeatureFlag;
 use Illuminate\Database\Migrations\Migration;
 

--- a/app-modules/portal/database/migrations/2024_08_14_201456_activate__gdpr_banner_customization.php
+++ b/app-modules/portal/database/migrations/2024_08_14_201456_activate__gdpr_banner_customization.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Enums\FeatureFlag;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        FeatureFlag::GdprBannerCustomization->activate();
+    }
+
+    public function down(): void
+    {
+        FeatureFlag::GdprBannerCustomization->deactivate();
+    }
+};

--- a/app-modules/portal/src/Enums/GdprBannerButtonLabel.php
+++ b/app-modules/portal/src/Enums/GdprBannerButtonLabel.php
@@ -7,9 +7,9 @@ use Filament\Support\Contracts\HasLabel;
 enum GdprBannerButtonLabel: string implements HasLabel
 {
     case Agree = 'Agree';
-    
+
     case AllowCookies = 'Allow Cookies';
-    
+
     case IUnderstand = 'I Understand';
 
     case Continue = 'Continue';

--- a/app-modules/portal/src/Enums/GdprBannerButtonLabel.php
+++ b/app-modules/portal/src/Enums/GdprBannerButtonLabel.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AidingApp\Portal\Enums;
 
 use Filament\Support\Contracts\HasLabel;

--- a/app-modules/portal/src/Enums/GdprBannerButtonLabel.php
+++ b/app-modules/portal/src/Enums/GdprBannerButtonLabel.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AidingApp\Portal\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum GdprBannerButtonLabel: string implements HasLabel
+{
+    case Agree = 'Agree';
+    
+    case AllowCookies = 'Allow Cookies';
+    
+    case IUnderstand = 'I Understand';
+
+    case Continue = 'Continue';
+
+    public function getLabel(): string
+    {
+        return $this->value;
+    }
+}

--- a/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
+++ b/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
@@ -36,33 +36,33 @@
 
 namespace AidingApp\Portal\Filament\Pages;
 
-use AidingApp\Form\Enums\Rounding;
-use AidingApp\Portal\Actions\GeneratePortalEmbedCode;
-use AidingApp\Portal\Enums\GdprBannerButtonLabel;
-use AidingApp\Portal\Enums\PortalLayout;
-use AidingApp\Portal\Enums\PortalType;
-use AidingApp\Portal\Settings\PortalSettings;
-use App\Enums\Feature;
-use App\Enums\FeatureFlag;
-use App\Filament\Clusters\GlobalSettings;
-use App\Filament\Forms\Components\ColorSelect;
-use App\Models\SettingsProperty;
 use App\Models\User;
-use Filament\Forms\Components\Actions;
-use Filament\Forms\Components\Actions\Action;
-use Filament\Forms\Components\Section;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
-use Filament\Forms\Components\Textarea;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Toggle;
-use Filament\Forms\Components\ToggleButtons;
-use Filament\Forms\Form;
+use App\Enums\Feature;
 use Filament\Forms\Get;
-use Filament\Infolists\Components\TextEntry;
+use Filament\Forms\Form;
+use App\Enums\FeatureFlag;
+use App\Models\SettingsProperty;
 use Filament\Pages\SettingsPage;
+use AidingApp\Form\Enums\Rounding;
 use Illuminate\Support\Facades\Gate;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
+use AidingApp\Portal\Enums\PortalType;
+use Filament\Forms\Components\Actions;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Textarea;
+use AidingApp\Portal\Enums\PortalLayout;
+use Filament\Forms\Components\TextInput;
+use App\Filament\Clusters\GlobalSettings;
+use Filament\Forms\Components\ToggleButtons;
+use Filament\Infolists\Components\TextEntry;
+use AidingApp\Portal\Settings\PortalSettings;
+use Filament\Forms\Components\Actions\Action;
+use App\Filament\Forms\Components\ColorSelect;
 use Laravel\Pennant\Feature as PennantFeature;
+use AidingApp\Portal\Enums\GdprBannerButtonLabel;
+use AidingApp\Portal\Actions\GeneratePortalEmbedCode;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 
 class ManagePortalSettings extends SettingsPage
 {
@@ -217,7 +217,7 @@ class ManagePortalSettings extends SettingsPage
                             ->options(GdprBannerButtonLabel::class)
                             ->enum(GdprBannerButtonLabel::class)
                             ->required()
-                            ->label('GDPR Button Label')
+                            ->label('GDPR Button Label'),
                     ])
                     ->visible(fn (Get $get) => $get('knowledge_management_portal_enabled') && FeatureFlag::GdprBannerCustomization->active()),
             ]);

--- a/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
+++ b/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
@@ -36,30 +36,32 @@
 
 namespace AidingApp\Portal\Filament\Pages;
 
-use App\Models\User;
-use App\Enums\Feature;
-use Filament\Forms\Get;
-use Filament\Forms\Form;
-use App\Models\SettingsProperty;
-use Filament\Pages\SettingsPage;
 use AidingApp\Form\Enums\Rounding;
-use Illuminate\Support\Facades\Gate;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\Toggle;
-use AidingApp\Portal\Enums\PortalType;
-use Filament\Forms\Components\Actions;
-use Filament\Forms\Components\Section;
-use AidingApp\Portal\Enums\PortalLayout;
-use Filament\Forms\Components\TextInput;
-use App\Filament\Clusters\GlobalSettings;
-use Filament\Forms\Components\ToggleButtons;
-use Filament\Infolists\Components\TextEntry;
-use AidingApp\Portal\Settings\PortalSettings;
-use Filament\Forms\Components\Actions\Action;
-use App\Filament\Forms\Components\ColorSelect;
-use Laravel\Pennant\Feature as PennantFeature;
 use AidingApp\Portal\Actions\GeneratePortalEmbedCode;
+use AidingApp\Portal\Enums\GdprBannerButtonLabel;
+use AidingApp\Portal\Enums\PortalLayout;
+use AidingApp\Portal\Enums\PortalType;
+use AidingApp\Portal\Settings\PortalSettings;
+use App\Enums\Feature;
+use App\Filament\Clusters\GlobalSettings;
+use App\Filament\Forms\Components\ColorSelect;
+use App\Models\SettingsProperty;
+use App\Models\User;
+use Filament\Forms\Components\Actions;
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Components\ToggleButtons;
+use Filament\Forms\Form;
+use Filament\Forms\Get;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Pages\SettingsPage;
+use Illuminate\Support\Facades\Gate;
+use Laravel\Pennant\Feature as PennantFeature;
 
 class ManagePortalSettings extends SettingsPage
 {
@@ -204,6 +206,19 @@ class ManagePortalSettings extends SettingsPage
                             )
                             ->columnSpanFull(),
                     ])->columns(2),
+                Section::make('GDPR Banner Notice')
+                    ->schema([
+                        Textarea::make('gdpr_banner_text')
+                            ->label('GDPR Banner Text')
+                            ->required()
+                            ->columnSpanFull(),
+                        Select::make('gdpr_banner_button_label')
+                            ->options(GdprBannerButtonLabel::class)
+                            ->enum(GdprBannerButtonLabel::class)
+                            ->required()
+                            ->label('GDPR Button Label')
+                    ])
+                    ->visible(fn (Get $get) => $get('knowledge_management_portal_enabled')),
             ]);
     }
 }

--- a/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
+++ b/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
@@ -43,6 +43,7 @@ use AidingApp\Portal\Enums\PortalLayout;
 use AidingApp\Portal\Enums\PortalType;
 use AidingApp\Portal\Settings\PortalSettings;
 use App\Enums\Feature;
+use App\Enums\FeatureFlag;
 use App\Filament\Clusters\GlobalSettings;
 use App\Filament\Forms\Components\ColorSelect;
 use App\Models\SettingsProperty;
@@ -218,7 +219,7 @@ class ManagePortalSettings extends SettingsPage
                             ->required()
                             ->label('GDPR Button Label')
                     ])
-                    ->visible(fn (Get $get) => $get('knowledge_management_portal_enabled')),
+                    ->visible(fn (Get $get) => $get('knowledge_management_portal_enabled') && FeatureFlag::GdprBannerCustomization->active()),
             ]);
     }
 }

--- a/app-modules/portal/src/Settings/PortalSettings.php
+++ b/app-modules/portal/src/Settings/PortalSettings.php
@@ -36,8 +36,8 @@
 
 namespace AidingApp\Portal\Settings;
 
-use AidingApp\Portal\Enums\GdprBannerButtonLabel;
 use Spatie\LaravelSettings\Settings;
+use AidingApp\Portal\Enums\GdprBannerButtonLabel;
 
 class PortalSettings extends Settings
 {

--- a/app-modules/portal/src/Settings/PortalSettings.php
+++ b/app-modules/portal/src/Settings/PortalSettings.php
@@ -36,6 +36,7 @@
 
 namespace AidingApp\Portal\Settings;
 
+use AidingApp\Portal\Enums\GdprBannerButtonLabel;
 use Spatie\LaravelSettings\Settings;
 
 class PortalSettings extends Settings
@@ -60,6 +61,10 @@ class PortalSettings extends Settings
     public ?string $knowledge_management_portal_authorized_domain = null;
 
     public ?string $knowledge_management_portal_layout = null;
+
+    public string $gdpr_banner_text;
+
+    public GdprBannerButtonLabel $gdpr_banner_button_label;
 
     public static function group(): string
     {

--- a/app/Enums/FeatureFlag.php
+++ b/app/Enums/FeatureFlag.php
@@ -22,4 +22,19 @@ enum FeatureFlag: string
     {
         return Feature::active($this->value);
     }
+
+    public function activate(): void
+    {
+        Feature::activate($this->value);
+    }
+
+    public function deactivate(): void
+    {
+        Feature::deactivate($this->value);
+    }
+
+    public function purge(): void
+    {
+        Feature::purge($this->value);
+    }
 }

--- a/app/Enums/FeatureFlag.php
+++ b/app/Enums/FeatureFlag.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Enums;
 
 use Closure;

--- a/app/Enums/FeatureFlag.php
+++ b/app/Enums/FeatureFlag.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Enums;
+
+use Closure;
+use Laravel\Pennant\Feature;
+
+enum FeatureFlag: string
+{
+    case GdprBannerCustomization = 'gdpr_banner_customization';
+
+    public function definition(): Closure
+    {
+        return match ($this) {
+            default => function () {
+                return false;
+            }
+        };
+    }
+
+    public function active(): bool
+    {
+        return Feature::active($this->value);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,28 +36,29 @@
 
 namespace App\Providers;
 
-use App\Models\Tenant;
-use Sentry\State\Scope;
+use App\Enums\FeatureFlag;
 use App\Models\SystemUser;
-use Laravel\Pennant\Feature;
-
-use function Sentry\configureScope;
-
-use Illuminate\Support\Facades\URL;
-use Illuminate\Support\Facades\Queue;
-use Illuminate\Support\Facades\Process;
-use Illuminate\Support\ServiceProvider;
-use Filament\Actions\Imports\Jobs\ImportCsv;
-use Filament\Actions\Exports\Jobs\PrepareCsvExport;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use App\Overrides\Laravel\PermissionMigrationCreator;
-use OpenSearch\Migrations\Filesystem\MigrationStorage;
+use App\Models\Tenant;
 use App\Overrides\Filament\Actions\Imports\Jobs\ImportCsvOverride;
 use App\Overrides\Filament\Actions\Imports\Jobs\PrepareCsvExportOverride;
-use LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition as GraphQLSearchByTypesCondition;
-use LastDragon_ru\LaraASP\GraphQL\SearchBy\Definitions\SearchByDirective as GraphQLSearchByDirectiveAlias;
-use App\Overrides\LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition as GraphQLSearchByTypesConditionOverride;
+
+use App\Overrides\Laravel\PermissionMigrationCreator;
+
 use App\Overrides\LastDragon_ru\LaraASP\GraphQL\SearchBy\Definitions\SearchByDirective as GraphQLSearchByDirectiveOverride;
+use App\Overrides\LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition as GraphQLSearchByTypesConditionOverride;
+use Filament\Actions\Exports\Jobs\PrepareCsvExport;
+use Filament\Actions\Imports\Jobs\ImportCsv;
+use function Sentry\configureScope;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\ServiceProvider;
+use Laravel\Pennant\Feature;
+use LastDragon_ru\LaraASP\GraphQL\SearchBy\Definitions\SearchByDirective as GraphQLSearchByDirectiveAlias;
+use LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition as GraphQLSearchByTypesCondition;
+use OpenSearch\Migrations\Filesystem\MigrationStorage;
+use Sentry\State\Scope;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -116,5 +117,9 @@ class AppServiceProvider extends ServiceProvider
 
             return null;
         });
+
+        collect(FeatureFlag::cases())->each(
+            fn (FeatureFlag $feature) => Feature::define($feature->value, $feature->definition())
+        );
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,29 +36,29 @@
 
 namespace App\Providers;
 
+use App\Models\Tenant;
+use Sentry\State\Scope;
 use App\Enums\FeatureFlag;
 use App\Models\SystemUser;
-use App\Models\Tenant;
+use Laravel\Pennant\Feature;
+
+use function Sentry\configureScope;
+
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\ServiceProvider;
+use Filament\Actions\Imports\Jobs\ImportCsv;
+use Filament\Actions\Exports\Jobs\PrepareCsvExport;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use App\Overrides\Laravel\PermissionMigrationCreator;
+use OpenSearch\Migrations\Filesystem\MigrationStorage;
 use App\Overrides\Filament\Actions\Imports\Jobs\ImportCsvOverride;
 use App\Overrides\Filament\Actions\Imports\Jobs\PrepareCsvExportOverride;
-
-use App\Overrides\Laravel\PermissionMigrationCreator;
-
-use App\Overrides\LastDragon_ru\LaraASP\GraphQL\SearchBy\Definitions\SearchByDirective as GraphQLSearchByDirectiveOverride;
-use App\Overrides\LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition as GraphQLSearchByTypesConditionOverride;
-use Filament\Actions\Exports\Jobs\PrepareCsvExport;
-use Filament\Actions\Imports\Jobs\ImportCsv;
-use function Sentry\configureScope;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Facades\Process;
-use Illuminate\Support\Facades\Queue;
-use Illuminate\Support\Facades\URL;
-use Illuminate\Support\ServiceProvider;
-use Laravel\Pennant\Feature;
-use LastDragon_ru\LaraASP\GraphQL\SearchBy\Definitions\SearchByDirective as GraphQLSearchByDirectiveAlias;
 use LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition as GraphQLSearchByTypesCondition;
-use OpenSearch\Migrations\Filesystem\MigrationStorage;
-use Sentry\State\Scope;
+use LastDragon_ru\LaraASP\GraphQL\SearchBy\Definitions\SearchByDirective as GraphQLSearchByDirectiveAlias;
+use App\Overrides\LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition as GraphQLSearchByTypesConditionOverride;
+use App\Overrides\LastDragon_ru\LaraASP\GraphQL\SearchBy\Definitions\SearchByDirective as GraphQLSearchByDirectiveOverride;
 
 class AppServiceProvider extends ServiceProvider
 {

--- a/database/settings/2024_08_14_181705_add_gdrp_settings_to_portal_settings.php
+++ b/database/settings/2024_08_14_181705_add_gdrp_settings_to_portal_settings.php
@@ -1,0 +1,19 @@
+<?php
+
+use AidingApp\Portal\Enums\GdprBannerButtonLabel;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('portal.gdpr_banner_text', "We use cookies to personalize content, to provide social media features, and to analyze our traffic. We also share information about your use of our site with our partners who may combine it with other information that you've provided to them or that they've collected from your use of their services.");
+        $this->migrator->add('portal.gdpr_banner_button_label', GdprBannerButtonLabel::AllowCookies);
+    }
+
+    public function down(): void
+    {
+        $this->migrator->delete('portal.gdpr_banner_text');
+        $this->migrator->delete('portal.gdpr_banner_button_label');
+    }
+};

--- a/database/settings/2024_08_14_181705_add_gdrp_settings_to_portal_settings.php
+++ b/database/settings/2024_08_14_181705_add_gdrp_settings_to_portal_settings.php
@@ -3,8 +3,7 @@
 use AidingApp\Portal\Enums\GdprBannerButtonLabel;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
-return new class extends SettingsMigration
-{
+return new class () extends SettingsMigration {
     public function up(): void
     {
         $this->migrator->add('portal.gdpr_banner_text', "We use cookies to personalize content, to provide social media features, and to analyze our traffic. We also share information about your use of our site with our partners who may combine it with other information that you've provided to them or that they've collected from your use of their services.");

--- a/database/settings/2024_08_14_181705_add_gdrp_settings_to_portal_settings.php
+++ b/database/settings/2024_08_14_181705_add_gdrp_settings_to_portal_settings.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AidingApp\Portal\Enums\GdprBannerButtonLabel;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2311,9 +2311,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",

--- a/resources/views/vendor/cookie-consent/dialog.blade.php
+++ b/resources/views/vendor/cookie-consent/dialog.blade.php
@@ -31,19 +31,32 @@
 
 </COPYRIGHT>
 --}}
+
+@php
+    use AidingApp\Portal\Settings\PortalSettings;
+@endphp
+
 <div class="js-cookie-consent cookie-consent z-50 fixed bottom-0 inset-x-0 pb-2">
     <div class="max-w-7xl mx-auto px-6">
         <div class="p-2 rounded-lg bg-primary-100 ring-1 ring-black/5 shadow-sm">
             <div class="flex items-center justify-between flex-wrap">
                 <div class="w-0 flex-1 items-center hidden md:inline">
                     <p class="ml-3 text-primary-950 text-sm font-medium cookie-consent__message">
-                        {!! trans('cookie-consent::texts.message') !!}
+                        @if(! empty(app(PortalSettings::class)->gdpr_banner_text))
+                            {!! str(app(PortalSettings::class)->gdpr_banner_text)->sanitizeHtml() !!}
+                        @else
+                            We use cookies to personalize content, to provide social media features, and to analyze our traffic. We also share information about your use of our site with our partners who may combine it with other information that you've provided to them or that they've collected from your use of their services.
+                        @endif
                     </p>
                 </div>
 
                 <div class="mt-2 flex-shrink-0 w-full sm:mt-0 sm:w-auto">
                     <x-filament::button class="js-cookie-consent-agree cookie-consent__agree">
-                        {{ trans('cookie-consent::texts.agree') }}
+                        @if(! empty(app(PortalSettings::class)->gdpr_banner_button_label))
+                            {{ str(app(PortalSettings::class)->gdpr_banner_button_label->getLabel()) }}
+                        @else
+                            Allow Cookies
+                        @endif
                     </x-filament::button>
                 </div>
             </div>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-151

### Technical Description

Adds the ability to customize the GDPR Banner for the Portal.

Adds the Feature Flag for this in a new way I would like to propose. We will now place Feature Flags in this new `FeatureFlag` ENUM. This way they are in a central location and it is easier to track when we have left any behind.
They are actually truly registered in the Service Provider with this ENUM, that way once all Feature Flags are like this we no longer have to have a purge migration during cleanup. We would setup a task to purge all flags that are not currently registered.
When we cleanup a Feature Flag we would delete it from the ENUM and remove it's reference from everywhere in the app. Even the initial activate migration.
This also allows use to define an active function for a feature so we can dynamically activate it if we wanted.

### Any deployment steps required?

No

### Are any Feature Flags Added?

Feature Flag: `GdprBannerCustomization`

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
