### PR TITLE
[AIDAPP-223]: When no logo is set for the client portal, it should default to the product logo, but instead it displays a broken image.

### DIFF
--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalController.php
@@ -47,36 +47,36 @@ use AidingApp\Portal\Settings\PortalSettings;
 
 class KnowledgeManagementPortalController extends Controller
 {
-  public function show(): JsonResponse
-  {
-    $settings = resolve(PortalSettings::class);
-    $settingsProperty = SettingsProperty::getInstance('portal.logo');
-    $logo = $settingsProperty->getFirstMedia('logo');
-    $settingsFaviconProperty = SettingsProperty::getInstance('portal.favicon');
-    $favicon = $settingsFaviconProperty->getFirstMedia('portal_favicon');
+    public function show(): JsonResponse
+    {
+        $settings = resolve(PortalSettings::class);
+        $settingsProperty = SettingsProperty::getInstance('portal.logo');
+        $logo = $settingsProperty->getFirstMedia('logo');
+        $settingsFaviconProperty = SettingsProperty::getInstance('portal.favicon');
+        $favicon = $settingsFaviconProperty->getFirstMedia('portal_favicon');
 
-    return response()->json([
-      'layout' => $settings->knowledge_management_portal_layout ?? PortalLayout::Full,
-      'header_logo' => $logo ?  $logo->getTemporaryUrl(
-        expiration: now()->addMinutes(5),
-        conversionName: 'logo-height-250px',
-      ) : url(Vite::asset('resources/images/default-logo-light.png')),
-      'favicon' => $favicon?->getTemporaryUrl(
-        expiration: now()->addMinutes(5),
-        conversionName: 'portal_favicon',
-      ),
-      'app_name' => config('app.name'),
-      'primary_color' => Color::all()[$settings->knowledge_management_portal_primary_color ?? 'blue'],
-      'rounding' => $settings->knowledge_management_portal_rounding,
-      'requires_authentication' => $settings->knowledge_management_portal_requires_authentication,
-      'service_management_enabled' => $settings->knowledge_management_portal_service_management,
-      'authentication_url' => URL::to(
-        URL::signedRoute(
-          name: 'api.portal.request-authentication',
-          absolute: false,
-        )
-      ),
-      'footer_logo' => Vite::asset('resources/images/canyon-logo-light.png'),
-    ]);
-  }
+        return response()->json([
+            'layout' => $settings->knowledge_management_portal_layout ?? PortalLayout::Full,
+            'header_logo' => $logo ? $logo->getTemporaryUrl(
+                expiration: now()->addMinutes(5),
+                conversionName: 'logo-height-250px',
+            ) : url(Vite::asset('resources/images/default-logo-light.png')),
+            'favicon' => $favicon?->getTemporaryUrl(
+                expiration: now()->addMinutes(5),
+                conversionName: 'portal_favicon',
+            ),
+            'app_name' => config('app.name'),
+            'primary_color' => Color::all()[$settings->knowledge_management_portal_primary_color ?? 'blue'],
+            'rounding' => $settings->knowledge_management_portal_rounding,
+            'requires_authentication' => $settings->knowledge_management_portal_requires_authentication,
+            'service_management_enabled' => $settings->knowledge_management_portal_service_management,
+            'authentication_url' => URL::to(
+                URL::signedRoute(
+                    name: 'api.portal.request-authentication',
+                    absolute: false,
+                )
+            ),
+            'footer_logo' => Vite::asset('resources/images/canyon-logo-light.png'),
+        ]);
+    }
 }

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalController.php
@@ -47,36 +47,36 @@ use AidingApp\Portal\Settings\PortalSettings;
 
 class KnowledgeManagementPortalController extends Controller
 {
-  public function show(): JsonResponse
-  {
-    $settings = resolve(PortalSettings::class);
-    $settingsProperty = SettingsProperty::getInstance('portal.logo');
-    $logo = $settingsProperty->getFirstMedia('logo');
-    $settingsFaviconProperty = SettingsProperty::getInstance('portal.favicon');
-    $favicon = $settingsFaviconProperty->getFirstMedia('portal_favicon');
+    public function show(): JsonResponse
+    {
+        $settings = resolve(PortalSettings::class);
+        $settingsProperty = SettingsProperty::getInstance('portal.logo');
+        $logo = $settingsProperty->getFirstMedia('logo');
+        $settingsFaviconProperty = SettingsProperty::getInstance('portal.favicon');
+        $favicon = $settingsFaviconProperty->getFirstMedia('portal_favicon');
 
-    return response()->json([
-      'layout' => $settings->knowledge_management_portal_layout ?? PortalLayout::Full,
-      'header_logo' => $logo ?  $logo?->getTemporaryUrl(
-        expiration: now()->addMinutes(5),
-        conversionName: 'logo-height-250px',
-      ) : url(Vite::asset('resources/images/default-logo-light.png')),
-      'favicon' => $favicon?->getTemporaryUrl(
-        expiration: now()->addMinutes(5),
-        conversionName: 'portal_favicon',
-      ),
-      'app_name' => config('app.name'),
-      'primary_color' => Color::all()[$settings->knowledge_management_portal_primary_color ?? 'blue'],
-      'rounding' => $settings->knowledge_management_portal_rounding,
-      'requires_authentication' => $settings->knowledge_management_portal_requires_authentication,
-      'service_management_enabled' => $settings->knowledge_management_portal_service_management,
-      'authentication_url' => URL::to(
-        URL::signedRoute(
-          name: 'api.portal.request-authentication',
-          absolute: false,
-        )
-      ),
-      'footer_logo' => Vite::asset('resources/images/canyon-logo-light.png'),
-    ]);
-  }
+        return response()->json([
+            'layout' => $settings->knowledge_management_portal_layout ?? PortalLayout::Full,
+            'header_logo' => $logo ? $logo?->getTemporaryUrl(
+                expiration: now()->addMinutes(5),
+                conversionName: 'logo-height-250px',
+            ) : url(Vite::asset('resources/images/default-logo-light.png')),
+            'favicon' => $favicon?->getTemporaryUrl(
+                expiration: now()->addMinutes(5),
+                conversionName: 'portal_favicon',
+            ),
+            'app_name' => config('app.name'),
+            'primary_color' => Color::all()[$settings->knowledge_management_portal_primary_color ?? 'blue'],
+            'rounding' => $settings->knowledge_management_portal_rounding,
+            'requires_authentication' => $settings->knowledge_management_portal_requires_authentication,
+            'service_management_enabled' => $settings->knowledge_management_portal_service_management,
+            'authentication_url' => URL::to(
+                URL::signedRoute(
+                    name: 'api.portal.request-authentication',
+                    absolute: false,
+                )
+            ),
+            'footer_logo' => Vite::asset('resources/images/canyon-logo-light.png'),
+        ]);
+    }
 }

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalController.php
@@ -47,36 +47,36 @@ use AidingApp\Portal\Settings\PortalSettings;
 
 class KnowledgeManagementPortalController extends Controller
 {
-    public function show(): JsonResponse
-    {
-        $settings = resolve(PortalSettings::class);
-        $settingsProperty = SettingsProperty::getInstance('portal.logo');
-        $logo = $settingsProperty->getFirstMedia('logo');
-        $settingsFaviconProperty = SettingsProperty::getInstance('portal.favicon');
-        $favicon = $settingsFaviconProperty->getFirstMedia('portal_favicon');
+  public function show(): JsonResponse
+  {
+    $settings = resolve(PortalSettings::class);
+    $settingsProperty = SettingsProperty::getInstance('portal.logo');
+    $logo = $settingsProperty->getFirstMedia('logo');
+    $settingsFaviconProperty = SettingsProperty::getInstance('portal.favicon');
+    $favicon = $settingsFaviconProperty->getFirstMedia('portal_favicon');
 
-        return response()->json([
-            'layout' => $settings->knowledge_management_portal_layout ?? PortalLayout::Full,
-            'header_logo' => $logo?->getTemporaryUrl(
-                expiration: now()->addMinutes(5),
-                conversionName: 'logo-height-250px',
-            ),
-            'favicon' => $favicon?->getTemporaryUrl(
-                expiration: now()->addMinutes(5),
-                conversionName: 'portal_favicon',
-            ),
-            'app_name' => config('app.name'),
-            'primary_color' => Color::all()[$settings->knowledge_management_portal_primary_color ?? 'blue'],
-            'rounding' => $settings->knowledge_management_portal_rounding,
-            'requires_authentication' => $settings->knowledge_management_portal_requires_authentication,
-            'service_management_enabled' => $settings->knowledge_management_portal_service_management,
-            'authentication_url' => URL::to(
-                URL::signedRoute(
-                    name: 'api.portal.request-authentication',
-                    absolute: false,
-                )
-            ),
-            'footer_logo' => Vite::asset('resources/images/canyon-logo-light.png'),
-        ]);
-    }
+    return response()->json([
+      'layout' => $settings->knowledge_management_portal_layout ?? PortalLayout::Full,
+      'header_logo' => $logo ?  $logo?->getTemporaryUrl(
+        expiration: now()->addMinutes(5),
+        conversionName: 'logo-height-250px',
+      ) : url(Vite::asset('resources/images/default-logo-light.png')),
+      'favicon' => $favicon?->getTemporaryUrl(
+        expiration: now()->addMinutes(5),
+        conversionName: 'portal_favicon',
+      ),
+      'app_name' => config('app.name'),
+      'primary_color' => Color::all()[$settings->knowledge_management_portal_primary_color ?? 'blue'],
+      'rounding' => $settings->knowledge_management_portal_rounding,
+      'requires_authentication' => $settings->knowledge_management_portal_requires_authentication,
+      'service_management_enabled' => $settings->knowledge_management_portal_service_management,
+      'authentication_url' => URL::to(
+        URL::signedRoute(
+          name: 'api.portal.request-authentication',
+          absolute: false,
+        )
+      ),
+      'footer_logo' => Vite::asset('resources/images/canyon-logo-light.png'),
+    ]);
+  }
 }

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalController.php
@@ -47,36 +47,36 @@ use AidingApp\Portal\Settings\PortalSettings;
 
 class KnowledgeManagementPortalController extends Controller
 {
-    public function show(): JsonResponse
-    {
-        $settings = resolve(PortalSettings::class);
-        $settingsProperty = SettingsProperty::getInstance('portal.logo');
-        $logo = $settingsProperty->getFirstMedia('logo');
-        $settingsFaviconProperty = SettingsProperty::getInstance('portal.favicon');
-        $favicon = $settingsFaviconProperty->getFirstMedia('portal_favicon');
+  public function show(): JsonResponse
+  {
+    $settings = resolve(PortalSettings::class);
+    $settingsProperty = SettingsProperty::getInstance('portal.logo');
+    $logo = $settingsProperty->getFirstMedia('logo');
+    $settingsFaviconProperty = SettingsProperty::getInstance('portal.favicon');
+    $favicon = $settingsFaviconProperty->getFirstMedia('portal_favicon');
 
-        return response()->json([
-            'layout' => $settings->knowledge_management_portal_layout ?? PortalLayout::Full,
-            'header_logo' => $logo ? $logo?->getTemporaryUrl(
-                expiration: now()->addMinutes(5),
-                conversionName: 'logo-height-250px',
-            ) : url(Vite::asset('resources/images/default-logo-light.png')),
-            'favicon' => $favicon?->getTemporaryUrl(
-                expiration: now()->addMinutes(5),
-                conversionName: 'portal_favicon',
-            ),
-            'app_name' => config('app.name'),
-            'primary_color' => Color::all()[$settings->knowledge_management_portal_primary_color ?? 'blue'],
-            'rounding' => $settings->knowledge_management_portal_rounding,
-            'requires_authentication' => $settings->knowledge_management_portal_requires_authentication,
-            'service_management_enabled' => $settings->knowledge_management_portal_service_management,
-            'authentication_url' => URL::to(
-                URL::signedRoute(
-                    name: 'api.portal.request-authentication',
-                    absolute: false,
-                )
-            ),
-            'footer_logo' => Vite::asset('resources/images/canyon-logo-light.png'),
-        ]);
-    }
+    return response()->json([
+      'layout' => $settings->knowledge_management_portal_layout ?? PortalLayout::Full,
+      'header_logo' => $logo ?  $logo->getTemporaryUrl(
+        expiration: now()->addMinutes(5),
+        conversionName: 'logo-height-250px',
+      ) : url(Vite::asset('resources/images/default-logo-light.png')),
+      'favicon' => $favicon?->getTemporaryUrl(
+        expiration: now()->addMinutes(5),
+        conversionName: 'portal_favicon',
+      ),
+      'app_name' => config('app.name'),
+      'primary_color' => Color::all()[$settings->knowledge_management_portal_primary_color ?? 'blue'],
+      'rounding' => $settings->knowledge_management_portal_rounding,
+      'requires_authentication' => $settings->knowledge_management_portal_requires_authentication,
+      'service_management_enabled' => $settings->knowledge_management_portal_service_management,
+      'authentication_url' => URL::to(
+        URL::signedRoute(
+          name: 'api.portal.request-authentication',
+          absolute: false,
+        )
+      ),
+      'footer_logo' => Vite::asset('resources/images/canyon-logo-light.png'),
+    ]);
+  }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-223

### Technical Description

> Give default logo in client portal page.

### Any deployment steps required?

> No.

### Are any Feature Flags Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
