### PR TITLE
[AIDAPP-233]: Update GitHub Action step versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
         uses: tj-actions/verify-changed-files@6ed7632824d235029086612d4330d659005af687
         with:
           fail-if-changed: 'true'
-          files: '*'
 
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,16 @@ jobs:
 
       - name: Commit changes
         if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
-        uses: stefanzweifel/git-auto-commit-action@v5
+        # SHA of release v5.0.1
+        uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842
         with:
           commit_message: >
             chore: fix enforcement of copyright on all files
 
       - name: Check for changes
         if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
-        uses: tj-actions/verify-changed-files@v19
+        # SHA of release v20.0.1
+        uses: tj-actions/verify-changed-files@6ed7632824d235029086612d4330d659005af687
         with:
           fail-if-changed: 'true'
           files: '*'
@@ -103,14 +105,16 @@ jobs:
 
       - name: Commit changes
         if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
-        uses: stefanzweifel/git-auto-commit-action@v5
+        # SHA of release v5.0.1
+        uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842
         with:
           commit_message: >
             chore: fix code style
 
       - name: Check for changes
         if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]' }}
-        uses: tj-actions/verify-changed-files@v19
+        # SHA of release v20.0.1
+        uses: tj-actions/verify-changed-files@6ed7632824d235029086612d4330d659005af687
         with:
           fail-if-changed: 'true'
           files: '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
         uses: tj-actions/verify-changed-files@6ed7632824d235029086612d4330d659005af687
         with:
           fail-if-changed: 'true'
-          files: '*'
 
   fix-code-style:
     runs-on: ubuntu-22.04

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -50,16 +50,16 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        # SHA of release v1.2.0
-        uses: aws-actions/amazon-ecs-render-task-definition@4225e0b507142a2e432b018bc3ccb728559b437a
+        # SHA of release v1.5.0
+        uses: aws-actions/amazon-ecs-render-task-definition@9933bf0d77b7f6d52e3886fbb8aae95a677db1ab
         with:
           task-definition: "docker/devops/ecs/aidingapp/aidingapp-dev-task-definition.json"
           container-name: "app"
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition
-        # SHA of release v1.4.11
-        uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+        # SHA of release v2.0.0
+        uses: aws-actions/amazon-ecs-deploy-task-definition@0a9a8fb7b39516cf53cc01d453b05c67c6fc7a2c
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: "aidingapp-dev-service"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,16 +50,16 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        # SHA of release v1.2.0
-        uses: aws-actions/amazon-ecs-render-task-definition@4225e0b507142a2e432b018bc3ccb728559b437a
+        # SHA of release v1.5.0
+        uses: aws-actions/amazon-ecs-render-task-definition@9933bf0d77b7f6d52e3886fbb8aae95a677db1ab
         with:
           task-definition: "docker/devops/ecs/aidingapp/aidingapp-prod-task-definition.json"
           container-name: "app"
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition
-        # SHA of release v1.4.11
-        uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+        # SHA of release v2.0.0
+        uses: aws-actions/amazon-ecs-deploy-task-definition@0a9a8fb7b39516cf53cc01d453b05c67c6fc7a2c
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: "aidingapp-prod-service"

--- a/.github/workflows/update_yearly_copyright.yml
+++ b/.github/workflows/update_yearly_copyright.yml
@@ -24,7 +24,8 @@ jobs:
         run: ruby ./copyright.rb
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        # SHA of release v6.1.0
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c
         with:
           token: ${{ secrets.PAT }}
           commit-message: >


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-233

### Technical Description

Updates all GitHub Action versions and locks some to a particular commit with a SHA.

### Any deployment steps required?

No

### Are any Feature Flags Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
