### PR TITLE
[AIDAPP-246]: Modify local configuration to allow containers to reach each other via subdomain 

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,7 +42,10 @@ services:
     volumes:
       - '.:/var/www/html'
     networks:
-      - cgbs-development
+      cgbs-development:
+        ipv4_address: 172.16.1.4
+    dns:
+      - 172.16.1.1
     depends_on:
       - aidingapp-redis
       - aidingapp-minio
@@ -73,13 +76,7 @@ services:
       - cgbs-development
     command: 'minio server /data/minio --console-address ":8900"'
     healthcheck:
-      test:
-        [
-          'CMD',
-          'curl',
-          '-f',
-          'http://localhost:9000/minio/health/live'
-        ]
+      test: [ 'CMD', 'curl', '-f', 'http://localhost:9000/minio/health/live' ]
       retries: 3
       timeout: 5s
     labels:
@@ -126,16 +123,7 @@ services:
     networks:
       - cgbs-development
     healthcheck:
-      test:
-        [
-          "CMD",
-          "pg_isready",
-          "-q",
-          "-d",
-          "${DB_DATABASE}",
-          "-U",
-          "${DB_USERNAME}"
-        ]
+      test: [ "CMD", "pg_isready", "-q", "-d", "${DB_DATABASE}", "-U", "${DB_USERNAME}" ]
       retries: 3
       timeout: 5s
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-246

### Technical Description

Adds needed configuration to work with changes to the `traefik` repo, allowing the app containers to communicate via subdomain.

### Any deployment steps required?

No

### Are any Feature Flags Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
