### PR TITLE
[AIDAPP-204]: Remove chmod of non-existant rr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,5 +101,4 @@ RUN chown -R "$PUID":"$PGID" /var/www/html \
     && chmod g+s /var/www/html/storage/logs \
     && find /var/www/html -type d -print0 | xargs -0 chmod 755 \
     && find /var/www/html \( -path /var/www/html/docker -o -path /var/www/html/node_modules -o -path /var/www/html/vendor \) -prune -o -type f -print0 | xargs -0 chmod 644 \
-    && chmod -R ug+rwx /var/www/html/storage /var/www/html/bootstrap/cache \
-    && chmod 0755 /var/www/html/rr
+    && chmod -R ug+rwx /var/www/html/storage /var/www/html/bootstrap/cache


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-204

### Technical Description

Removes prod chmod of `rr` file that does not exist anymore.

### Any deployment steps required?

No

### Are any Feature Flags Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
