### PR TITLE
[Bugfix]: Remove reference to old FeatureFlag ENUM

### DIFF
--- a/resources/views/vendor/cookie-consent/dialog.blade.php
+++ b/resources/views/vendor/cookie-consent/dialog.blade.php
@@ -34,7 +34,6 @@
 
 @php
     use AidingApp\Portal\Settings\PortalSettings;
-    use App\Enums\FeatureFlag;
 @endphp
 
 <div class="js-cookie-consent cookie-consent z-50 fixed bottom-0 inset-x-0 pb-2">


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Removes reference to old FeatureFlag ENUM that was missed.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
