### PR TITLE
[AIDAPP-293]: Resolve issues in our Docker Compose setup from Docker Updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,3 @@ services:
             args:
                 USER_ID: ${SPIN_USER_ID:-9999}
                 GROUP_ID: ${SPIN_GROUP_ID:-9999}
-        extra_hosts:
-            - 'host.docker.internal:host-gateway'


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-293

### Technical Description

Resolves issues in our Docker Compose setup by removing duplicate `extra_hosts` entries that are no longer allowed in recent Docker version.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
