### PR TITLE
[AIDAPP-299]: When viewing the GDPR banner, the message is presented outside of the intended CSS container

### DIFF
--- a/resources/views/vendor/cookie-consent/dialog.blade.php
+++ b/resources/views/vendor/cookie-consent/dialog.blade.php
@@ -41,13 +41,13 @@
         <div class="p-2 rounded-lg bg-primary-100 ring-1 ring-black/5 shadow-sm">
             <div class="flex items-center justify-between flex-wrap">
                 <div class="w-0 flex-1 items-center hidden md:inline [&_a]:text-primary-500 hover:[&_a]:underline">
-                    <p class="ml-3 text-primary-950 text-sm font-medium cookie-consent__message">
+                    <div class="ml-3 text-primary-950 text-sm font-medium cookie-consent__message">
                             @if(! empty(app(PortalSettings::class)->gdpr_banner_text))
                                 {!! str(tiptap_converter()->asHtml(app(PortalSettings::class)->gdpr_banner_text))->sanitizeHtml() !!}
                             @else
                                 We use cookies to personalize content, to provide social media features, and to analyze our traffic. We also share information about your use of our site with our partners who may combine it with other information that you've provided to them or that they've collected from your use of their services.
                             @endif
-                    </p>
+                    </div>
                 </div>
 
                 <div class="mt-2 flex-shrink-0 w-full sm:mt-0 sm:w-auto">


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-299

### Technical Description

> When viewing the GDPR banner, the message is presented outside of the intended CSS container

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
