### PR TITLE
[AIDAPP-277]: Ensure a status is set to New when a service request is created in the portal

### DIFF
--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/CreateServiceRequestController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/CreateServiceRequestController.php
@@ -57,6 +57,7 @@ use AidingApp\ServiceManagement\Models\ServiceRequestForm;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use AidingApp\Form\Filament\Blocks\TextInputFormFieldBlock;
 use AidingApp\Form\Actions\ResolveSubmissionAuthorFromEmail;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequestFormStep;
 use AidingApp\ServiceManagement\Models\ServiceRequestFormField;
 use AidingApp\Form\Filament\Blocks\EducatableEmailFormFieldBlock;
@@ -108,9 +109,12 @@ class CreateServiceRequestController extends Controller
         DB::beginTransaction();
 
         try {
+            $serviceRequestStatus = ServiceRequestStatus::orderBy('id', 'asc')->firstOrFail();
             $serviceRequest = new ServiceRequest([
                 'title' => $data->pull('Main.title'),
                 'close_details' => $data->pull('Main.description'),
+                'status_id' => $serviceRequestStatus ? $serviceRequestStatus->id : null,
+                'status_updated_at' => $serviceRequestStatus ? now() : null,
             ]);
 
             $serviceRequest->respondent()->associate($contact);

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/CreateServiceRequestController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/CreateServiceRequestController.php
@@ -62,6 +62,7 @@ use AidingApp\ServiceManagement\Models\ServiceRequestFormStep;
 use AidingApp\ServiceManagement\Models\ServiceRequestFormField;
 use AidingApp\Form\Filament\Blocks\EducatableEmailFormFieldBlock;
 use AidingApp\ServiceManagement\Models\ServiceRequestFormSubmission;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Models\MediaCollections\UploadsMediaCollection;
 use AidingApp\ServiceManagement\Actions\ResolveUploadsMediaCollectionForServiceRequest;
 
@@ -109,12 +110,12 @@ class CreateServiceRequestController extends Controller
         DB::beginTransaction();
 
         try {
-            $serviceRequestStatus = ServiceRequestStatus::orderBy('id', 'asc')->firstOrFail();
+            $serviceRequestStatus = ServiceRequestStatus::where('classification', SystemServiceRequestClassification::Open)->where('name', 'New')->where('is_system_protected', true)->firstOrFail();
             $serviceRequest = new ServiceRequest([
                 'title' => $data->pull('Main.title'),
                 'close_details' => $data->pull('Main.description'),
-                'status_id' => $serviceRequestStatus ? $serviceRequestStatus->id : null,
-                'status_updated_at' => $serviceRequestStatus ? now() : null,
+                'status_id' => $serviceRequestStatus->id,
+                'status_updated_at' => now(),
             ]);
 
             $serviceRequest->respondent()->associate($contact);

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/CreateServiceRequestController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/CreateServiceRequestController.php
@@ -110,11 +110,15 @@ class CreateServiceRequestController extends Controller
         DB::beginTransaction();
 
         try {
-            $serviceRequestStatus = ServiceRequestStatus::where('classification', SystemServiceRequestClassification::Open)->where('name', 'New')->where('is_system_protected', true)->firstOrFail();
+            $serviceRequestStatus = ServiceRequestStatus::query()
+                ->where('classification', SystemServiceRequestClassification::Open)
+                ->where('name', 'New')
+                ->where('is_system_protected', true)
+                ->firstOrFail();
             $serviceRequest = new ServiceRequest([
                 'title' => $data->pull('Main.title'),
                 'close_details' => $data->pull('Main.description'),
-                'status_id' => $serviceRequestStatus->id,
+                'status_id' => $serviceRequestStatus->getKey(),
                 'status_updated_at' => now(),
             ]);
 


### PR DESCRIPTION

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-277

### Technical Description

> "New" label set when a service request created from the portal.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
