### PR TITLE
[AIDAPP-303]: Extend the model for knowledge base categories to have a slug value

### DIFF
--- a/.config/psysh/psysh_history
+++ b/.config/psysh/psysh_history
@@ -1,8 +1,0 @@
-_HiStOrY_V2_
-AidingApp\134KnowledgeBase\134Models\134KnowledgeBaseCategory::factory(10)->create();
-AidingApp\134KnowledgeBase\134Models\134KnowledgeBaseCategory::factory(10)->create();
-clear
-AidingApp\134KnowledgeBase\134Models\134KnowledgeBaseCategory::factory(10)->create();
-exit
-AidingApp\134KnowledgeBase\134Models\134KnowledgeBaseCategory::factory(10)->create();
-exit

--- a/.config/psysh/psysh_history
+++ b/.config/psysh/psysh_history
@@ -1,0 +1,8 @@
+_HiStOrY_V2_
+AidingApp\134KnowledgeBase\134Models\134KnowledgeBaseCategory::factory(10)->create();
+AidingApp\134KnowledgeBase\134Models\134KnowledgeBaseCategory::factory(10)->create();
+clear
+AidingApp\134KnowledgeBase\134Models\134KnowledgeBaseCategory::factory(10)->create();
+exit
+AidingApp\134KnowledgeBase\134Models\134KnowledgeBaseCategory::factory(10)->create();
+exit

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ public/api-docs/*
 /rr
 _temp_graphql_parse_ide_helper_models.php
 /.bash_history
+.config/psysh/psysh_history

--- a/app-modules/knowledge-base/database/factories/KnowledgeBaseCategoryFactory.php
+++ b/app-modules/knowledge-base/database/factories/KnowledgeBaseCategoryFactory.php
@@ -52,6 +52,7 @@ class KnowledgeBaseCategoryFactory extends Factory
             'name' => str(fake()->word())->ucfirst()->toString(),
             'description' => fake()->optional()->sentences(2, true),
             'icon' => fake()->optional()->randomElement($this->icons()),
+            'slug' => fake()->slug(),
         ];
     }
 

--- a/app-modules/knowledge-base/database/migrations/2024_10_10_115843_add_slug_to_knowledge_base_categories_table.php
+++ b/app-modules/knowledge-base/database/migrations/2024_10_10_115843_add_slug_to_knowledge_base_categories_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;

--- a/app-modules/knowledge-base/database/migrations/2024_10_10_115843_add_slug_to_knowledge_base_categories_table.php
+++ b/app-modules/knowledge-base/database/migrations/2024_10_10_115843_add_slug_to_knowledge_base_categories_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('knowledge_base_categories', function (Blueprint $table) {
+            $table->string('slug')->unique()->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('knowledge_base_categories', function (Blueprint $table) {
+            $table->dropColumn('slug');
+        });
+    }
+};

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/CreateKnowledgeBaseCategory.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/CreateKnowledgeBaseCategory.php
@@ -36,14 +36,13 @@
 
 namespace AidingApp\KnowledgeBase\Filament\Resources\KnowledgeBaseCategoryResource\Pages;
 
-use App\Features\Slug;
 use Filament\Forms\Form;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
+use App\Features\KnowledgeBaseCategorySlug;
 use App\Filament\Forms\Components\IconSelect;
 use AidingApp\KnowledgeBase\Filament\Resources\KnowledgeBaseCategoryResource;
-use App\Features\KnowledgeBaseCategorySlug;
 
 class CreateKnowledgeBaseCategory extends CreateRecord
 {

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/CreateKnowledgeBaseCategory.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/CreateKnowledgeBaseCategory.php
@@ -36,12 +36,14 @@
 
 namespace AidingApp\KnowledgeBase\Filament\Resources\KnowledgeBaseCategoryResource\Pages;
 
+use App\Features\Slug;
 use Filament\Forms\Form;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
 use App\Filament\Forms\Components\IconSelect;
 use AidingApp\KnowledgeBase\Filament\Resources\KnowledgeBaseCategoryResource;
+use App\Features\KnowledgeBaseCategorySlug;
 
 class CreateKnowledgeBaseCategory extends CreateRecord
 {
@@ -56,6 +58,13 @@ class CreateKnowledgeBaseCategory extends CreateRecord
                     ->required()
                     ->string(),
                 IconSelect::make('icon'),
+                TextInput::make('slug')
+                    ->regex('/^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$/')
+                    ->unique()
+                    ->maxLength(255)
+                    ->required()
+                    ->dehydrateStateUsing(fn (string $state): string => strtolower($state))
+                    ->visible(KnowledgeBaseCategorySlug::active()),
                 Textarea::make('description')
                     ->label('Description')
                     ->nullable()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/EditKnowledgeBaseCategory.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/EditKnowledgeBaseCategory.php
@@ -42,6 +42,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
+use App\Features\KnowledgeBaseCategorySlug;
 use App\Filament\Forms\Components\IconSelect;
 use AidingApp\KnowledgeBase\Filament\Resources\KnowledgeBaseCategoryResource;
 
@@ -58,6 +59,13 @@ class EditKnowledgeBaseCategory extends EditRecord
                     ->required()
                     ->string(),
                 IconSelect::make('icon'),
+                TextInput::make('slug')
+                    ->regex('/^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$/')
+                    ->unique(ignoreRecord: true)
+                    ->maxLength(255)
+                    ->required()
+                    ->dehydrateStateUsing(fn (string $state): string => strtolower($state))
+                    ->visible(KnowledgeBaseCategorySlug::active()),
                 Textarea::make('description')
                     ->label('Description')
                     ->nullable()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/ViewKnowledgeBaseCategory.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseCategoryResource/Pages/ViewKnowledgeBaseCategory.php
@@ -40,6 +40,7 @@ use Filament\Actions\EditAction;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Infolists\Components\Section;
+use App\Features\KnowledgeBaseCategorySlug;
 use Filament\Infolists\Components\TextEntry;
 use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
 use AidingApp\KnowledgeBase\Filament\Resources\KnowledgeBaseCategoryResource;
@@ -63,6 +64,9 @@ class ViewKnowledgeBaseCategory extends ViewRecord
                         TextEntry::make('description')
                             ->label('Description')
                             ->columnSpanFull(),
+                        TextEntry::make('slug')
+                            ->hidden(fn (KnowledgeBaseCategory $record): bool => blank($record->slug))
+                            ->visible(KnowledgeBaseCategorySlug::active()),
                     ])
                     ->columns(),
             ]);

--- a/app-modules/knowledge-base/src/Models/KnowledgeBaseCategory.php
+++ b/app-modules/knowledge-base/src/Models/KnowledgeBaseCategory.php
@@ -57,6 +57,7 @@ class KnowledgeBaseCategory extends BaseModel implements Auditable
         'name',
         'description',
         'icon',
+        'slug',
     ];
 
     public function knowledgeBaseItems(): HasMany

--- a/app-modules/knowledge-base/tests/KnowledgeBaseCategory/RequestFactories/CreateKnowledgeBaseCategoryRequestFactory.php
+++ b/app-modules/knowledge-base/tests/KnowledgeBaseCategory/RequestFactories/CreateKnowledgeBaseCategoryRequestFactory.php
@@ -44,7 +44,7 @@ class CreateKnowledgeBaseCategoryRequestFactory extends RequestFactory
     {
         return [
             'name' => $this->faker->word(),
-            'slug' => fake()->slug(),
+            'slug' => $this->faker->slug(),
         ];
     }
 }

--- a/app-modules/knowledge-base/tests/KnowledgeBaseCategory/RequestFactories/CreateKnowledgeBaseCategoryRequestFactory.php
+++ b/app-modules/knowledge-base/tests/KnowledgeBaseCategory/RequestFactories/CreateKnowledgeBaseCategoryRequestFactory.php
@@ -44,6 +44,7 @@ class CreateKnowledgeBaseCategoryRequestFactory extends RequestFactory
     {
         return [
             'name' => $this->faker->word(),
+            'slug' => fake()->slug(),
         ];
     }
 }

--- a/app-modules/knowledge-base/tests/KnowledgeBaseCategory/RequestFactories/CreateKnowledgeBaseCategoryRequestFactory.php
+++ b/app-modules/knowledge-base/tests/KnowledgeBaseCategory/RequestFactories/CreateKnowledgeBaseCategoryRequestFactory.php
@@ -43,8 +43,8 @@ class CreateKnowledgeBaseCategoryRequestFactory extends RequestFactory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->word(),
-            'slug' => $this->faker->slug(),
+            'name' => fake()->word(),
+            'slug' => fake()->slug(),
         ];
     }
 }

--- a/app/Features/KnowledgeBaseCategorySlug.php
+++ b/app/Features/KnowledgeBaseCategorySlug.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/app/Features/KnowledgeBaseCategorySlug.php
+++ b/app/Features/KnowledgeBaseCategorySlug.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class KnowledgeBaseCategorySlug extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/database/migrations/2024_10_10_142117_data_activate_feature_flag_knowledge_base_category_slug.php
+++ b/database/migrations/2024_10_10_142117_data_activate_feature_flag_knowledge_base_category_slug.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Features\KnowledgeBaseCategorySlug;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        KnowledgeBaseCategorySlug::activate();
+    }
+
+    public function down(): void
+    {
+        KnowledgeBaseCategorySlug::deactivate();
+    }
+};

--- a/database/migrations/2024_10_10_142117_data_activate_feature_flag_knowledge_base_category_slug.php
+++ b/database/migrations/2024_10_10_142117_data_activate_feature_flag_knowledge_base_category_slug.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\KnowledgeBaseCategorySlug;
 use Illuminate\Database\Migrations\Migration;
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-303

### Technical Description

> In the Knowledge Base Category, Added a Slug field with validation for unique, hyphenated, alphanumeric values only on create, edit, and view pages.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> Yes. "KnowledgeBaseCategorySlug".
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
