### PR TITLE
[AIDAPP-301] Prevent users from viewing service requests of types that they are not managers or auditors of

### DIFF
--- a/.config/psysh/psysh_history
+++ b/.config/psysh/psysh_history
@@ -1,0 +1,7 @@
+_HiStOrY_V2_
+$user=\040User:find('sampleadmin@aiding.app','email');
+$user=\040User::find('sampleadmin@aiding.app','email');
+$user=\040User::find('email','sampleadmin@aiding.app');
+$user=\040User::whereEmail('sampleadmin@aiding.app')->first();
+$user->roles()->attach('authorization.super_admin');
+$user->roles()->attach('9c8715c5-5daa-4151-8d86-e7413a7e8206');

--- a/.config/psysh/psysh_history
+++ b/.config/psysh/psysh_history
@@ -1,7 +1,0 @@
-_HiStOrY_V2_
-$user=\040User:find('sampleadmin@aiding.app','email');
-$user=\040User::find('sampleadmin@aiding.app','email');
-$user=\040User::find('email','sampleadmin@aiding.app');
-$user=\040User::whereEmail('sampleadmin@aiding.app')->first();
-$user->roles()->attach('authorization.super_admin');
-$user->roles()->attach('9c8715c5-5daa-4151-8d86-e7413a7e8206');

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
@@ -75,13 +75,13 @@ class ListServiceRequests extends ListRecords
                 ],
                 'status',
             ])
-            ->when(!auth()->user()->hasRole('authorization.super_admin'),function(Builder $q){
-                return $q->whereHas('priority.type.managers',function(Builder $query): void{
-                    $query->where('teams.id',auth()->user()->teams()->first()?->getKey());
-                })->orWhereHas('priority.type.auditors',function(Builder $query): void {
-                    $query->where('teams.id',auth()->user()->teams()->first()?->getKey());
-                });
-            }))
+                ->when(! auth()->user()->hasRole('authorization.super_admin'), function (Builder $q) {
+                    return $q->whereHas('priority.type.managers', function (Builder $query): void {
+                        $query->where('teams.id', auth()->user()->teams()->first()?->getKey());
+                    })->orWhereHas('priority.type.auditors', function (Builder $query): void {
+                        $query->where('teams.id', auth()->user()->teams()->first()?->getKey());
+                    });
+                }))
             ->columns([
                 IdColumn::make(),
                 TextColumn::make('service_request_number')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
@@ -74,7 +74,14 @@ class ListServiceRequests extends ListRecords
                     'sla',
                 ],
                 'status',
-            ]))
+            ])
+            ->when(!auth()->user()->hasRole('authorization.super_admin'),function($q){
+                return $q->whereHas('priority.type.managers',function($query){
+                    return $query->where('teams.id',auth()->user()->teams()->first()?->getKey());
+                })->orWhereHas('priority.type.auditors',function($query){
+                    return $query->where('teams.id',auth()->user()->teams()->first()?->getKey());
+                });
+            }))
             ->columns([
                 IdColumn::make(),
                 TextColumn::make('service_request_number')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
@@ -75,11 +75,11 @@ class ListServiceRequests extends ListRecords
                 ],
                 'status',
             ])
-            ->when(!auth()->user()->hasRole('authorization.super_admin'),function($q){
-                return $q->whereHas('priority.type.managers',function($query){
-                    return $query->where('teams.id',auth()->user()->teams()->first()?->getKey());
-                })->orWhereHas('priority.type.auditors',function($query){
-                    return $query->where('teams.id',auth()->user()->teams()->first()?->getKey());
+            ->when(!auth()->user()->hasRole('authorization.super_admin'),function(Builder $q){
+                return $q->whereHas('priority.type.managers',function(Builder $query): void{
+                    $query->where('teams.id',auth()->user()->teams()->first()?->getKey());
+                })->orWhereHas('priority.type.auditors',function(Builder $query): void {
+                    $query->where('teams.id',auth()->user()->teams()->first()?->getKey());
                 });
             }))
             ->columns([

--- a/app-modules/service-management/src/Policies/ServiceRequestPolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestPolicy.php
@@ -76,27 +76,22 @@ class ServiceRequestPolicy
             return Response::deny('You do not have permission to view this service request.');
         }
 
-        if(auth()->user()->hasRole('authorization.super_admin')){
-            return $authenticatable->canOrElse(
-                abilities: ['service_request.*.view', "service_request.{$serviceRequest->id}.view"],
-                denyResponse: 'You do not have permission to view this service request.'
-            );
-        }
-
-        if ($serviceRequest?->priority?->type?->managers()->exists() || $serviceRequest?->priority?->type?->auditors()->exists()) {
-           
+        if (!auth()->user()->hasRole('authorization.super_admin')) {
             $team = auth()->user()->teams()->first();
-
-            if ($serviceRequest?->priority?->type?->managers->contains('id', $team?->getKey()) || $serviceRequest?->priority?->type?->auditors->contains('id', $team?->getKey())) {
-            
-                return $authenticatable->canOrElse(
-                    abilities: ['service_request.*.view', "service_request.{$serviceRequest->id}.view"],
-                    denyResponse: 'You do not have permission to view this service request.'
-                );
+        
+            if (!$serviceRequest?->priority?->type?->managers()->exists() && !$serviceRequest?->priority?->type?->auditors()->exists()) {
+                return Response::deny("You don't have permission to view this service request because you're not an auditor or manager.");
+            }
+        
+            if (!$serviceRequest?->priority?->type?->managers->contains('id', $team?->getKey()) && !$serviceRequest?->priority?->type?->auditors->contains('id', $team?->getKey())) {
+                return Response::deny("You don't have permission to view this service request because you're not an auditor or manager.");
             }
         }
-
-        return Response::deny('You don\'t have permission to view this service request because you\'re not an auditor or manager.');
+        
+        return $authenticatable->canOrElse(
+            abilities: ['service_request.*.view', "service_request.{$serviceRequest->id}.view"],
+            denyResponse: 'You do not have permission to view this service request.'
+        );
     }
 
     public function create(Authenticatable $authenticatable): Response

--- a/app-modules/service-management/src/Policies/ServiceRequestPolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestPolicy.php
@@ -76,18 +76,18 @@ class ServiceRequestPolicy
             return Response::deny('You do not have permission to view this service request.');
         }
 
-        if (!auth()->user()->hasRole('authorization.super_admin')) {
+        if (! auth()->user()->hasRole('authorization.super_admin')) {
             $team = auth()->user()->teams()->first();
-        
-            if (!$serviceRequest?->priority?->type?->managers()->exists() && !$serviceRequest?->priority?->type?->auditors()->exists()) {
+
+            if (! $serviceRequest?->priority?->type?->managers()->exists() && ! $serviceRequest?->priority?->type?->auditors()->exists()) {
                 return Response::deny("You don't have permission to view this service request because you're not an auditor or manager.");
             }
-        
-            if (!$serviceRequest?->priority?->type?->managers->contains('id', $team?->getKey()) && !$serviceRequest?->priority?->type?->auditors->contains('id', $team?->getKey())) {
+
+            if (! $serviceRequest?->priority?->type?->managers->contains('id', $team?->getKey()) && ! $serviceRequest?->priority?->type?->auditors->contains('id', $team?->getKey())) {
                 return Response::deny("You don't have permission to view this service request because you're not an auditor or manager.");
             }
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ['service_request.*.view', "service_request.{$serviceRequest->id}.view"],
             denyResponse: 'You do not have permission to view this service request.'

--- a/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
@@ -237,7 +237,7 @@ test('service requests only visible to service request type auditors', function 
 
     $serviceRequestType->auditors()->attach($team);
 
-    $serviceRequestsWithAuditors= ServiceRequest::factory()->state([
+    $serviceRequestsWithAuditors = ServiceRequest::factory()->state([
         'priority_id' => ServiceRequestPriority::factory()->create([
             'type_id' => $serviceRequestType->getKey(),
         ])->getKey(),

--- a/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
@@ -197,10 +197,10 @@ test('service requests only visible to service request type managers', function 
 
     $serviceRequestsWithManager = ServiceRequest::factory()->state([
         'priority_id' => ServiceRequestPriority::factory()->create([
-            'type_id' => $serviceRequestType->id,
-        ])->id,
+            'type_id' => $serviceRequestType->getKey(),
+        ])->getKey(),
     ])
-        ->count(10)
+        ->count(3)
         ->create();
 
     livewire(ListServiceRequests::class)
@@ -237,17 +237,17 @@ test('service requests only visible to service request type auditors', function 
 
     $serviceRequestType->auditors()->attach($team);
 
-    $serviceRequestsWithManager = ServiceRequest::factory()->state([
+    $serviceRequestsWithAuditors= ServiceRequest::factory()->state([
         'priority_id' => ServiceRequestPriority::factory()->create([
-            'type_id' => $serviceRequestType->id,
-        ])->id,
+            'type_id' => $serviceRequestType->getKey(),
+        ])->getKey(),
     ])
-        ->count(10)
+        ->count(3)
         ->create();
 
     livewire(ListServiceRequests::class)
         ->assertCanSeeTableRecords(
-            $serviceRequestsWithManager
+            $serviceRequestsWithAuditors
         )
         ->assertCanNotSeeTableRecords($serviceRequests);
 });

--- a/app-modules/service-management/tests/ServiceRequest/ViewServiceRequestTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ViewServiceRequestTest.php
@@ -149,11 +149,11 @@ test('service request lock icon is shown when status classification closed', fun
     ])
         ->assertSeeHtml('data-identifier="service_request_closed"');
 })
-->with([
-    ViewServiceRequest::class,
-    ManageAssignments::class,
-    ManageServiceRequestUpdate::class,
-]);
+    ->with([
+        ViewServiceRequest::class,
+        ManageAssignments::class,
+        ManageServiceRequestUpdate::class,
+    ]);
 
 test('service requests not authorized if user is not an auditor or manager of the service request type', function () {
     $settings = app(LicenseSettings::class);

--- a/app-modules/service-management/tests/ServiceRequest/ViewServiceRequestTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ViewServiceRequestTest.php
@@ -35,6 +35,7 @@
 */
 
 use App\Models\User;
+use AidingApp\Team\Models\Team;
 
 use function Tests\asSuperAdmin;
 
@@ -43,9 +44,12 @@ use App\Settings\LicenseSettings;
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
+use AidingApp\Contact\Models\Contact;
 use AidingApp\Authorization\Enums\LicenseType;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
+use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
 use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages\ManageAssignments;
@@ -89,15 +93,7 @@ test('ViewServiceRequest is gated with proper access control', function () {
 
     $serviceRequest = ServiceRequest::factory()->create();
 
-    actingAs($user)
-        ->get(
-            ServiceRequestResource::getUrl('view', [
-                'record' => $serviceRequest,
-            ])
-        )->assertForbidden();
-
-    $user->givePermissionTo('service_request.view-any');
-    $user->givePermissionTo('service_request.*.view');
+    asSuperAdmin($user);
 
     actingAs($user)
         ->get(
@@ -116,12 +112,9 @@ test('ViewServiceRequest is gated with proper feature access control', function 
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('service_request.view-any');
-    $user->givePermissionTo('service_request.*.view');
-
     $serviceRequest = ServiceRequest::factory()->create();
 
-    actingAs($user)
+    asSuperAdmin($user)
         ->get(
             ServiceRequestResource::getUrl('view', [
                 'record' => $serviceRequest,
@@ -143,12 +136,7 @@ test('ViewServiceRequest is gated with proper feature access control', function 
 test('service request lock icon is shown when status classification closed', function (string $pages) {
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('service_request.view-any');
-    $user->givePermissionTo('service_request.*.view');
-    $user->givePermissionTo('service_request_assignment.view-any');
-    $user->givePermissionTo('service_request_update.view-any');
-
-    actingAs($user);
+    asSuperAdmin($user);
 
     $serviceRequest = ServiceRequest::factory([
         'status_id' => ServiceRequestStatus::factory()->create([
@@ -161,8 +149,106 @@ test('service request lock icon is shown when status classification closed', fun
     ])
         ->assertSeeHtml('data-identifier="service_request_closed"');
 })
-    ->with([
-        ViewServiceRequest::class,
-        ManageAssignments::class,
-        ManageServiceRequestUpdate::class,
-    ]);
+->with([
+    ViewServiceRequest::class,
+    ManageAssignments::class,
+    ManageServiceRequestUpdate::class,
+]);
+
+test('service requests not visible if service request type has no auditors/managers', function () {
+    $settings = app(LicenseSettings::class);
+
+    $settings->data->addons->serviceManagement = true;
+
+    $settings->save();
+
+    $user = User::factory()->licensed([Contact::getLicenseType()])->create();
+
+    $user->givePermissionTo('service_request.view-any');
+
+    $user->refresh();
+
+    actingAs($user);
+
+    $serviceRequest = ServiceRequest::factory()
+        ->create();
+
+    livewire(ViewServiceRequest::class, [
+        'record' => $serviceRequest->getRouteKey(),
+    ])
+        ->assertForbidden();
+});
+
+test('view service request page visible if service request type has auditors', function () {
+    $settings = app(LicenseSettings::class);
+
+    $settings->data->addons->serviceManagement = true;
+
+    $settings->save();
+
+    $user = User::factory()->licensed([Contact::getLicenseType()])->create();
+
+    $user->givePermissionTo('service_request.view-any');
+    $user->givePermissionTo('service_request.*.view');
+
+    $team = Team::factory()->create();
+
+    $user->teams()->attach($team);
+
+    $user->refresh();
+
+    actingAs($user);
+
+    $serviceRequestType = ServiceRequestType::factory()->create();
+
+    $serviceRequestType->auditors()->attach($team);
+
+    $serviceRequestsWithManager = ServiceRequest::factory()->state([
+        'priority_id' => ServiceRequestPriority::factory()->create([
+            'type_id' => $serviceRequestType->id,
+        ])->id,
+    ])
+        ->create();
+
+    livewire(ViewServiceRequest::class, [
+        'record' => $serviceRequestsWithManager->getRouteKey(),
+    ])
+        ->assertSuccessful();
+});
+
+test('view service request page visible if service request type has managers', function () {
+    $settings = app(LicenseSettings::class);
+
+    $settings->data->addons->serviceManagement = true;
+
+    $settings->save();
+
+    $user = User::factory()->licensed([Contact::getLicenseType()])->create();
+
+    $user->givePermissionTo('service_request.view-any');
+    $user->givePermissionTo('service_request.*.view');
+
+    $team = Team::factory()->create();
+
+    $user->teams()->attach($team);
+
+    $user->refresh();
+
+    actingAs($user);
+
+    $serviceRequestType = ServiceRequestType::factory()->create();
+
+    $serviceRequestType->managers()->attach($team);
+
+    $serviceRequestsWithManager = ServiceRequest::factory()->state([
+        'priority_id' => ServiceRequestPriority::factory()->create([
+            'type_id' => $serviceRequestType->id,
+        ])->id,
+    ])
+        ->create();
+
+    livewire(ViewServiceRequest::class, [
+        'record' => $serviceRequestsWithManager->getRouteKey(),
+    ])
+        ->assertSuccessful();
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-301

### Technical Description

> Prevent users from viewing service requests of types that they are not managers or auditors of.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
