### PR TITLE
Add default DEV_SUPER_ADMIN_EMAIL to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,7 +115,7 @@ CACHE_EVENTS=false
 CACHE_ICONS=false
 CACHE_FILAMENT_COMPONENTS=false
 
-DEV_SUPER_ADMIN_EMAIL=
+DEV_SUPER_ADMIN_EMAIL=sampleadmin@aiding.app
 
 # A comma separated list of emails
 DEV_USER_EMAILS=


### PR DESCRIPTION
When following the setup instructions, the sample admin is seeded without an email address, so it is impossible to sign in. I didn't realise that it was actually a blank value in the `.env.example`.

Advising doesn't use an env var here, so could be worth making this consistent in the future.