### PR TITLE
[AIDAPP-353]: Update routes to use category slugs for articles and categories with fall back

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 // @formatter:off
 // phpcs:ignoreFile
 /**

--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1,39 +1,5 @@
 <?php
 
-/*
-<COPYRIGHT>
-
-    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
-
-    Aiding App™ is licensed under the Elastic License 2.0. For more details,
-    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
-
-    Notice:
-
-    - You may not provide the software to third parties as a hosted or managed
-      service, where the service provides users with access to any substantial set of
-      the features or functionality of the software.
-    - You may not move, change, disable, or circumvent the license key functionality
-      in the software, and you may not remove or obscure any functionality in the
-      software that is protected by the license key.
-    - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
-      to applicable law.
-    - Canyon GBS LLC respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
-      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
-      vigorously.
-    - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS LLC.
-    - Use of this software implies agreement to the license terms and conditions as stated
-      in the Elastic License 2.0.
-
-    For more information or inquiries please visit our website at
-    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
-
-</COPYRIGHT>
-*/
-
 // @formatter:off
 // phpcs:ignoreFile
 /**
@@ -1114,6 +1080,8 @@ namespace AidingApp\Contact\Models{
  * @property-read int|null $engagement_responses_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AidingApp\Engagement\Models\Engagement> $engagements
  * @property-read int|null $engagements_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \AidingApp\Portal\Models\KnowledgeBaseArticleVote> $knowledgeBaseArticleVotes
+ * @property-read int|null $knowledge_base_article_votes_count
  * @property-read \Illuminate\Notifications\DatabaseNotificationCollection<int, \Illuminate\Notifications\DatabaseNotification> $notifications
  * @property-read int|null $notifications_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AidingApp\Engagement\Models\EngagementResponse> $orderedEngagementResponses
@@ -2123,7 +2091,7 @@ namespace AidingApp\KnowledgeBase\Models{
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
- * @property string|null $slug
+ * @property string $slug
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AidingApp\Audit\Models\Audit> $audits
  * @property-read int|null $audits_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AidingApp\KnowledgeBase\Models\KnowledgeBaseItem> $knowledgeBaseItems
@@ -2177,6 +2145,8 @@ namespace AidingApp\KnowledgeBase\Models{
  * @property-read \AidingApp\KnowledgeBase\Models\KnowledgeBaseStatus|null $status
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Tag> $tags
  * @property-read int|null $tags_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \AidingApp\Portal\Models\KnowledgeBaseArticleVote> $votes
+ * @property-read int|null $votes_count
  * @method static \AidingApp\KnowledgeBase\Database\Factories\KnowledgeBaseItemFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseItem newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseItem newQuery()
@@ -2351,6 +2321,36 @@ namespace AidingApp\Notification\Models{
 
 namespace AidingApp\Portal\Models{
 /**
+ * AidingApp\Portal\Models\KnowledgeBaseArticleVote
+ *
+ * @property string $id
+ * @property bool $is_helpful
+ * @property string $voter_type
+ * @property string $voter_id
+ * @property string $article_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \AidingApp\KnowledgeBase\Models\KnowledgeBaseItem $knowledgeBaseArticle
+ * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent $voter
+ * @method static \AidingApp\Portal\Database\Factories\KnowledgeBaseArticleVoteFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseArticleVote newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseArticleVote newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseArticleVote query()
+ * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseArticleVote whereArticleId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseArticleVote whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseArticleVote whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseArticleVote whereIsHelpful($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseArticleVote whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseArticleVote whereVoterId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|KnowledgeBaseArticleVote whereVoterType($value)
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+	class IdeHelperKnowledgeBaseArticleVote {}
+}
+
+namespace AidingApp\Portal\Models{
+/**
  * AidingApp\Portal\Models\PortalAuthentication
  *
  * @property Carbon|null $created_at
@@ -2376,6 +2376,33 @@ namespace AidingApp\Portal\Models{
  */
 	#[\AllowDynamicProperties]
 	class IdeHelperPortalAuthentication {}
+}
+
+namespace AidingApp\Portal\Models{
+/**
+ * AidingApp\Portal\Models\PortalGuest
+ *
+ * @property string $id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \AidingApp\Portal\Models\KnowledgeBaseArticleVote> $knowledgeBaseArticleVotes
+ * @property-read int|null $knowledge_base_article_votes_count
+ * @method static \AidingApp\Portal\Database\Factories\PortalGuestFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder|PortalGuest newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|PortalGuest newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|PortalGuest onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|PortalGuest query()
+ * @method static \Illuminate\Database\Eloquent\Builder|PortalGuest whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|PortalGuest whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|PortalGuest whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|PortalGuest whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|PortalGuest withTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder|PortalGuest withoutTrashed()
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+	class IdeHelperPortalGuest {}
 }
 
 namespace AidingApp\ServiceManagement\Models{

--- a/app-modules/portal/routes/api.php
+++ b/app-modules/portal/routes/api.php
@@ -97,7 +97,7 @@ Route::prefix('api')
                 Route::get('/categories', [KnowledgeManagementPortalCategoryController::class, 'index'])
                     ->name('category.index');
 
-                Route::get('/categories/{category}', [KnowledgeManagementPortalCategoryController::class, 'show'])
+                Route::get('/categories/{category:slug}', [KnowledgeManagementPortalCategoryController::class, 'show'])
                     ->name('category.show');
 
                 Route::get('/categories/{category}/articles/{article}', [KnowledgeManagementPortalArticleController::class, 'show'])

--- a/app-modules/portal/routes/api.php
+++ b/app-modules/portal/routes/api.php
@@ -37,6 +37,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpFoundation\Response;
+use AidingApp\KnowledgeBase\Models\KnowledgeBaseItem;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
@@ -110,8 +111,30 @@ Route::prefix('api')
                         return redirect()->route('api.portal.category.show', $category->slug);
                     });
 
-                Route::get('/categories/{category}/articles/{article}', [KnowledgeManagementPortalArticleController::class, 'show'])
-                    ->name('article.show');
+                Route::get('/categories/{category:slug}/articles/{article}', [KnowledgeManagementPortalArticleController::class, 'show'])
+                    ->name('article.show')
+                    ->missing(function (Request $request) {
+                        throw_if(
+                            ! $request->category instanceof KnowledgeBaseCategory
+                            && ! str()->isUuid($request->category),
+                            ModelNotFoundException::class
+                        );
+
+                        $category = $request->category instanceof KnowledgeBaseCategory ? $request->category : KnowledgeBaseCategory::findOrFail($request->category);
+
+                        throw_if(
+                            ! $request->article instanceof KnowledgeBaseItem
+                            && ! str()->isUuid($request->article),
+                            ModelNotFoundException::class
+                        );
+
+                        $article = $request->article instanceof KnowledgeBaseItem ? $request->article : KnowledgeBaseItem::findOrFail($request->article);
+
+                        return redirect()->route('api.portal.article.show', [
+                            'category' => $category,
+                            'article' => $article,
+                        ]);
+                    });
 
                 Route::get('/service-request-type/select', [ServiceRequestTypesController::class, 'index'])
                     ->name('service-request-type.index');

--- a/app-modules/portal/routes/api.php
+++ b/app-modules/portal/routes/api.php
@@ -34,8 +34,11 @@
 </COPYRIGHT>
 */
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 use AidingApp\Portal\Http\Middleware\EnsureKnowledgeManagementPortalIsEnabled;
 use AidingApp\Portal\Http\Controllers\KnowledgeManagementPortal\GetServiceRequestUploadUrl;
@@ -98,7 +101,14 @@ Route::prefix('api')
                     ->name('category.index');
 
                 Route::get('/categories/{category:slug}', [KnowledgeManagementPortalCategoryController::class, 'show'])
-                    ->name('category.show');
+                    ->name('category.show')
+                    ->missing(function (Request $request) {
+                        throw_if(! str()->isUuid($request->category), ModelNotFoundException::class);
+
+                        $category = KnowledgeBaseCategory::findOrFail($request->category);
+
+                        return redirect()->route('api.portal.category.show', $category->slug);
+                    });
 
                 Route::get('/categories/{category}/articles/{article}', [KnowledgeManagementPortalArticleController::class, 'show'])
                     ->name('article.show');

--- a/app-modules/portal/routes/api.php
+++ b/app-modules/portal/routes/api.php
@@ -34,12 +34,9 @@
 </COPYRIGHT>
 */
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpFoundation\Response;
-use AidingApp\KnowledgeBase\Models\KnowledgeBaseItem;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
+use AidingApp\Portal\Http\Routing\ArticleShowMissingHandler;
 use AidingApp\Portal\Http\Routing\CategoryShowMissingHandler;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 use AidingApp\Portal\Http\Middleware\EnsureKnowledgeManagementPortalIsEnabled;
@@ -108,28 +105,7 @@ Route::prefix('api')
 
                 Route::get('/categories/{category:slug}/articles/{article}', [KnowledgeManagementPortalArticleController::class, 'show'])
                     ->name('article.show')
-                    ->missing(function (Request $request) {
-                        throw_if(
-                            ! $request->category instanceof KnowledgeBaseCategory
-                            && ! str()->isUuid($request->category),
-                            ModelNotFoundException::class
-                        );
-
-                        $category = $request->category instanceof KnowledgeBaseCategory ? $request->category : KnowledgeBaseCategory::findOrFail($request->category);
-
-                        throw_if(
-                            ! $request->article instanceof KnowledgeBaseItem
-                            && ! str()->isUuid($request->article),
-                            ModelNotFoundException::class
-                        );
-
-                        $article = $request->article instanceof KnowledgeBaseItem ? $request->article : KnowledgeBaseItem::findOrFail($request->article);
-
-                        return redirect()->route('api.portal.article.show', [
-                            'category' => $category,
-                            'article' => $article,
-                        ]);
-                    });
+                    ->missing(app(ArticleShowMissingHandler::class));
 
                 Route::get('/service-request-type/select', [ServiceRequestTypesController::class, 'index'])
                     ->name('service-request-type.index');

--- a/app-modules/portal/routes/api.php
+++ b/app-modules/portal/routes/api.php
@@ -40,6 +40,7 @@ use Symfony\Component\HttpFoundation\Response;
 use AidingApp\KnowledgeBase\Models\KnowledgeBaseItem;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
+use AidingApp\Portal\Http\Routing\CategoryShowMissingHandler;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 use AidingApp\Portal\Http\Middleware\EnsureKnowledgeManagementPortalIsEnabled;
 use AidingApp\Portal\Http\Controllers\KnowledgeManagementPortal\GetServiceRequestUploadUrl;
@@ -103,13 +104,7 @@ Route::prefix('api')
 
                 Route::get('/categories/{category:slug}', [KnowledgeManagementPortalCategoryController::class, 'show'])
                     ->name('category.show')
-                    ->missing(function (Request $request) {
-                        throw_if(! str()->isUuid($request->category), ModelNotFoundException::class);
-
-                        $category = KnowledgeBaseCategory::findOrFail($request->category);
-
-                        return redirect()->route('api.portal.category.show', $category->slug);
-                    });
+                    ->missing(app(CategoryShowMissingHandler::class));
 
                 Route::get('/categories/{category:slug}/articles/{article}', [KnowledgeManagementPortalArticleController::class, 'show'])
                     ->name('article.show')

--- a/app-modules/portal/src/DataTransferObjects/KnowledgeBaseArticleData.php
+++ b/app-modules/portal/src/DataTransferObjects/KnowledgeBaseArticleData.php
@@ -42,7 +42,7 @@ class KnowledgeBaseArticleData extends Data
 {
     public function __construct(
         public string $id,
-        public ?string $categoryId,
+        public string $categorySlug,
         public string $name,
         public ?string $lastUpdated,
         public ?string $content,

--- a/app-modules/portal/src/DataTransferObjects/KnowledgeBaseCategoryData.php
+++ b/app-modules/portal/src/DataTransferObjects/KnowledgeBaseCategoryData.php
@@ -41,7 +41,7 @@ use Spatie\LaravelData\Data;
 class KnowledgeBaseCategoryData extends Data
 {
     public function __construct(
-        public string $id,
+        public string $slug,
         public string $name,
         public ?string $description,
         public ?string $icon,

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalArticleController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalArticleController.php
@@ -78,7 +78,7 @@ class KnowledgeManagementPortalArticleController extends Controller
             ]),
             'article' => KnowledgeBaseArticleData::from([
                 'id' => $article->getKey(),
-                'categoryId' => $article->category_id,
+                'categorySlug' => $article->category->slug,
                 'name' => $article->title,
                 'lastUpdated' => $article->updated_at->format('M d Y, h:m a'),
                 'content' => $article->article_details ? tiptap_converter()->record($article, attribute: 'article_details')->asHTML($article->article_details) : '',

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalArticleController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalArticleController.php
@@ -72,7 +72,7 @@ class KnowledgeManagementPortalArticleController extends Controller
 
         return response()->json([
             'category' => KnowledgeBaseCategoryData::from([
-                'id' => $category->getKey(),
+                'slug' => $category->slug,
                 'name' => $category->name,
                 'description' => $category->description,
             ]),

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategoryController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategoryController.php
@@ -39,6 +39,7 @@ namespace AidingApp\Portal\Http\Controllers\KnowledgeManagementPortal;
 use Illuminate\Http\JsonResponse;
 use App\Http\Controllers\Controller;
 use Illuminate\Database\Eloquent\Builder;
+use AidingApp\KnowledgeBase\Models\KnowledgeBaseItem;
 use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
 use AidingApp\Portal\DataTransferObjects\KnowledgeBaseCategoryData;
 
@@ -82,22 +83,21 @@ class KnowledgeManagementPortalCategoryController extends Controller
                     $query->where('portal_view_count', '>', 0)->orderBy('portal_view_count', 'desc');
                 })
                 ->paginate(5)
-                ->through(function ($category) {
-                    $category->name = $category->title;
-                    $category->categoryId = $category->category_id;
-                    $category->id = $category->getKey();
-
-                    $category->featured = $category->is_featured;
-                    $category->tags = $category->tags()
-                        ->orderBy('name')
-                        ->select([
-                            'id',
-                            'name',
-                        ])
-                        ->get()
-                        ->toArray();
-
-                    return $category;
+                ->through(function (KnowledgeBaseItem $article) {
+                    return [
+                        'id' => $article->getKey(),
+                        'categorySlug' => $article->category->slug,
+                        'name' => $article->title,
+                        'tags' => $article->tags()
+                            ->orderBy('name')
+                            ->select([
+                                'id',
+                                'name',
+                            ])
+                            ->get()
+                            ->toArray(),
+                        'featured' => $article->is_featured,
+                    ];
                 }),
         ]);
     }

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategoryController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategoryController.php
@@ -53,7 +53,7 @@ class KnowledgeManagementPortalCategoryController extends Controller
                     ->get()
                     ->map(function (KnowledgeBaseCategory $category) {
                         return [
-                            'id' => $category->getKey(),
+                            'slug' => $category->slug,
                             'name' => $category->name,
                             'description' => $category->description,
                             'icon' => $category->icon ? svg($category->icon, 'h-6 w-6')->toHtml() : null,
@@ -68,7 +68,7 @@ class KnowledgeManagementPortalCategoryController extends Controller
     {
         return response()->json([
             'category' => KnowledgeBaseCategoryData::from([
-                'id' => $category->getKey(),
+                'slug' => $category->slug,
                 'name' => $category->name,
                 'description' => $category->description,
             ]),

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalSearchController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalSearchController.php
@@ -99,7 +99,7 @@ class KnowledgeManagementPortalSearchController extends Controller
                 ->get()
                 ->map(function (KnowledgeBaseCategory $category) {
                     return [
-                        'id' => $category->getKey(),
+                        'slug' => $category->slug,
                         'name' => $category->name,
                         'description' => $category->description,
                     ];

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalSearchController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalSearchController.php
@@ -79,7 +79,7 @@ class KnowledgeManagementPortalSearchController extends Controller
                 ->through(function (KnowledgeBaseItem $article) {
                     return [
                         'id' => $article->getKey(),
-                        'categoryId' => $article->category_id,
+                        'categorySlug' => $article->category->slug,
                         'name' => $article->title,
                         'tags' => $article->tags()
                             ->orderBy('name')

--- a/app-modules/portal/src/Http/Routing/ArticleShowMissingHandler.php
+++ b/app-modules/portal/src/Http/Routing/ArticleShowMissingHandler.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AidingApp\Portal\Http\Routing;
 
 use Illuminate\Http\Request;

--- a/app-modules/portal/src/Http/Routing/ArticleShowMissingHandler.php
+++ b/app-modules/portal/src/Http/Routing/ArticleShowMissingHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AidingApp\Portal\Http\Routing;
+
+use Illuminate\Http\Request;
+use AidingApp\KnowledgeBase\Models\KnowledgeBaseItem;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
+
+class ArticleShowMissingHandler
+{
+    public function __invoke(Request $request)
+    {
+        throw_if(
+            ! $request->category instanceof KnowledgeBaseCategory
+            && ! str()->isUuid($request->category),
+            ModelNotFoundException::class
+        );
+
+        $category = $request->category instanceof KnowledgeBaseCategory ? $request->category : KnowledgeBaseCategory::findOrFail($request->category);
+
+        throw_if(
+            ! $request->article instanceof KnowledgeBaseItem
+            && ! str()->isUuid($request->article),
+            ModelNotFoundException::class
+        );
+
+        $article = $request->article instanceof KnowledgeBaseItem ? $request->article : KnowledgeBaseItem::findOrFail($request->article);
+
+        return redirect()->route('api.portal.article.show', [
+            'category' => $category,
+            'article' => $article,
+        ]);
+    }
+}

--- a/app-modules/portal/src/Http/Routing/CategoryShowMissingHandler.php
+++ b/app-modules/portal/src/Http/Routing/CategoryShowMissingHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AidingApp\Portal\Http\Routing;
+
+use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
+
+class CategoryShowMissingHandler
+{
+    public function __invoke(Request $request)
+    {
+        throw_if(! str()->isUuid($request->category), ModelNotFoundException::class);
+
+        $category = KnowledgeBaseCategory::findOrFail($request->category);
+
+        return redirect()->route('api.portal.category.show', $category->slug);
+    }
+}

--- a/app-modules/portal/src/Http/Routing/CategoryShowMissingHandler.php
+++ b/app-modules/portal/src/Http/Routing/CategoryShowMissingHandler.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AidingApp\Portal\Http\Routing;
 
 use Illuminate\Http\Request;

--- a/app-modules/portal/src/Models/KnowledgeBaseArticleVote.php
+++ b/app-modules/portal/src/Models/KnowledgeBaseArticleVote.php
@@ -42,6 +42,9 @@ use AidingApp\KnowledgeBase\Models\KnowledgeBaseItem;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
+/**
+ * @mixin IdeHelperKnowledgeBaseArticleVote
+ */
 class KnowledgeBaseArticleVote extends Pivot
 {
     use HasUuids;

--- a/app-modules/portal/src/Models/PortalGuest.php
+++ b/app-modules/portal/src/Models/PortalGuest.php
@@ -40,6 +40,9 @@ use App\Models\BaseModel;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
+/**
+ * @mixin IdeHelperPortalGuest
+ */
 class PortalGuest extends BaseModel
 {
     use SoftDeletes;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "esbuild-plugin-polyfill-node": "^0.3.0",
                 "flowbite": "^2.3.0",
                 "laravel-vite-plugin": "^1.0.4",
+                "lodash": "^4.17.21",
                 "marked": "^12.0.0",
                 "pinia": "^2.1.7",
                 "showdown": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "esbuild-plugin-polyfill-node": "^0.3.0",
         "flowbite": "^2.3.0",
         "laravel-vite-plugin": "^1.0.4",
+        "lodash": "^4.17.21",
         "marked": "^12.0.0",
         "pinia": "^2.1.7",
         "showdown": "^2.1.0",

--- a/portals/knowledge-management/src/Components/Article.vue
+++ b/portals/knowledge-management/src/Components/Article.vue
@@ -48,7 +48,7 @@
         :to="{
             name: 'view-article',
             params: {
-                categoryId: article.categoryId,
+                categorySlug: article.categorySlug,
                 articleId: article.id,
             },
         }"

--- a/portals/knowledge-management/src/Components/HelpCenter.vue
+++ b/portals/knowledge-management/src/Components/HelpCenter.vue
@@ -82,7 +82,7 @@
 
                         <div class="w-full mt-8">
                             <h3 class="text-base font-semibold leading-6 text-gray-900">
-                                <router-link :to="{ name: 'view-category', params: { categoryId: category.slug } }">
+                                <router-link :to="{ name: 'view-category', params: { categorySlug: category.slug } }">
                                     <span class="absolute inset-0" aria-hidden="true" />
                                     {{ category.name }}
                                 </router-link>

--- a/portals/knowledge-management/src/Components/HelpCenter.vue
+++ b/portals/knowledge-management/src/Components/HelpCenter.vue
@@ -56,7 +56,7 @@
             >
                 <div
                     v-for="category in categories"
-                    :key="category.id"
+                    :key="category.slug"
                     class="group relative bg-white p-6 focus-within:bg-gray-50"
                 >
                     <div class="grid">
@@ -82,7 +82,7 @@
 
                         <div class="w-full mt-8">
                             <h3 class="text-base font-semibold leading-6 text-gray-900">
-                                <router-link :to="{ name: 'view-category', params: { categoryId: category.id } }">
+                                <router-link :to="{ name: 'view-category', params: { categoryId: category.slug } }">
                                     <span class="absolute inset-0" aria-hidden="true" />
                                     {{ category.name }}
                                 </router-link>

--- a/portals/knowledge-management/src/Components/SearchResults.vue
+++ b/portals/knowledge-management/src/Components/SearchResults.vue
@@ -139,9 +139,9 @@
 
             <div v-if="searchResults.data.categories.length > 0">
                 <ul role="list" class="divide-y">
-                    <li v-for="category in searchResults.data.categories" :key="category.id">
+                    <li v-for="category in searchResults.data.categories" :key="category.slug">
                         <router-link
-                            :to="{ name: 'view-category', params: { categoryId: category.id } }"
+                            :to="{ name: 'view-category', params: { categorySlug: category.slug } }"
                             class="group p-3 flex items-start text-sm font-medium text-gray-700"
                         >
                             <h5>

--- a/portals/knowledge-management/src/Pages/ViewArticle.vue
+++ b/portals/knowledge-management/src/Pages/ViewArticle.vue
@@ -37,12 +37,7 @@
     import Breadcrumbs from '../Components/Breadcrumbs.vue';
     import AppLoading from '../Components/AppLoading.vue';
     import { consumer } from '../Services/Consumer.js';
-    import {
-        ClockIcon,
-        EyeIcon,
-        HandThumbUpIcon,
-        HandThumbDownIcon,
-    } from '@heroicons/vue/24/outline/index.js';
+    import { ClockIcon, EyeIcon, HandThumbUpIcon, HandThumbDownIcon } from '@heroicons/vue/24/outline/index.js';
     import DOMPurify from 'dompurify';
     import Tags from '../Components/Tags.vue';
     import { XMarkIcon } from '@heroicons/vue/20/solid/index.js';
@@ -87,12 +82,9 @@
 
     const currentCrumb = computed(() => {
         return article.value
-            ? truncate(
-                article.value.name,
-                {
-                    length: 16,
-                },
-            )
+            ? truncate(article.value.name, {
+                  length: 16,
+              })
             : 'Not Found';
     });
 
@@ -113,10 +105,13 @@
             .then((response) => {
                 if (response.data) {
                     if (response.data.category.slug !== route.params.categorySlug) {
-                        router.replace({ name: 'view-article', params: {
-                            categorySlug: response.data.category.slug,
-                            articleId: route.params.articleId,
-                        } });
+                        router.replace({
+                            name: 'view-article',
+                            params: {
+                                categorySlug: response.data.category.slug,
+                                articleId: route.params.articleId,
+                            },
+                        });
                     }
 
                     category.value = response.data.category;
@@ -129,13 +124,7 @@
                 loading.value = false;
             })
             .catch((error) => {
-                if (
-                    error.response
-                    && (
-                        error.response.status === 401
-                        || error.response.status === 404
-                    )
-                ) {
+                if (error.response && (error.response.status === 401 || error.response.status === 404)) {
                     loading.value = false;
                 } else {
                     console.log('An error occurred', error);
@@ -173,15 +162,9 @@
                 </div>
                 <div v-else>
                     <main class="flex flex-col gap-8">
-                        <Breadcrumbs
-                            :breadcrumbs="breadcrumbs"
-                            :currentCrumb="currentCrumb"
-                        ></Breadcrumbs>
+                        <Breadcrumbs :breadcrumbs="breadcrumbs" :currentCrumb="currentCrumb"></Breadcrumbs>
 
-                        <div
-                            class="grid space-y-2"
-                            v-if="category && article"
-                        >
+                        <div class="grid space-y-2" v-if="category && article">
                             <div class="flex flex-col gap-3">
                                 <div class="prose max-w-none" v-if="article">
                                     <h1 class="font-semibold">{{ article.name }}</h1>
@@ -255,9 +238,7 @@
                         <div v-else class="p-3 flex items-start gap-2">
                             <XMarkIcon class="h-5 w-5 text-gray-400" />
 
-                            <p class="text-gray-600 text-sm font-medium">
-                                No article found.
-                            </p>
+                            <p class="text-gray-600 text-sm font-medium">No article found.</p>
                         </div>
                     </main>
                 </div>

--- a/portals/knowledge-management/src/Pages/ViewArticle.vue
+++ b/portals/knowledge-management/src/Pages/ViewArticle.vue
@@ -33,7 +33,7 @@
 -->
 <script setup>
     import { defineProps, ref, watch, onMounted } from 'vue';
-    import { useRoute } from 'vue-router';
+    import { useRoute, useRouter } from 'vue-router';
     import Breadcrumbs from '../Components/Breadcrumbs.vue';
     import AppLoading from '../Components/AppLoading.vue';
     import { consumer } from '../Services/Consumer.js';
@@ -49,6 +49,7 @@
     import { useAuthStore } from '../Stores/auth.js';
 
     const route = useRoute();
+    const router = useRouter();
 
     const { get, post } = consumer();
 
@@ -71,7 +72,6 @@
     const category = ref(null);
     const article = ref(null);
     const portalViewCount = ref(0);
-    const portalViewCountFlag = ref(false);
     const feedback = ref(null);
     const helpfulVotePercentage = ref(0);
 
@@ -88,9 +88,16 @@
     function getData() {
         loading.value = true;
 
-        get(props.apiUrl + '/categories/' + route.params.categoryId + '/articles/' + route.params.articleId)
+        get(props.apiUrl + '/categories/' + route.params.categorySlug + '/articles/' + route.params.articleId)
             .then((response) => {
                 if (response.data) {
+                    if (response.data.category.slug !== route.params.categorySlug) {
+                        router.replace({ name: 'view-article', params: {
+                            categorySlug: response.data.category.slug,
+                            articleId: route.params.articleId,
+                        } });
+                    }
+
                     category.value = response.data.category;
                     article.value = response.data.article;
                     portalViewCount.value = response.data.portal_view_count;
@@ -141,7 +148,7 @@
                     <main class="flex flex-col gap-8">
                         <Breadcrumbs
                             :breadcrumbs="[
-                                { name: category.name, route: 'view-category', params: { categoryId: category.id } },
+                                { name: category.name, route: 'view-category', params: { categorySlug: category.slug } },
                             ]"
                             currentCrumb="Articles"
                             v-if="article"

--- a/portals/knowledge-management/src/Pages/ViewCategory.vue
+++ b/portals/knowledge-management/src/Pages/ViewCategory.vue
@@ -197,10 +197,10 @@
 
         const { get } = consumer();
 
-        await get(props.apiUrl + '/categories/' + route.params.categoryId, { page: page, filter: filter.value }).then(
+        await get(props.apiUrl + '/categories/' + route.params.categorySlug, { page: page, filter: filter.value }).then(
             (response) => {
-                if (response.data.category.slug !== route.params.categoryId) {
-                    router.replace({ name: 'view-category', params: { categoryId: response.data.category.slug } });
+                if (response.data.category.slug !== route.params.categorySlug) {
+                    router.replace({ name: 'view-category', params: { categorySlug: response.data.category.slug } });
                 }
 
                 category.value = response.data.category;

--- a/portals/knowledge-management/src/Pages/ViewCategory.vue
+++ b/portals/knowledge-management/src/Pages/ViewCategory.vue
@@ -34,7 +34,7 @@
 <script setup>
     import { MagnifyingGlassIcon } from '@heroicons/vue/24/outline';
     import { defineProps, ref, watch } from 'vue';
-    import { useRoute } from 'vue-router';
+    import { useRoute, useRouter } from 'vue-router';
     import Breadcrumbs from '../Components/Breadcrumbs.vue';
     import AppLoading from '../Components/AppLoading.vue';
     import { consumer } from '../Services/Consumer.js';
@@ -48,6 +48,7 @@
     import Pagination from '../Components/Pagination.vue';
 
     const route = useRoute();
+    const router = useRouter();
 
     const props = defineProps({
         searchUrl: {
@@ -200,6 +201,10 @@
 
         await get(props.apiUrl + '/categories/' + route.params.categoryId, { page: page, filter: filter.value }).then(
             (response) => {
+                if (response.data.category.slug !== route.params.categoryId) {
+                    router.replace({ name: 'view-category', params: { categoryId: response.data.category.slug } });
+                }
+
                 category.value = response.data.category;
                 articles.value = response.data.articles.data;
                 setPagination(response.data.articles);

--- a/portals/knowledge-management/src/Pages/ViewCategory.vue
+++ b/portals/knowledge-management/src/Pages/ViewCategory.vue
@@ -38,9 +38,7 @@
     import Breadcrumbs from '../Components/Breadcrumbs.vue';
     import AppLoading from '../Components/AppLoading.vue';
     import { consumer } from '../Services/Consumer.js';
-    import { Bars3Icon } from '@heroicons/vue/24/outline/index.js';
-    import { ChevronRightIcon, XMarkIcon, ChevronLeftIcon } from '@heroicons/vue/20/solid/index.js';
-    import Tags from '../Components/Tags.vue';
+    import { XMarkIcon } from '@heroicons/vue/20/solid/index.js';
     import Article from '../Components/Article.vue';
     import SearchResults from '../Components/SearchResults.vue';
     import Badge from '../Components/Badge.vue';

--- a/portals/knowledge-management/src/portal.js
+++ b/portals/knowledge-management/src/portal.js
@@ -66,12 +66,12 @@ customElements.define(
                         component: Home,
                     },
                     {
-                        path: baseUrl + '/categories/:categoryId',
+                        path: baseUrl + '/categories/:categorySlug',
                         name: 'view-category',
                         component: ViewCategory,
                     },
                     {
-                        path: baseUrl + '/categories/:categoryId/articles/:articleId',
+                        path: baseUrl + '/categories/:categorySlug/articles/:articleId',
                         name: 'view-article',
                         component: ViewArticle,
                     },


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-353

### Technical Description

Set up routing for Article categories based on slugs rather than ID, but it will still redirect to the correct slug URL if an ID URL is accessed for backward compatibility.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
