### PR TITLE
[AIDAPP-180]: Support backwards-compatibility by updating column/collection name change for KB article details for deployed tenants

### DIFF
--- a/app-modules/knowledge-base/database/migrations/2024_11_26_213119_data_update_media_records_knowledge_base_item_collection_name.php
+++ b/app-modules/knowledge-base/database/migrations/2024_11_26_213119_data_update_media_records_knowledge_base_item_collection_name.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::table('media')
+            ->where('model_type', 'knowledge_base_item')
+            ->where('collection_name', 'solution')
+            ->update(['collection_name' => 'article_details']);
+    }
+
+    public function down(): void
+    {
+        DB::table('media')
+            ->where('model_type', 'knowledge_base_item')
+            ->where('collection_name', 'article_details')
+            ->update(['collection_name' => 'solution']);
+    }
+};


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-180

### Technical Description

Adds a data migration to fix any media references to the old collection name for Knowledge Base Items.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

Data Migrations:
- `app-modules/knowledge-base/database/migrations/2024_11_26_213119_data_update_media_records_knowledge_base_item_collection_name.php`

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
