### PR TITLE
[OLYMPUS-196]: Ensure all requests between Olympus and the other application are done over HTTPS

### DIFF
--- a/app/Console/Commands/ConnectOlympus.php
+++ b/app/Console/Commands/ConnectOlympus.php
@@ -67,7 +67,11 @@ class ConnectOlympus extends Command
             $url = (string) str($url)->after('://');
         }
 
-        $response = Http::post("https://{$url}", [
+        $response = Http::withOptions(
+            app()->environment('local')
+                ? ['verify' => false]
+                : []
+        )->post("https://{$url}", [
             'url' => config('app.landlord_url'),
         ])->throw();
 

--- a/app/Console/Commands/ConnectOlympus.php
+++ b/app/Console/Commands/ConnectOlympus.php
@@ -61,7 +61,13 @@ class ConnectOlympus extends Command
      */
     public function handle(): int
     {
-        $response = Http::post($this->argument('url'), [
+        $url = $this->argument('url');
+
+        if (str($url)->contains('://')) {
+            $url = (string) str($url)->after('://');
+        }
+
+        $response = Http::post("https://{$url}", [
             'url' => config('app.landlord_url'),
         ])->throw();
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/OLYMPUS-196

### Technical Description

When connecting, the protocol is forced as HTTPS when sending app data back to Olympus.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
