### PR TITLE
[AIDAPP-359]: Change all Observers to be registered via ObservedBy rather than through registration in the Service Provider

### DIFF
--- a/app-modules/alert/src/Models/Alert.php
+++ b/app-modules/alert/src/Models/Alert.php
@@ -43,9 +43,11 @@ use AidingApp\Alert\Enums\AlertSeverity;
 use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Database\Eloquent\Builder;
 use App\Models\Scopes\LicensedToEducatable;
+use AidingApp\Alert\Observers\AlertObserver;
 use App\Models\Concerns\BelongsToEducatable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Notification\Models\Contracts\Subscribable;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
@@ -55,6 +57,7 @@ use AidingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
  *
  * @mixin IdeHelperAlert
  */
+#[ObservedBy([AlertObserver::class])]
 class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription
 {
     use SoftDeletes;

--- a/app-modules/alert/src/Providers/AlertServiceProvider.php
+++ b/app-modules/alert/src/Providers/AlertServiceProvider.php
@@ -45,7 +45,6 @@ use AidingApp\Alert\Enums\AlertStatus;
 use Illuminate\Support\ServiceProvider;
 use AidingApp\Alert\Enums\AlertSeverity;
 use AidingApp\Alert\Events\AlertCreated;
-use AidingApp\Alert\Observers\AlertObserver;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use AidingApp\Alert\Listeners\NotifySubscribersOfAlertCreated;
 
@@ -64,16 +63,9 @@ class AlertServiceProvider extends ServiceProvider
             'alert' => Alert::class,
         ]);
 
-        $this->registerObservers();
-
         $this->registerEvents();
 
         $this->registerGraphQL();
-    }
-
-    protected function registerObservers(): void
-    {
-        Alert::observe(AlertObserver::class);
     }
 
     protected function registerEvents(): void

--- a/app-modules/authorization/src/Models/License.php
+++ b/app-modules/authorization/src/Models/License.php
@@ -42,11 +42,14 @@ use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use AidingApp\Authorization\Enums\LicenseType;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use AidingApp\Authorization\Observers\LicenseObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableConcern;
 
 /**
  * @mixin IdeHelperLicense
  */
+#[ObservedBy([LicenseObserver::class])]
 class License extends BaseModel implements Auditable
 {
     use AuditableConcern;

--- a/app-modules/authorization/src/Providers/AuthorizationServiceProvider.php
+++ b/app-modules/authorization/src/Providers/AuthorizationServiceProvider.php
@@ -47,7 +47,6 @@ use SocialiteProviders\Azure\AzureExtendSocialite;
 use SocialiteProviders\Manager\SocialiteWasCalled;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use SocialiteProviders\Google\GoogleExtendSocialite;
-use AidingApp\Authorization\Observers\LicenseObserver;
 use AidingApp\Authorization\Http\Controllers\Auth\LogoutController;
 use Filament\Http\Controllers\Auth\LogoutController as FilamentLogoutController;
 
@@ -72,8 +71,6 @@ class AuthorizationServiceProvider extends ServiceProvider
             'license' => License::class,
         ]);
 
-        $this->registerObservers();
-
         Event::listen(
             events: SocialiteWasCalled::class,
             listener: AzureExtendSocialite::class . '@handle'
@@ -83,10 +80,5 @@ class AuthorizationServiceProvider extends ServiceProvider
             events: SocialiteWasCalled::class,
             listener: GoogleExtendSocialite::class . '@handle'
         );
-    }
-
-    public function registerObservers(): void
-    {
-        License::observe(LicenseObserver::class);
     }
 }

--- a/app-modules/contact/src/Models/Contact.php
+++ b/app-modules/contact/src/Models/Contact.php
@@ -51,6 +51,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use AidingApp\Authorization\Enums\LicenseType;
 use AidingApp\Engagement\Models\EngagementFile;
 use AidingApp\Notification\Models\Subscription;
+use AidingApp\Contact\Observers\ContactObserver;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -63,6 +64,7 @@ use AidingApp\ServiceManagement\Models\ServiceRequest;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use AidingApp\Engagement\Models\EngagementFileEntities;
 use AidingApp\InventoryManagement\Models\AssetCheckOut;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use AidingApp\Contact\Filament\Resources\ContactResource;
 use AidingApp\Notification\Models\Contracts\Subscribable;
@@ -81,6 +83,7 @@ use AidingApp\Engagement\Models\Concerns\HasManyMorphedEngagementResponses;
  *
  * @mixin IdeHelperContact
  */
+#[ObservedBy([ContactObserver::class])]
 class Contact extends BaseAuthenticatable implements Auditable, Subscribable, Educatable, HasFilamentResource, NotifiableInterface
 {
     use AuditableTrait;

--- a/app-modules/contact/src/Models/OrganizationIndustry.php
+++ b/app-modules/contact/src/Models/OrganizationIndustry.php
@@ -42,11 +42,14 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use AidingApp\Contact\Observers\OrganizationIndustryObserver;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 
 /**
  * @mixin IdeHelperOrganizationIndustry
  */
+#[ObservedBy([OrganizationIndustryObserver::class])]
 class OrganizationIndustry extends Model implements Auditable
 {
     use HasFactory;

--- a/app-modules/contact/src/Models/OrganizationType.php
+++ b/app-modules/contact/src/Models/OrganizationType.php
@@ -42,11 +42,14 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use AidingApp\Contact\Observers\OrganizationTypeObserver;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 
 /**
  * @mixin IdeHelperOrganizationType
  */
+#[ObservedBy([OrganizationTypeObserver::class])]
 class OrganizationType extends Model implements Auditable
 {
     use HasFactory;

--- a/app-modules/contact/src/Providers/ContactServiceProvider.php
+++ b/app-modules/contact/src/Providers/ContactServiceProvider.php
@@ -45,13 +45,10 @@ use AidingApp\Contact\Models\Organization;
 use AidingApp\Contact\Models\ContactSource;
 use AidingApp\Contact\Models\ContactStatus;
 use AidingApp\Contact\Models\OrganizationType;
-use AidingApp\Contact\Observers\ContactObserver;
 use AidingApp\Contact\Models\OrganizationIndustry;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use AidingApp\Contact\Enums\ContactStatusColorOptions;
 use AidingApp\Contact\Enums\SystemContactClassification;
-use AidingApp\Contact\Observers\OrganizationTypeObserver;
-use AidingApp\Contact\Observers\OrganizationIndustryObserver;
 
 class ContactServiceProvider extends ServiceProvider
 {
@@ -72,9 +69,6 @@ class ContactServiceProvider extends ServiceProvider
             'organization_industry' => OrganizationIndustry::class,
             'organization_type' => OrganizationType::class,
         ]);
-        Contact::observe(ContactObserver::class);
-        OrganizationType::observe(OrganizationTypeObserver::class);
-        OrganizationIndustry::observe(OrganizationIndustryObserver::class);
 
         $this->discoverSchema(__DIR__ . '/../../graphql/*');
         $this->registerEnum(ContactStatusColorOptions::class);

--- a/app-modules/division/src/Models/Division.php
+++ b/app-modules/division/src/Models/Division.php
@@ -42,14 +42,17 @@ use AidingApp\Team\Models\Team;
 use App\Models\NotificationSettingPivot;
 use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use AidingApp\Division\Observers\DivisionObserver;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 
 /**
  * @mixin IdeHelperDivision
  */
+#[ObservedBy([DivisionObserver::class])]
 class Division extends BaseModel implements Auditable
 {
     use AuditableTrait;

--- a/app-modules/division/src/Providers/DivisionServiceProvider.php
+++ b/app-modules/division/src/Providers/DivisionServiceProvider.php
@@ -41,7 +41,6 @@ use App\Concerns\ImplementsGraphQL;
 use AidingApp\Division\DivisionPlugin;
 use AidingApp\Division\Models\Division;
 use Illuminate\Support\ServiceProvider;
-use AidingApp\Division\Observers\DivisionObserver;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
 class DivisionServiceProvider extends ServiceProvider
@@ -59,12 +58,6 @@ class DivisionServiceProvider extends ServiceProvider
             'division' => Division::class,
         ]);
 
-        $this->registerObservers();
         $this->discoverSchema(__DIR__ . '/../../graphql/division.graphql');
-    }
-
-    protected function registerObservers(): void
-    {
-        Division::observe(DivisionObserver::class);
     }
 }

--- a/app-modules/engagement/src/Models/EmailTemplate.php
+++ b/app-modules/engagement/src/Models/EmailTemplate.php
@@ -42,10 +42,13 @@ use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use AidingApp\Engagement\Observers\EmailTemplateObserver;
 
 /**
  * @mixin IdeHelperEmailTemplate
  */
+#[ObservedBy([EmailTemplateObserver::class])]
 class EmailTemplate extends BaseModel implements HasMedia
 {
     use InteractsWithMedia;

--- a/app-modules/engagement/src/Models/Engagement.php
+++ b/app-modules/engagement/src/Models/Engagement.php
@@ -55,6 +55,8 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use AidingApp\Timeline\Timelines\EngagementTimeline;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use AidingApp\Engagement\Observers\EngagementObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Engagement\Enums\EngagementDeliveryStatus;
 use AidingApp\Notification\Models\Contracts\Subscribable;
 use AidingApp\Timeline\Models\Contracts\ProvidesATimeline;
@@ -67,6 +69,7 @@ use AidingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
  *
  * @mixin IdeHelperEngagement
  */
+#[ObservedBy([EngagementObserver::class])]
 class Engagement extends BaseModel implements Auditable, CanTriggerAutoSubscription, ProvidesATimeline, HasMedia
 {
     use AuditableTrait;

--- a/app-modules/engagement/src/Models/EngagementBatch.php
+++ b/app-modules/engagement/src/Models/EngagementBatch.php
@@ -41,11 +41,14 @@ use App\Models\BaseModel;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use AidingApp\Engagement\Observers\EngagementBatchObserver;
 use AidingApp\Engagement\Models\Concerns\HasManyEngagements;
 
 /**
  * @mixin IdeHelperEngagementBatch
  */
+#[ObservedBy([EngagementBatchObserver::class])]
 class EngagementBatch extends BaseModel implements HasMedia
 {
     use HasManyEngagements;

--- a/app-modules/engagement/src/Models/EngagementFileEntities.php
+++ b/app-modules/engagement/src/Models/EngagementFileEntities.php
@@ -39,12 +39,15 @@ namespace AidingApp\Engagement\Models;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphPivot;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Notification\Models\Contracts\Subscribable;
+use AidingApp\Engagement\Observers\EngagementFileEntitiesObserver;
 use AidingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
 
 /**
  * @mixin IdeHelperEngagementFileEntities
  */
+#[ObservedBy([EngagementFileEntitiesObserver::class])]
 class EngagementFileEntities extends MorphPivot implements CanTriggerAutoSubscription
 {
     protected $table = 'engagement_file_entities';

--- a/app-modules/engagement/src/Models/SmsTemplate.php
+++ b/app-modules/engagement/src/Models/SmsTemplate.php
@@ -40,10 +40,13 @@ use App\Models\User;
 use App\Models\BaseModel;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use AidingApp\Engagement\Observers\SmsTemplateObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 
 /**
  * @mixin IdeHelperSmsTemplate
  */
+#[ObservedBy([SmsTemplateObserver::class])]
 class SmsTemplate extends BaseModel
 {
     use SoftDeletes;

--- a/app-modules/engagement/src/Providers/EngagementServiceProvider.php
+++ b/app-modules/engagement/src/Providers/EngagementServiceProvider.php
@@ -51,12 +51,6 @@ use AidingApp\Engagement\Models\EngagementResponse;
 use AidingApp\Engagement\Actions\DeliverEngagements;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use AidingApp\Engagement\Models\EngagementDeliverable;
-use AidingApp\Engagement\Observers\EngagementObserver;
-use AidingApp\Engagement\Models\EngagementFileEntities;
-use AidingApp\Engagement\Observers\SmsTemplateObserver;
-use AidingApp\Engagement\Observers\EmailTemplateObserver;
-use AidingApp\Engagement\Observers\EngagementBatchObserver;
-use AidingApp\Engagement\Observers\EngagementFileEntitiesObserver;
 
 class EngagementServiceProvider extends ServiceProvider
 {
@@ -93,16 +87,5 @@ class EngagementServiceProvider extends ServiceProvider
                 ->onOneServer()
                 ->withoutOverlapping();
         });
-
-        $this->registerObservers();
-    }
-
-    public function registerObservers(): void
-    {
-        EmailTemplate::observe(EmailTemplateObserver::class);
-        Engagement::observe(EngagementObserver::class);
-        EngagementBatch::observe(EngagementBatchObserver::class);
-        EngagementFileEntities::observe(EngagementFileEntitiesObserver::class);
-        SmsTemplate::observe(SmsTemplateObserver::class);
     }
 }

--- a/app-modules/inventory-management/src/Models/AssetCheckIn.php
+++ b/app-modules/inventory-management/src/Models/AssetCheckIn.php
@@ -47,12 +47,15 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use AidingApp\Timeline\Timelines\AssetCheckInTimeline;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Timeline\Models\Contracts\ProvidesATimeline;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
+use AidingApp\InventoryManagement\Observers\AssetCheckInObserver;
 
 /**
  * @mixin IdeHelperAssetCheckIn
  */
+#[ObservedBy([AssetCheckInObserver::class])]
 class AssetCheckIn extends BaseModel implements Auditable, ProvidesATimeline
 {
     use AuditableTrait;

--- a/app-modules/inventory-management/src/Models/AssetCheckOut.php
+++ b/app-modules/inventory-management/src/Models/AssetCheckOut.php
@@ -48,13 +48,16 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use AidingApp\Timeline\Timelines\AssetCheckOutTimeline;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Timeline\Models\Contracts\ProvidesATimeline;
 use AidingApp\InventoryManagement\Enums\AssetCheckOutStatus;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
+use AidingApp\InventoryManagement\Observers\AssetCheckOutObserver;
 
 /**
  * @mixin IdeHelperAssetCheckOut
  */
+#[ObservedBy([AssetCheckOutObserver::class])]
 class AssetCheckOut extends BaseModel implements Auditable, ProvidesATimeline
 {
     use AuditableTrait;

--- a/app-modules/inventory-management/src/Models/MaintenanceActivity.php
+++ b/app-modules/inventory-management/src/Models/MaintenanceActivity.php
@@ -44,14 +44,17 @@ use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Timeline\Models\Contracts\ProvidesATimeline;
 use AidingApp\Timeline\Timelines\MaintenanceActivityTimeline;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\InventoryManagement\Enums\MaintenanceActivityStatus;
+use AidingApp\InventoryManagement\Observers\MaintenanceActivityObserver;
 
 /**
  * @mixin IdeHelperMaintenanceActivity
  */
+#[ObservedBy([MaintenanceActivityObserver::class])]
 class MaintenanceActivity extends BaseModel implements Auditable, ProvidesATimeline
 {
     use AuditableTrait;

--- a/app-modules/inventory-management/src/Providers/InventoryManagementServiceProvider.php
+++ b/app-modules/inventory-management/src/Providers/InventoryManagementServiceProvider.php
@@ -48,9 +48,6 @@ use AidingApp\InventoryManagement\Models\AssetLocation;
 use AidingApp\InventoryManagement\InventoryManagementPlugin;
 use AidingApp\InventoryManagement\Models\MaintenanceActivity;
 use AidingApp\InventoryManagement\Models\MaintenanceProvider;
-use AidingApp\InventoryManagement\Observers\AssetCheckInObserver;
-use AidingApp\InventoryManagement\Observers\AssetCheckOutObserver;
-use AidingApp\InventoryManagement\Observers\MaintenanceActivityObserver;
 
 class InventoryManagementServiceProvider extends ServiceProvider
 {
@@ -71,14 +68,5 @@ class InventoryManagementServiceProvider extends ServiceProvider
             'maintenance_activity' => MaintenanceActivity::class,
             'maintenance_provider' => MaintenanceProvider::class,
         ]);
-
-        $this->registerObservers();
-    }
-
-    public function registerObservers(): void
-    {
-        AssetCheckIn::observe(AssetCheckInObserver::class);
-        AssetCheckOut::observe(AssetCheckOutObserver::class);
-        MaintenanceActivity::observe(MaintenanceActivityObserver::class);
     }
 }

--- a/app-modules/notification/src/Models/OutboundDeliverable.php
+++ b/app-modules/notification/src/Models/OutboundDeliverable.php
@@ -46,14 +46,17 @@ use AidingApp\Notification\Drivers\EmailDriver;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use AidingApp\Notification\Enums\NotificationChannel;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Timeline\Models\Contracts\ProvidesATimeline;
 use AidingApp\Notification\Enums\NotificationDeliveryStatus;
 use AidingApp\Timeline\Timelines\OutboundDeliverableTimeline;
+use AidingApp\Notification\Observers\OutboundDeliverableObserver;
 use AidingApp\Notification\Drivers\Contracts\OutboundDeliverableDriver;
 
 /**
  * @mixin IdeHelperOutboundDeliverable
  */
+#[ObservedBy([OutboundDeliverableObserver::class])]
 class OutboundDeliverable extends BaseModel implements ProvidesATimeline
 {
     use SoftDeletes;

--- a/app-modules/notification/src/Models/Subscription.php
+++ b/app-modules/notification/src/Models/Subscription.php
@@ -46,10 +46,13 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\MorphPivot;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use AidingApp\Notification\Observers\SubscriptionObserver;
 
 /**
  * @mixin IdeHelperSubscription
  */
+#[ObservedBy([SubscriptionObserver::class])]
 class Subscription extends MorphPivot
 {
     use BelongsToEducatable;

--- a/app-modules/notification/src/Providers/NotificationServiceProvider.php
+++ b/app-modules/notification/src/Providers/NotificationServiceProvider.php
@@ -46,12 +46,10 @@ use AidingApp\Notification\Events\SubscriptionCreated;
 use AidingApp\Notification\Events\SubscriptionDeleted;
 use AidingApp\Notification\Models\OutboundDeliverable;
 use Illuminate\Notifications\Events\NotificationFailed;
-use AidingApp\Notification\Observers\SubscriptionObserver;
 use AidingApp\Notification\Events\TriggeredAutoSubscription;
 use AidingApp\Notification\Listeners\CreateAutoSubscription;
 use AidingApp\Notification\Listeners\HandleNotificationSent;
 use AidingApp\Notification\Listeners\HandleNotificationFailed;
-use AidingApp\Notification\Observers\OutboundDeliverableObserver;
 use AidingApp\Notification\Listeners\NotifyUserOfSubscriptionCreated;
 use AidingApp\Notification\Listeners\NotifyUserOfSubscriptionDeleted;
 
@@ -68,16 +66,9 @@ class NotificationServiceProvider extends ServiceProvider
             'outbound_deliverable' => OutboundDeliverable::class,
         ]);
 
-        $this->registerObservers();
         $this->registerEvents();
 
         $this->discoverSchema(__DIR__ . '/../../graphql/subscription.graphql');
-    }
-
-    protected function registerObservers(): void
-    {
-        Subscription::observe(SubscriptionObserver::class);
-        OutboundDeliverable::observe(OutboundDeliverableObserver::class);
     }
 
     protected function registerEvents(): void

--- a/app-modules/service-management/src/Models/ChangeRequest.php
+++ b/app-modules/service-management/src/Models/ChangeRequest.php
@@ -42,12 +42,15 @@ use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Models\Concerns\HasRelationBasedStateMachine;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
+use AidingApp\ServiceManagement\Observers\ChangeRequestObserver;
 use AidingApp\ServiceManagement\Enums\SystemChangeRequestClassification;
 
 /**
  * @mixin IdeHelperChangeRequest
  */
+#[ObservedBy([ChangeRequestObserver::class])]
 class ChangeRequest extends BaseModel implements Auditable
 {
     use AuditableTrait;

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -59,10 +59,12 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 use AidingApp\Notification\Models\OutboundDeliverable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Notification\Models\Contracts\Subscribable;
 use AidingApp\ServiceManagement\Enums\SlaComplianceStatus;
 use Illuminate\Database\UniqueConstraintViolationException;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
+use AidingApp\ServiceManagement\Observers\ServiceRequestObserver;
 use AidingApp\ServiceManagement\Enums\ServiceRequestUpdateDirection;
 use AidingApp\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
 use AidingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
@@ -76,6 +78,7 @@ use AidingApp\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceR
  *
  * @mixin IdeHelperServiceRequest
  */
+#[ObservedBy([ServiceRequestObserver::class])]
 class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubscription, HasMedia
 {
     use BelongsToEducatable;

--- a/app-modules/service-management/src/Models/ServiceRequestAssignment.php
+++ b/app-modules/service-management/src/Models/ServiceRequestAssignment.php
@@ -43,16 +43,19 @@ use Illuminate\Database\Eloquent\Model;
 use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Notification\Models\Contracts\Subscribable;
 use AidingApp\Timeline\Models\Contracts\ProvidesATimeline;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\Timeline\Timelines\ServiceRequestAssignmentTimeline;
 use AidingApp\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
 use AidingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
+use AidingApp\ServiceManagement\Observers\ServiceRequestAssignmentObserver;
 
 /**
  * @mixin IdeHelperServiceRequestAssignment
  */
+#[ObservedBy([ServiceRequestAssignmentObserver::class])]
 class ServiceRequestAssignment extends BaseModel implements Auditable, CanTriggerAutoSubscription, ProvidesATimeline
 {
     use AuditableTrait;

--- a/app-modules/service-management/src/Models/ServiceRequestHistory.php
+++ b/app-modules/service-management/src/Models/ServiceRequestHistory.php
@@ -46,12 +46,15 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Timeline\Models\Contracts\ProvidesATimeline;
 use AidingApp\Timeline\Timelines\ServiceRequestHistoryTimeline;
+use AidingApp\ServiceManagement\Observers\ServiceRequestHistoryObserver;
 
 /**
  * @mixin IdeHelperServiceRequestHistory
  */
+#[ObservedBy([ServiceRequestHistoryObserver::class])]
 class ServiceRequestHistory extends BaseModel implements ProvidesATimeline
 {
     use SoftDeletes;

--- a/app-modules/service-management/src/Models/ServiceRequestType.php
+++ b/app-modules/service-management/src/Models/ServiceRequestType.php
@@ -47,13 +47,16 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
+use AidingApp\ServiceManagement\Observers\ServiceRequestTypeObserver;
 use AidingApp\ServiceManagement\Enums\ServiceRequestTypeAssignmentTypes;
 
 /**
  * @mixin IdeHelperServiceRequestType
  */
+#[ObservedBy([ServiceRequestTypeObserver::class])]
 class ServiceRequestType extends BaseModel implements Auditable
 {
     use SoftDeletes;

--- a/app-modules/service-management/src/Models/ServiceRequestUpdate.php
+++ b/app-modules/service-management/src/Models/ServiceRequestUpdate.php
@@ -44,16 +44,19 @@ use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Notification\Models\Contracts\Subscribable;
 use AidingApp\Timeline\Models\Contracts\ProvidesATimeline;
 use AidingApp\Timeline\Timelines\ServiceRequestUpdateTimeline;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\ServiceManagement\Enums\ServiceRequestUpdateDirection;
 use AidingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
+use AidingApp\ServiceManagement\Observers\ServiceRequestUpdateObserver;
 
 /**
  * @mixin IdeHelperServiceRequestUpdate
  */
+#[ObservedBy([ServiceRequestUpdateObserver::class])]
 class ServiceRequestUpdate extends BaseModel implements Auditable, CanTriggerAutoSubscription, ProvidesATimeline
 {
     use SoftDeletes;

--- a/app-modules/service-management/src/Providers/ServiceManagementServiceProvider.php
+++ b/app-modules/service-management/src/Providers/ServiceManagementServiceProvider.php
@@ -56,14 +56,8 @@ use AidingApp\ServiceManagement\Models\ServiceRequestFormStep;
 use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
 use AidingApp\ServiceManagement\Models\ServiceRequestFormField;
 use AidingApp\ServiceManagement\Models\ServiceRequestAssignment;
-use AidingApp\ServiceManagement\Observers\ChangeRequestObserver;
-use AidingApp\ServiceManagement\Observers\ServiceRequestObserver;
 use AidingApp\ServiceManagement\Models\ServiceRequestFormSubmission;
-use AidingApp\ServiceManagement\Observers\ServiceRequestTypeObserver;
-use AidingApp\ServiceManagement\Observers\ServiceRequestUpdateObserver;
 use AidingApp\ServiceManagement\Models\ServiceRequestFormAuthentication;
-use AidingApp\ServiceManagement\Observers\ServiceRequestHistoryObserver;
-use AidingApp\ServiceManagement\Observers\ServiceRequestAssignmentObserver;
 use AidingApp\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceRequestNumberGenerator;
 use AidingApp\ServiceManagement\Services\ServiceRequestNumber\SqidPlusSixServiceRequestNumberGenerator;
 
@@ -100,18 +94,6 @@ class ServiceManagementServiceProvider extends ServiceProvider
             'sla' => Sla::class,
         ]);
 
-        $this->registerObservers();
-
         $this->discoverSchema(__DIR__ . '/../../graphql/service-management.graphql');
-    }
-
-    protected function registerObservers(): void
-    {
-        ChangeRequest::observe(ChangeRequestObserver::class);
-        ServiceRequest::observe(ServiceRequestObserver::class);
-        ServiceRequestAssignment::observe(ServiceRequestAssignmentObserver::class);
-        ServiceRequestHistory::observe(ServiceRequestHistoryObserver::class);
-        ServiceRequestUpdate::observe(ServiceRequestUpdateObserver::class);
-        ServiceRequestType::observe(ServiceRequestTypeObserver::class);
     }
 }

--- a/app-modules/task/src/Models/Task.php
+++ b/app-modules/task/src/Models/Task.php
@@ -43,12 +43,14 @@ use App\Models\Contracts\Educatable;
 use AidingApp\Contact\Models\Contact;
 use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Database\Eloquent\Builder;
+use AidingApp\Task\Observers\TaskObserver;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Bvtterfly\ModelStateMachine\HasStateMachine;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use AidingApp\Notification\Models\Contracts\Subscribable;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
@@ -58,6 +60,7 @@ use AidingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
  *
  * @mixin IdeHelperTask
  */
+#[ObservedBy([TaskObserver::class])]
 class Task extends BaseModel implements Auditable, CanTriggerAutoSubscription
 {
     use HasFactory;

--- a/app-modules/task/src/Providers/TaskServiceProvider.php
+++ b/app-modules/task/src/Providers/TaskServiceProvider.php
@@ -41,7 +41,6 @@ use AidingApp\Task\TaskPlugin;
 use AidingApp\Task\Models\Task;
 use Filament\Support\Assets\Js;
 use Illuminate\Support\ServiceProvider;
-use AidingApp\Task\Observers\TaskObserver;
 use Filament\Support\Facades\FilamentAsset;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
@@ -60,14 +59,7 @@ class TaskServiceProvider extends ServiceProvider
             ]
         );
 
-        $this->registerObservers();
-
         $this->registerAssets();
-    }
-
-    protected function registerObservers(): void
-    {
-        Task::observe(TaskObserver::class);
     }
 
     protected function registerAssets(): void

--- a/app-modules/team/src/Models/TeamUser.php
+++ b/app-modules/team/src/Models/TeamUser.php
@@ -37,13 +37,16 @@
 namespace AidingApp\Team\Models;
 
 use App\Models\User;
+use AidingApp\Team\Observers\TeamUserObserver;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 
 /**
  * @mixin IdeHelperTeamUser
  */
+#[ObservedBy([TeamUserObserver::class])]
 class TeamUser extends Pivot
 {
     use HasUuids;

--- a/app-modules/team/src/Providers/TeamServiceProvider.php
+++ b/app-modules/team/src/Providers/TeamServiceProvider.php
@@ -39,9 +39,7 @@ namespace AidingApp\Team\Providers;
 use Filament\Panel;
 use AidingApp\Team\TeamPlugin;
 use AidingApp\Team\Models\Team;
-use AidingApp\Team\Models\TeamUser;
 use Illuminate\Support\ServiceProvider;
-use AidingApp\Team\Observers\TeamUserObserver;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
 class TeamServiceProvider extends ServiceProvider
@@ -56,12 +54,5 @@ class TeamServiceProvider extends ServiceProvider
         Relation::morphMap([
             'team' => Team::class,
         ]);
-
-        $this->registerObservers();
-    }
-
-    protected function registerObservers(): void
-    {
-        TeamUser::observe(TeamUserObserver::class);
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-359

### Technical Description

> Change all Observers to be registered via ObservedBy rather than through registration in the Service Provider.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
