### PR TITLE
[AIDAPP-421]: By default, exclude closed service requests via a removable filter from dashboard and service request list views

### DIFF
--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
@@ -129,6 +129,14 @@ class ListServiceRequests extends ListRecords
                     ->toggleable(),
             ])
             ->filters([
+                Filter::make('classification')
+                    ->default()
+                    ->label('All (Except Closed)')
+                    ->query(
+                        fn (Builder $query) => $query->whereHas('status',fn($q) =>
+                            $q->where('classification','!=',SystemServiceRequestClassification::Closed)
+                        )
+                    ),
                 SelectFilter::make('priority')
                     ->relationship('priority', 'name', fn (Builder $query) => $query->with('type')->whereRelation('type', 'deleted_at'))
                     ->getOptionLabelFromRecordUsing(fn (ServiceRequestPriority $record) => "{$record->type->name} - {$record->name}")

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
@@ -45,6 +45,7 @@ use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource\Actions\ChangeServiceRequestStatusBulkAction;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use App\Filament\Tables\Columns\IdColumn;
 use App\Models\Authenticatable;
 use App\Models\Scopes\EducatableSearch;
@@ -129,14 +130,6 @@ class ListServiceRequests extends ListRecords
                     ->toggleable(),
             ])
             ->filters([
-                Filter::make('classification')
-                    ->default()
-                    ->label('All (Except Closed)')
-                    ->query(
-                        fn (Builder $query) => $query->whereHas('status',fn($q) =>
-                            $q->where('classification','!=',SystemServiceRequestClassification::Closed)
-                        )
-                    ),
                 SelectFilter::make('priority')
                     ->relationship('priority', 'name', fn (Builder $query) => $query->with('type')->whereRelation('type', 'deleted_at'))
                     ->getOptionLabelFromRecordUsing(fn (ServiceRequestPriority $record) => "{$record->type->name} - {$record->name}")
@@ -144,6 +137,15 @@ class ListServiceRequests extends ListRecords
                     ->preload(),
                 SelectFilter::make('status')
                     ->relationship('status', 'name')
+                    ->default(fn () => ServiceRequestStatus::query()
+                                        ->where(
+                                            'classification',
+                                            '!=',
+                                            SystemServiceRequestClassification::Closed
+                                        )
+                                        ->pluck('id')
+                                        ->toArray()
+                    )
                     ->multiple()
                     ->preload(),
                 SelectFilter::make('organization')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
@@ -137,14 +137,15 @@ class ListServiceRequests extends ListRecords
                     ->preload(),
                 SelectFilter::make('status')
                     ->relationship('status', 'name')
-                    ->default(fn () => ServiceRequestStatus::query()
-                                        ->where(
-                                            'classification',
-                                            '!=',
-                                            SystemServiceRequestClassification::Closed
-                                        )
-                                        ->pluck('id')
-                                        ->toArray()
+                    ->default(
+                        fn () => ServiceRequestStatus::query()
+                            ->where(
+                                'classification',
+                                '!=',
+                                SystemServiceRequestClassification::Closed
+                            )
+                            ->pluck('id')
+                            ->toArray()
                     )
                     ->multiple()
                     ->preload(),

--- a/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
@@ -39,11 +39,13 @@ use AidingApp\Contact\Filament\Resources\ContactResource\Pages\ContactServiceMan
 use AidingApp\Contact\Filament\Resources\ContactResource\RelationManagers\ServiceRequestsRelationManager;
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Contact\Models\Organization;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages\ListServiceRequests;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestAssignment;
 use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use AidingApp\Team\Models\Team;
 use App\Models\User;
@@ -317,3 +319,30 @@ it('filters unassigned service requests', function () {
         ->assertCanSeeTableRecords([$unassignedRequest])
         ->assertCanNotSeeTableRecords([$assignedRequest]);
 });
+
+it('default non closed service request will not display',function(){
+    $nonClosedServiceRequests = ServiceRequest::factory()
+                                    ->for(
+                                        ServiceRequestStatus::factory()
+                                        ->state(['classification' => SystemServiceRequestClassification::Open]),'status'
+                                    )
+                                    ->count(3)
+                                    ->create();
+
+
+    $closedServiceRequests = ServiceRequest::factory()
+                                ->for(
+                                    ServiceRequestStatus::factory()
+                                    ->state(['classification' => SystemServiceRequestClassification::Closed]),'status'
+                                )
+                                ->count(3)
+                                ->create();
+
+    asSuperAdmin();
+
+    livewire(ListServiceRequests::class)
+        ->assertCanSeeTableRecords($nonClosedServiceRequests)
+        ->assertCanNotSeeTableRecords($closedServiceRequests)
+        ->removeTableFilter('classification')
+        ->assertCanSeeTableRecords($nonClosedServiceRequests->merge($closedServiceRequests));
+})->only();

--- a/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
@@ -346,4 +346,4 @@ it('default non closed service request will not display', function () {
         ->assertCanNotSeeTableRecords($closedServiceRequests)
         ->removeTableFilter('status')
         ->assertCanSeeTableRecords($nonClosedServiceRequests->merge($closedServiceRequests));
-})->only();
+});

--- a/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
@@ -320,23 +320,24 @@ it('filters unassigned service requests', function () {
         ->assertCanNotSeeTableRecords([$assignedRequest]);
 });
 
-it('default non closed service request will not display',function(){
+it('default non closed service request will not display', function () {
     $nonClosedServiceRequests = ServiceRequest::factory()
-                                    ->for(
-                                        ServiceRequestStatus::factory()
-                                        ->state(['classification' => SystemServiceRequestClassification::Open]),'status'
-                                    )
-                                    ->count(3)
-                                    ->create();
-
+        ->for(
+            ServiceRequestStatus::factory()
+                ->state(['classification' => SystemServiceRequestClassification::Open]),
+            'status'
+        )
+        ->count(3)
+        ->create();
 
     $closedServiceRequests = ServiceRequest::factory()
-                                ->for(
-                                    ServiceRequestStatus::factory()
-                                    ->state(['classification' => SystemServiceRequestClassification::Closed]),'status'
-                                )
-                                ->count(3)
-                                ->create();
+        ->for(
+            ServiceRequestStatus::factory()
+                ->state(['classification' => SystemServiceRequestClassification::Closed]),
+            'status'
+        )
+        ->count(3)
+        ->create();
 
     asSuperAdmin();
 

--- a/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
@@ -343,6 +343,6 @@ it('default non closed service request will not display',function(){
     livewire(ListServiceRequests::class)
         ->assertCanSeeTableRecords($nonClosedServiceRequests)
         ->assertCanNotSeeTableRecords($closedServiceRequests)
-        ->removeTableFilter('classification')
+        ->removeTableFilter('status')
         ->assertCanSeeTableRecords($nonClosedServiceRequests->merge($closedServiceRequests));
 })->only();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-421

### Technical Description

> By default, exclude closed service requests via a removable filter from dashboard and service request list views

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
