### PR TITLE
[AIDAPP-446]: Tickets are failing to automatically assign the designated user on new ticket creation

### DIFF
--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/CreateServiceRequestController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/CreateServiceRequestController.php
@@ -127,6 +127,12 @@ class CreateServiceRequestController extends Controller
 
             $serviceRequest->save();
 
+            $assignmentClass = $serviceRequest->priority->type?->assignment_type?->getAssignerClass();
+
+            if ($assignmentClass) {
+                $assignmentClass->execute($serviceRequest);
+            }
+
             $files = collect($data->pull('Main.upload-file', []));
 
             Bus::batch([


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-446

### Technical Description

> Tickets are failing to automatically assign the designated user when creating new service request from portal side.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
