### PR TITLE
[AIDAPP-447]: Add an optional Change Status option to happen simultaneously when creating a service request update

### DIFF
--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
@@ -121,7 +121,7 @@ class ServiceRequestUpdatesRelationManager extends RelationManager
                 CreateAction::make()
                     ->visible($this->getOwnerRecord()?->status?->classification == SystemServiceRequestClassification::Closed ? false : true)
                     ->after(function ($data, ServiceRequestUpdate $serviceRequestUpdate) {
-                        $serviceRequestUpdate->serviceRequest->update(['status_id'=>$data['status_id']]);
+                        $serviceRequestUpdate->serviceRequest->update(['status_id' => $data['status_id']]);
                     }),
             ])
             ->actions([


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-447

### Technical Description

Add an optional Change Status option to happen simultaneously when creating a service request update

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
