### PR TITLE
[AIDAPP-468]: Update state management to allow tasks to go from Cancelled back to In Progress

### DIFF
--- a/app-modules/task/src/Enums/TaskStatus.php
+++ b/app-modules/task/src/Enums/TaskStatus.php
@@ -54,6 +54,7 @@ enum TaskStatus: string implements HasColor, HasLabel
 
     case Completed = 'completed';
 
+    #[AllowTransitionTo(self::InProgress)]
     case Canceled = 'canceled';
 
     public function getColor(): string

--- a/app-modules/task/tests/ListTasksTest.php
+++ b/app-modules/task/tests/ListTasksTest.php
@@ -119,3 +119,104 @@ test('ListTasks is gated with proper access control', function () {
 
 // TODO: Test that mark_as_in_progress is visible to the proper users
 //test('mark_as_in_progress is only visible to those with the proper access', function () {});
+
+test('Task status change from pending to in progress', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    $user->givePermissionTo('task.*.update');
+    $user->givePermissionTo('task.view-any');
+    $user->givePermissionTo('task.*.view');
+
+    actingAs($user);
+
+    $task = Task::factory()->create([
+        'status' => TaskStatus::Pending,
+    ]);
+
+    livewire(ListTasks::class)
+        ->callTableAction('view.mark_as_in_progress', $task);
+
+    $task->refresh();
+    expect($task->status)->toEqual(TaskStatus::InProgress);
+});
+
+test('Task status change from pending to canceled', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    $user->givePermissionTo('task.*.update');
+    $user->givePermissionTo('task.view-any');
+    $user->givePermissionTo('task.*.view');
+
+    actingAs($user);
+
+    $task = Task::factory()->create([
+        'status' => TaskStatus::Pending,
+    ]);
+
+    livewire(ListTasks::class)
+        ->callTableAction('view.mark_as_canceled', $task);
+
+    $task->refresh();
+    expect($task->status)->toEqual(TaskStatus::Canceled);
+});
+
+test('Task status change from in progress to completed', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    $user->givePermissionTo('task.*.update');
+    $user->givePermissionTo('task.view-any');
+    $user->givePermissionTo('task.*.view');
+
+    actingAs($user);
+
+    $task = Task::factory()->create([
+        'status' => TaskStatus::InProgress,
+    ]);
+
+    livewire(ListTasks::class)
+        ->callTableAction('view.mark_as_completed', $task);
+
+    $task->refresh();
+    expect($task->status)->toEqual(TaskStatus::Completed);
+});
+
+test('Task status change from in progress to canceled', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    $user->givePermissionTo('task.*.update');
+    $user->givePermissionTo('task.view-any');
+    $user->givePermissionTo('task.*.view');
+
+    actingAs($user);
+
+    $task = Task::factory()->create([
+        'status' => TaskStatus::InProgress,
+    ]);
+
+    livewire(ListTasks::class)
+        ->callTableAction('view.mark_as_canceled', $task);
+
+    $task->refresh();
+    expect($task->status)->toEqual(TaskStatus::Canceled);
+});
+
+test('Task status change from canceled to in progress', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    $user->givePermissionTo('task.*.update');
+    $user->givePermissionTo('task.view-any');
+    $user->givePermissionTo('task.*.view');
+
+    actingAs($user);
+
+    $task = Task::factory()->create([
+        'status' => TaskStatus::Canceled,
+    ]);
+
+    livewire(ListTasks::class)
+        ->removeTableFilters()
+        ->callTableAction('view.mark_as_in_progress', $task);
+
+    $task->refresh();
+    expect($task->status)->toEqual(TaskStatus::InProgress);
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-468

### Technical Description

> Add task status transition tests and allow transition from canceled to in progress.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
