### PR TITLE
[AIDAPP-466]: Indicate contact's name when that task is related to a contact in the resulting notification.

### DIFF
--- a/app-modules/task/src/Notifications/TaskAssignedToUserNotification.php
+++ b/app-modules/task/src/Notifications/TaskAssignedToUserNotification.php
@@ -36,6 +36,8 @@
 
 namespace AidingApp\Task\Notifications;
 
+use AidingApp\Contact\Filament\Resources\ContactResource;
+use AidingApp\Contact\Filament\Resources\OrganizationResource;
 use AidingApp\Notification\Notifications\BaseNotification;
 use AidingApp\Notification\Notifications\Concerns\DatabaseChannelTrait;
 use AidingApp\Notification\Notifications\Concerns\EmailChannelTrait;
@@ -48,7 +50,6 @@ use App\Models\NotificationSetting;
 use App\Models\User;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\HtmlString;
 
 class TaskAssignedToUserNotification extends BaseNotification implements DatabaseNotification, EmailNotification
 {
@@ -77,11 +78,17 @@ class TaskAssignedToUserNotification extends BaseNotification implements Databas
 
         $title = str($this->task->title)->limit();
 
-        $link = new HtmlString("<a href='{$url}' target='_blank' class='underline'>{$title}</a>");
+        $message = match (true) {
+            is_null($this->task->concern->organization) => "You have been assigned a new Task: <a href='{$url}' target='_blank' class='underline'>{$title}</a> related to Contact <a href='" . ContactResource::getUrl('view', ['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern?->full_name}</a>",
+
+            ! is_null($this->task->concern->organization) => "You have been assigned a new Task: <a href='{$url}' target='_blank' class='underline'>{$title}</a> related to Contact <a href='" . ContactResource::getUrl('view', ['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern?->full_name}</a><a href='" . OrganizationResource::getUrl('view', ['record' => $this->task->concern->organization]) . "' target='_blank' class='underline'>({$this->task->concern->organization?->name})</a>",
+
+            default => "You have been assigned a new Task: <a href='{$url}' target='_blank' class='underline'>{$title}</a>",
+        };
 
         return FilamentNotification::make()
             ->success()
-            ->title("You have been assigned a new Task: {$link}")
+            ->title($message)
             ->getDatabaseMessage();
     }
 


### PR DESCRIPTION

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-466

### Technical Description

> Indicate contact's name when that task is related to a contact in the resulting notification.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
