### PR TITLE
[AIDAPP-482]: Fix flaky test CreateServiceRequestTest

### DIFF
--- a/app-modules/service-management/tests/ServiceRequestStatus/CreateServiceRequestStatusTest.php
+++ b/app-modules/service-management/tests/ServiceRequestStatus/CreateServiceRequestStatusTest.php
@@ -72,6 +72,8 @@ test('A successful action on the CreateServiceRequestStatus page', function () {
 test('CreateServiceRequestStatus requires valid data', function ($data, $errors) {
     asSuperAdmin();
 
+    ServiceRequestStatus::query()->truncate();
+
     livewire(CreateServiceRequestStatus::class)
         ->fillForm(CreateServiceRequestStatusRequestFactory::new($data)->create())
         ->call('create')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-482

### Technical Description

The system creates an open / info record so that needs to be purged before running the test or we will get flaky issues during the random time it tries to create a record similar to that.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
