### PR TITLE
[AIDAPP-485]: Change the vite config to name the stylesheets style.css

### DIFF
--- a/portals/knowledge-management/src/App.vue
+++ b/portals/knowledge-management/src/App.vue
@@ -415,10 +415,7 @@
         }"
     >
         <div>
-            <link
-                rel="stylesheet"
-                v-bind:href="hostUrl + '/js/portals/knowledge-management/aiding-app-knowledge-management-portal.css'"
-            />
+            <link rel="stylesheet" v-bind:href="hostUrl + '/js/portals/knowledge-management/style.css'" />
         </div>
 
         <div v-if="loading">

--- a/portals/knowledge-management/vite.config.js
+++ b/portals/knowledge-management/vite.config.js
@@ -43,6 +43,7 @@ export default defineConfig({
             entry: resolve(__dirname, './src/portal.js'),
             name: 'KnowledgeManagementPortal',
             fileName: 'aiding-app-knowledge-management-portal',
+            cssFileName: 'style',
             formats: ['es'],
         },
         outDir: resolve(__dirname, '../../public/js/portals/knowledge-management'),

--- a/widgets/service-request-feedback-form/src/App.vue
+++ b/widgets/service-request-feedback-form/src/App.vue
@@ -314,13 +314,7 @@
         class="font-sans px-6"
     >
         <div>
-            <link
-                rel="stylesheet"
-                v-bind:href="
-                    hostUrl +
-                    '/js/widgets/service-request-feedback-form/aiding-app-service-request-feedback-form-widget.css'
-                "
-            />
+            <link rel="stylesheet" v-bind:href="hostUrl + '/js/widgets/service-request-feedback-form/style.css'" />
         </div>
 
         <div v-if="loading">

--- a/widgets/service-request-feedback-form/vite.config.js
+++ b/widgets/service-request-feedback-form/vite.config.js
@@ -43,6 +43,7 @@ export default defineConfig({
             entry: resolve(__dirname, 'src/widget.js'),
             name: 'AidingAppServiceRequestFeedbackFormWidget',
             fileName: 'aiding-app-service-request-feedback-form-widget',
+            cssFileName: 'style',
             formats: ['es'],
         },
         outDir: resolve(__dirname, '../../public/js/widgets/service-request-feedback-form'),

--- a/widgets/service-request-form/src/App.vue
+++ b/widgets/service-request-form/src/App.vue
@@ -303,10 +303,7 @@
         class="font-sans"
     >
         <div class="prose max-w-none" v-if="display && !submittedSuccess">
-            <link
-                rel="stylesheet"
-                v-bind:href="hostUrl + '/js/widgets/service-request-form/aiding-app-service-request-form-widget.css'"
-            />
+            <link rel="stylesheet" v-bind:href="hostUrl + '/js/widgets/service-request-form/style.css'" />
 
             <h1>
                 {{ formName }}

--- a/widgets/service-request-form/vite.config.js
+++ b/widgets/service-request-form/vite.config.js
@@ -43,6 +43,7 @@ export default defineConfig({
             entry: resolve(__dirname, 'src/widget.js'),
             name: 'AidingAppServiceRequestFormWidget',
             fileName: 'aiding-app-service-request-form-widget',
+            cssFileName: 'style',
             formats: ['es'],
         },
         outDir: resolve(__dirname, '../../public/js/widgets/service-request-form'),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-485

### Technical Description

Fixes the issue in a non-cache busting way so that they output as `style.css` like they used to.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
