### PR TITLE
[AIDAPP-418] & [AIDAPP-419]: Show color name with preview of color in dropdown when configuring a service request type color & Display the service request status in its assigned color

### DIFF
--- a/app-modules/report/src/Filament/Widgets/RecentServiceRequestsTable.php
+++ b/app-modules/report/src/Filament/Widgets/RecentServiceRequestsTable.php
@@ -91,7 +91,9 @@ class RecentServiceRequestsTable extends BaseWidget
                 TextColumn::make('service_request_number')
                     ->label('Service Request #'),
                 TextColumn::make('title'),
-                TextColumn::make('status.name'),
+                TextColumn::make('status.name')
+                    ->badge()
+                    ->color(fn (ServiceRequest $record): string => $record->status->color->value),
                 TextColumn::make('priority.name'),
                 TextColumn::make('priority.type.name'),
                 TextColumn::make('assignedTo.user.name')

--- a/app-modules/service-management/database/migrations/2025_03_12_144425_data_convert_service_request_status_colors_to_literal_values.php
+++ b/app-modules/service-management/database/migrations/2025_03_12_144425_data_convert_service_request_status_colors_to_literal_values.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::transaction(function () {
+            DB::statement('alter table service_request_statuses disable trigger prevent_modification_of_system_protected_rows');
+
+            DB::table('service_request_statuses')
+                ->where('color', 'danger')
+                ->update(['color' => 'red']);
+
+            DB::table('service_request_statuses')
+                ->whereIn('color', ['warning', 'primary'])
+                ->update(['color' => 'amber']);
+
+            DB::table('service_request_statuses')
+                ->where('color', 'success')
+                ->update(['color' => 'green']);
+
+            DB::table('service_request_statuses')
+                ->where('color', 'info')
+                ->update(['color' => 'blue']);
+
+            DB::statement('alter table service_request_statuses enable trigger prevent_modification_of_system_protected_rows');
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            DB::statement('alter table service_request_statuses disable trigger prevent_modification_of_system_protected_rows');
+
+            DB::table('service_request_statuses')
+                ->where('color', 'red')
+                ->update(['color' => 'danger']);
+
+            DB::table('service_request_statuses')
+                ->where('color', 'amber')
+                ->update(['color' => 'warning']);
+
+            DB::table('service_request_statuses')
+                ->where('color', 'green')
+                ->update(['color' => 'success']);
+
+            DB::table('service_request_statuses')
+                ->where('color', 'blue')
+                ->update(['color' => 'info']);
+
+            DB::statement('alter table service_request_statuses enable trigger prevent_modification_of_system_protected_rows');
+        });
+    }
+};

--- a/app-modules/service-management/database/migrations/2025_03_12_144426_data_activate_service_request_status_colors_feature.php
+++ b/app-modules/service-management/database/migrations/2025_03_12_144426_data_activate_service_request_status_colors_feature.php
@@ -34,53 +34,17 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Models;
-
-use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
-use AidingApp\ServiceManagement\Enums\ColumnColorOptions;
-use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use App\Features\ServiceRequestStatusColorFeature;
-use App\Models\BaseModel;
-use CanyonGBS\Common\Enums\Color;
-use DateTimeInterface;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use OwenIt\Auditing\Contracts\Auditable;
+use Illuminate\Database\Migrations\Migration;
 
-/**
- * @mixin IdeHelperServiceRequestStatus
- */
-class ServiceRequestStatus extends BaseModel implements Auditable
-{
-    use SoftDeletes;
-    use AuditableTrait;
-
-    protected $fillable = [
-        'classification',
-        'name',
-        'color',
-        'is_system_protected',
-    ];
-
-    public function serviceRequests(): HasMany
+return new class () extends Migration {
+    public function up(): void
     {
-        return $this->hasMany(ServiceRequest::class, 'status_id');
+        ServiceRequestStatusColorFeature::activate();
     }
 
-    /**
-     * @return array<string, string>
-     */
-    protected function casts(): array
+    public function down(): void
     {
-        return [
-            'classification' => SystemServiceRequestClassification::class,
-            'color' => ServiceRequestStatusColorFeature::active() ? Color::class : ColumnColorOptions::class,
-            'is_system_protected' => 'boolean',
-        ];
+        ServiceRequestStatusColorFeature::deactivate();
     }
-
-    protected function serializeDate(DateTimeInterface $date): string
-    {
-        return $date->format(config('project.datetime_format') ?? 'Y-m-d H:i:s');
-    }
-}
+};

--- a/app-modules/service-management/resources/views/components/service-request-status-select-option-label.blade.php
+++ b/app-modules/service-management/resources/views/components/service-request-status-select-option-label.blade.php
@@ -1,0 +1,5 @@
+<div class="flex">
+    <x-filament::badge :color="$status->color->value">
+        {{ $status->name }}
+    </x-filament::badge>
+</div>

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/CreateServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/CreateServiceRequest.php
@@ -76,12 +76,16 @@ class CreateServiceRequest extends CreateRecord
                 Select::make('status_id')
                     ->relationship('status', 'name')
                     ->label('Status')
+                    ->native(false)
+                    ->allowHtml()
                     ->options(fn () => ServiceRequestStatus::query()
                         ->orderBy('classification')
                         ->orderBy('name')
-                        ->get(['id', 'name', 'classification'])
+                        ->get(['id', 'name', 'classification', 'color'])
                         ->groupBy(fn (ServiceRequestStatus $status) => $status->classification->getlabel())
-                        ->map(fn (Collection $group) => $group->pluck('name', 'id')))
+                        ->map(fn (Collection $group) => $group->mapWithKeys(fn (ServiceRequestStatus $status): array => [
+                            $status->getKey() => view('service-management::components.service-request-status-select-option-label', ['status' => $status])->render(),
+                        ])))
                     ->required()
                     ->exists((new ServiceRequestStatus())->getTable(), 'id'),
                 Grid::make()

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
@@ -98,6 +98,8 @@ class ListServiceRequests extends ListRecords
                     ->description(fn (ServiceRequest $record): string => Str::limit($record->title, 40)),
                 TextColumn::make('status.name')
                     ->label('Status')
+                    ->badge()
+                    ->color(fn (ServiceRequest $record): string => $record->status->color->value)
                     ->sortable()
                     ->toggleable(),
                 TextColumn::make('respondent.display_name')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ViewServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ViewServiceRequest.php
@@ -81,9 +81,8 @@ class ViewServiceRequest extends ViewRecord
                             ->label('Division'),
                         TextEntry::make('status.name')
                             ->label('Status')
-                            ->state(
-                                fn (ServiceRequest $record) => $record->status()->withTrashed()->first()?->name
-                            ),
+                            ->badge()
+                            ->color(fn (ServiceRequest $record): string => $record->status->color->value),
                         TextEntry::make('title'),
                         TextEntry::make('priority.name')
                             ->label('Priority'),

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
@@ -84,13 +84,15 @@ class ServiceRequestUpdatesRelationManager extends RelationManager
                     ->default(ServiceRequestUpdateDirection::default()),
                 Select::make('status_id')
                     ->label('Status')
+                    ->native(false)
+                    ->allowHtml()
                     ->options(fn () => ServiceRequestStatus::orderBy('classification')
                         ->orderBy('name')
-                        ->get(['id', 'name', 'classification'])
+                        ->get(['id', 'name', 'classification', 'color'])
                         ->groupBy(fn (ServiceRequestStatus $status) => $status->classification->getlabel())
-                        ->map(fn (Collection $group) => $group->pluck('name', 'id')->map(
-                            fn ($name, $id) => $name . ($id === $this->getOwnerRecord()->status->getKey() ? ' (Current)' : '')
-                        )))
+                        ->map(fn (Collection $group) => $group->mapWithKeys(fn (ServiceRequestStatus $status): array => [
+                            $status->getKey() => view('service-management::components.service-request-status-select-option-label', ['status' => $status])->render(),
+                        ])))
                     ->exists((new ServiceRequestStatus())->getTable(), 'id')
                     ->default($this->getOwnerRecord()->status->getKey()),
             ]);

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestStatusResource/Pages/CreateServiceRequestStatus.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestStatusResource/Pages/CreateServiceRequestStatus.php
@@ -39,6 +39,8 @@ namespace AidingApp\ServiceManagement\Filament\Resources\ServiceRequestStatusRes
 use AidingApp\ServiceManagement\Enums\ColumnColorOptions;
 use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestStatusResource;
+use App\Features\ServiceRequestStatusColorFeature;
+use CanyonGBS\Common\Filament\Forms\Components\ColorSelect;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -70,7 +72,11 @@ class CreateServiceRequestStatus extends CreateRecord
                             ->searchable()
                             ->options(ColumnColorOptions::class)
                             ->required()
-                            ->enum(ColumnColorOptions::class),
+                            ->enum(ColumnColorOptions::class)
+                            ->hidden(ServiceRequestStatusColorFeature::active()),
+                        ColorSelect::make()
+                            ->required()
+                            ->visible(ServiceRequestStatusColorFeature::active()),
                     ]),
             ]);
     }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestStatusResource/Pages/EditServiceRequestStatus.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestStatusResource/Pages/EditServiceRequestStatus.php
@@ -41,6 +41,8 @@ use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestStatusResource;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use App\Concerns\EditPageRedirection;
+use App\Features\ServiceRequestStatusColorFeature;
+use CanyonGBS\Common\Filament\Forms\Components\ColorSelect;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ForceDeleteAction;
@@ -78,7 +80,11 @@ class EditServiceRequestStatus extends EditRecord
                             ->searchable()
                             ->options(ColumnColorOptions::class)
                             ->required()
-                            ->enum(ColumnColorOptions::class),
+                            ->enum(ColumnColorOptions::class)
+                            ->hidden(ServiceRequestStatusColorFeature::active()),
+                        ColorSelect::make()
+                            ->required()
+                            ->visible(ServiceRequestStatusColorFeature::active()),
                     ]),
             ])->disabled(fn (ServiceRequestStatus $record) => $record->trashed());
     }

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -188,7 +188,7 @@ class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubsc
 
     public function status(): BelongsTo
     {
-        return $this->belongsTo(ServiceRequestStatus::class);
+        return $this->belongsTo(ServiceRequestStatus::class)->withTrashed();
     }
 
     public function priority(): BelongsTo

--- a/app/Features/ServiceRequestStatusColorFeature.php
+++ b/app/Features/ServiceRequestStatusColorFeature.php
@@ -34,53 +34,14 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Models;
+namespace App\Features;
 
-use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
-use AidingApp\ServiceManagement\Enums\ColumnColorOptions;
-use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
-use App\Features\ServiceRequestStatusColorFeature;
-use App\Models\BaseModel;
-use CanyonGBS\Common\Enums\Color;
-use DateTimeInterface;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\SoftDeletes;
-use OwenIt\Auditing\Contracts\Auditable;
+use App\Support\AbstractFeatureFlag;
 
-/**
- * @mixin IdeHelperServiceRequestStatus
- */
-class ServiceRequestStatus extends BaseModel implements Auditable
+class ServiceRequestStatusColorFeature extends AbstractFeatureFlag
 {
-    use SoftDeletes;
-    use AuditableTrait;
-
-    protected $fillable = [
-        'classification',
-        'name',
-        'color',
-        'is_system_protected',
-    ];
-
-    public function serviceRequests(): HasMany
+    public function resolve(mixed $scope): mixed
     {
-        return $this->hasMany(ServiceRequest::class, 'status_id');
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    protected function casts(): array
-    {
-        return [
-            'classification' => SystemServiceRequestClassification::class,
-            'color' => ServiceRequestStatusColorFeature::active() ? Color::class : ColumnColorOptions::class,
-            'is_system_protected' => 'boolean',
-        ];
-    }
-
-    protected function serializeDate(DateTimeInterface $date): string
-    {
-        return $date->format(config('project.datetime_format') ?? 'Y-m-d H:i:s');
+        return false;
     }
 }

--- a/app/Filament/Widgets/ListServiceRequestTableWidgets.php
+++ b/app/Filament/Widgets/ListServiceRequestTableWidgets.php
@@ -83,6 +83,8 @@ class ListServiceRequestTableWidgets extends BaseWidget
                     ->color('primary')
                     ->description(fn (ServiceRequest $record): string => Str::limit($record->title, 40)),
                 TextColumn::make('status.name')
+                    ->badge()
+                    ->color(fn (ServiceRequest $record): string => $record->status->color->value)
                     ->searchable()
                     ->sortable()
                     ->toggleable(),

--- a/composer.lock
+++ b/composer.lock
@@ -2344,16 +2344,16 @@
         },
         {
             "name": "canyongbs/common",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/canyongbs/common.git",
-                "reference": "53c8223b444860b68efa7afcd3a589e8bc077367"
+                "reference": "459480bc3a948bbebf3858000ee99ca0052aad87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/canyongbs/common/zipball/53c8223b444860b68efa7afcd3a589e8bc077367",
-                "reference": "53c8223b444860b68efa7afcd3a589e8bc077367",
+                "url": "https://api.github.com/repos/canyongbs/common/zipball/459480bc3a948bbebf3858000ee99ca0052aad87",
+                "reference": "459480bc3a948bbebf3858000ee99ca0052aad87",
                 "shasum": ""
             },
             "require": {
@@ -2388,9 +2388,9 @@
             ],
             "support": {
                 "issues": "https://github.com/canyongbs/common/issues",
-                "source": "https://github.com/canyongbs/common/tree/1.0.2"
+                "source": "https://github.com/canyongbs/common/tree/1.1.0"
             },
-            "time": "2025-03-10T14:58:47+00:00"
+            "time": "2025-03-12T16:02:11+00:00"
         },
         {
             "name": "canyongbs/filament-tiptap-editor",


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-418
- https://canyongbs.atlassian.net/browse/AIDAPP-419

### Technical Description

Migrates set colors (success/warning/danger) to literal ones (red/blue/green). Introduces color selection and display throughout the application.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

`ServiceRequestStatusColorFeature`

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
