### PR TITLE
[AIDAPP-502]: Disable health check process from sending emails

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -73,7 +73,7 @@ return [
         /*
          * Notifications will only get sent if this option is set to `true`.
          */
-        'enabled' => true,
+        'enabled' => false,
 
         'notifications' => [
             CheckFailedNotification::class => ['mail'],


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-502

### Technical Description

Disables the Spatie Health checks from sending emails as we get these notices in Olympus now.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
