### PR TITLE
[AIDAPP-521]: When using the knowledge base and working with an article, the label on the button reads replicate instead of duplicate after initiating a duplicate action

### DIFF
--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ListKnowledgeBaseItems.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/ListKnowledgeBaseItems.php
@@ -156,7 +156,6 @@ class ListKnowledgeBaseItems extends ListRecords
             ->actions([
                 EditAction::make(),
                 ReplicateAction::make()
-                    ->label('Duplicate')
                     ->form([
                         Section::make()
                             ->schema([
@@ -237,7 +236,7 @@ class ListKnowledgeBaseItems extends ListRecords
                         $replica->save();
                     })
                     ->excludeAttributes(['views_count', 'upvotes_count', 'my_upvotes_count'])
-                    ->successNotificationTitle('Article replicated successfully!'),
+                    ->successNotificationTitle('Article duplicated successfully!'),
             ])
             ->bulkActions([
                 BulkActionGroup::make([

--- a/resources/lang/vendor/filament-actions/en/replicate.php
+++ b/resources/lang/vendor/filament-actions/en/replicate.php
@@ -15,7 +15,7 @@ return [
         ],
 
         'notifications' => [
-            'Duplicated' => [
+            'replicate' => [
                 'title' => 'Duplicated',
             ],
         ],

--- a/resources/lang/vendor/filament-actions/en/replicate.php
+++ b/resources/lang/vendor/filament-actions/en/replicate.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 return [
     'single' => [
         'label' => 'Duplicate',

--- a/resources/lang/vendor/filament-actions/en/replicate.php
+++ b/resources/lang/vendor/filament-actions/en/replicate.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'single' => [
+        'label' => 'Duplicate',
+
+        'modal' => [
+            'heading' => 'Duplicate :label',
+
+            'actions' => [
+                'replicate' => [
+                    'label' => 'Duplicate',
+                ],
+            ],
+        ],
+
+        'notifications' => [
+            'Duplicated' => [
+                'title' => 'Duplicated',
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-521

### Technical Description

When using the knowledge base and working with an article, the label on the button reads replicate instead of duplicate after initiating a duplicate action

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
