### PR TITLE
[AIDAPP-530]: Engagements sent to contacts are not using the correct communication settings configuration attached to the division.

### DIFF
--- a/app-modules/engagement/src/Notifications/EngagementNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementNotification.php
@@ -117,7 +117,6 @@ class EngagementNotification extends Notification implements ShouldQueue, HasBef
 
     private function resolveNotificationSetting(User $notifiable): ?NotificationSetting
     {
-        // Engagement->User->Team->Division->NotificationSetting
         return $notifiable->teams()->first()?->division?->notificationSetting?->setting;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -280,7 +280,6 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
         return $this
             ->belongsToMany(Team::class, 'team_user', 'user_id', 'team_id')
             ->using(TeamUser::class)
-            ->limit(1)
             ->withTimestamps();
     }
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-530

### Technical Description

> Fixed: Engagements sent to contacts are not using the correct communication settings configuration attached to the division.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
