### PR TITLE
[OLYMPUS-441]: Tiptap merge tags type ahead is currently limited to only 5 items and typeahead search does not seem to be working

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2394,16 +2394,16 @@
         },
         {
             "name": "canyongbs/filament-tiptap-editor",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/canyongbs/filament-tiptap-editor.git",
-                "reference": "a24f32ba6e0e97bb70003abd0009cf176a8df6f1"
+                "reference": "d93400d65a27909e9f3ce20c3e3d2febd678606c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/canyongbs/filament-tiptap-editor/zipball/a24f32ba6e0e97bb70003abd0009cf176a8df6f1",
-                "reference": "a24f32ba6e0e97bb70003abd0009cf176a8df6f1",
+                "url": "https://api.github.com/repos/canyongbs/filament-tiptap-editor/zipball/d93400d65a27909e9f3ce20c3e3d2febd678606c",
+                "reference": "d93400d65a27909e9f3ce20c3e3d2febd678606c",
                 "shasum": ""
             },
             "require": {
@@ -2466,7 +2466,7 @@
             ],
             "support": {
                 "issues": "https://github.com/canyongbs/filament-tiptap-editor/issues",
-                "source": "https://github.com/canyongbs/filament-tiptap-editor/tree/1.2.0"
+                "source": "https://github.com/canyongbs/filament-tiptap-editor/tree/1.2.1"
             },
             "funding": [
                 {
@@ -2474,7 +2474,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-13T23:08:16+00:00"
+            "time": "2025-04-02T16:59:26+00:00"
         },
         {
             "name": "canyongbs/model-state-machine",


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/OLYMPUS-441

### Technical Description

Updates package

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
