### PR TITLE
[AIDAPP-538]: Apply Filament and Laravel auto discovery caching during CI linting and CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,11 +187,23 @@ jobs:
       - name: Generate key
         run: php artisan key:generate
 
-      - name: Clear Config
-        run: php artisan optimize:clear
+      - name: Cache Modular Modules
+        run: php artisan modules:cache --env=testing
 
-      - name: Directory Permissions
-        run: chmod -R 777 storage bootstrap/cache
+      - name: Cache Routes
+        run: php artisan route:cache --env=testing
+
+      - name: Cache Views
+        run: php artisan view:cache --env=testing
+
+      - name: Cache Events
+        run: php artisan event:cache --env=testing
+
+      - name: Cache Icons
+        run: php artisan icons:cache --env=testing
+
+      - name: Cache Filament Components
+        run: php artisan filament:cache-components --env=testing
 
       - name: Check route integrity
         run: php artisan route:list
@@ -221,5 +233,20 @@ jobs:
       - name: Setup Dependencies
         uses: ./.github/actions/composer-dependency-setup
 
+      - name: "Restore result cache"
+        uses: actions/cache/restore@v4
+        with:
+          path: tmp
+          key: "phpstan-result-cache-${{ github.run_id }}"
+          restore-keys: |
+            phpstan-result-cache-
+
       - name: Linting
         run: composer lint
+
+      - name: "Save result cache"
+        uses: actions/cache/save@v4
+        if: ${{ !cancelled() }}
+        with:
+          path: tmp
+          key: "phpstan-result-cache-${{ github.run_id }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,26 +8,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-deps:
-    runs-on: ubuntu-22.04
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: "8.2"
-          extensions: mailparse
-
-      - name: Setup Dependencies
-        uses: ./.github/actions/composer-dependency-setup
-
   enforce-copyright:
     runs-on: ubuntu-22.04
 
     timeout-minutes: 10
-
-    needs: [build-deps]
 
     steps:
       - name: Checkout code | Internal
@@ -66,7 +50,7 @@ jobs:
 
     timeout-minutes: 10
 
-    needs: [build-deps, enforce-copyright]
+    needs: [enforce-copyright]
 
     steps:
       - uses: shivammathur/setup-php@v2
@@ -132,7 +116,7 @@ jobs:
 
     timeout-minutes: 15
 
-    needs: [build-deps,enforce-copyright,fix-code-style]
+    needs: [enforce-copyright,fix-code-style]
 
     services:
       postgres:
@@ -210,7 +194,7 @@ jobs:
 
     timeout-minutes: 10
 
-    needs: [build-deps,enforce-copyright,fix-code-style]
+    needs: [enforce-copyright,fix-code-style]
 
     steps:
       - uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,14 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-${{ github.repository }}-phpcsfixer-
 
+      - name: Cache Prettier
+        uses: actions/cache@v4
+        with:
+          path: ./node_modules/.cache/prettier/.prettier-cache
+          key: ${{ runner.OS }}-${{ github.repository }}-prettier-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.OS }}-${{ github.repository }}-prettier-
+
       - name: Run Formatters
         run: composer format
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.2"
+          coverage: none
           extensions: mailparse
 
       - name: Checkout code | Internal
@@ -152,6 +153,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.2"
+          coverage: none
           extensions: gd, gmp, redis, mailparse
 
       - uses: actions/checkout@v4
@@ -200,6 +202,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: "8.2"
+          coverage: none
           extensions: gd, gmp, redis, mailparse
 
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
             phpstan-result-cache-
 
       - name: Linting
-        run: composer lint
+        run: ./vendor/bin/phpstan analyse --configuration phpstan-ci.neon --no-progress
 
       - name: "Save result cache"
         uses: actions/cache/save@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
 
     timeout-minutes: 15
 
-    needs: [enforce-copyright,fix-code-style]
+    needs: [enforce-copyright, fix-code-style]
 
     services:
       postgres:
@@ -216,7 +216,7 @@ jobs:
 
     timeout-minutes: 10
 
-    needs: [enforce-copyright,fix-code-style]
+    needs: [enforce-copyright, fix-code-style]
 
     steps:
       - uses: shivammathur/setup-php@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="CanyonGBS"
 ARG POSTGRES_VERSION=15
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git cron s6 gnupg zip unzip php8.2-apcu php8.2-pgsql php8.2-imagick php8.2-mailparse php8.2-redis php8.2-pcov php8.2-xdebug \
+    && apt-get install -y --no-install-recommends git cron s6 gnupg zip unzip php8.2-apcu php8.2-pgsql php8.2-imagick php8.2-mailparse php8.2-redis \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/keyrings/pgdg.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt jammy-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \

--- a/app-modules/service-management/tests/ServiceRequest/CreateServiceRequestTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/CreateServiceRequestTest.php
@@ -608,7 +608,7 @@ test('assignment type workload will auto-assign to new service requests', functi
             ->call('create')
             ->assertHasNoFormErrors();
 
-        $latestServiceRequest = ServiceRequest::latest()->first();
+        $latestServiceRequest = ServiceRequest::query()->latest('id')->first();
         $getServiceRequestType = ServiceRequestType::where('assignment_type', ServiceRequestTypeAssignmentTypes::Workload->value)->first();
         expect($getServiceRequestType->assignment_type)->toBe(ServiceRequestTypeAssignmentTypes::Workload);
         expect($getServiceRequestType->last_assigned_id)->ToBe($user->getKey());

--- a/app-modules/service-management/tests/ServiceRequest/CreateServiceRequestTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/CreateServiceRequestTest.php
@@ -519,11 +519,17 @@ test('assignment type round robin will auto-assign to new service requests', fun
             ->call('create')
             ->assertHasNoFormErrors();
 
-        $latestServiceRequest = ServiceRequest::latest()->first();
+        $latestServiceRequest = ServiceRequest::query()->latest('id')->first();
+
         $getServiceRequestType = ServiceRequestType::where('assignment_type', ServiceRequestTypeAssignmentTypes::RoundRobin->value)->first();
         expect($getServiceRequestType->assignment_type)->toBe(ServiceRequestTypeAssignmentTypes::RoundRobin);
         expect($getServiceRequestType->last_assigned_id)->ToBe($user->getKey());
         expect($latestServiceRequest->assignedTo->user_id)->ToBe($user->getKey());
+
+        // This needs to be added due to a bug in Laravel
+        // Laravel's uuidv4 orderedUuids is NOT same second safe
+        // So until we update to UUID v7 we need to sleep for 1 second
+        sleep(1);
     }
 
     livewire(CreateServiceRequest::class)
@@ -538,7 +544,7 @@ test('assignment type round robin will auto-assign to new service requests', fun
     $getServiceRequestType = ServiceRequestType::where('assignment_type', ServiceRequestTypeAssignmentTypes::RoundRobin->value)->first();
     expect($getServiceRequestType->last_assigned_id)->ToBe($team->users()->orderBy('name')->orderBy('id')->first()->getKey());
     expect($latestServiceRequest->assignedTo->user_id)->ToBe($team->users()->orderBy('name')->orderBy('id')->first()->getKey());
-});
+})->only()->repeat(10);
 
 test('assignment type workload will auto-assign to new service requests', function () {
     asSuperAdmin();
@@ -607,6 +613,11 @@ test('assignment type workload will auto-assign to new service requests', functi
         expect($getServiceRequestType->assignment_type)->toBe(ServiceRequestTypeAssignmentTypes::Workload);
         expect($getServiceRequestType->last_assigned_id)->ToBe($user->getKey());
         expect($latestServiceRequest->assignedTo->user_id)->ToBe($user->getKey());
+
+        // This needs to be added due to a bug in Laravel
+        // Laravel's uuidv4 orderedUuids is NOT same second safe
+        // So until we update to UUID v7 we need to sleep for 1 second
+        sleep(1);
     }
 
     livewire(CreateServiceRequest::class)

--- a/app-modules/service-management/tests/ServiceRequest/CreateServiceRequestTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/CreateServiceRequestTest.php
@@ -55,6 +55,8 @@ use Filament\Forms\Components\Select;
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Laravel\assertDatabaseMissing;
+use function Pest\Laravel\travelBack;
+use function Pest\Laravel\travelTo;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertCount;
 use function Tests\asSuperAdmin;
@@ -510,6 +512,8 @@ test('assignment type round robin will auto-assign to new service requests', fun
 
     $users = $team->users()->orderBy('name')->orderBy('id')->get();
 
+    travelTo(now()->subSeconds(count($users)));
+
     foreach ($users as $user) {
         livewire(CreateServiceRequest::class)
             ->fillForm($request->toArray())
@@ -529,8 +533,10 @@ test('assignment type round robin will auto-assign to new service requests', fun
         // This needs to be added due to a bug in Laravel
         // Laravel's uuidv4 orderedUuids is NOT same second safe
         // So until we update to UUID v7 we need to sleep for 1 second
-        sleep(1);
+        travelTo(now()->addSecond());
     }
+
+    travelBack();
 
     livewire(CreateServiceRequest::class)
         ->fillForm($request->toArray())
@@ -542,9 +548,9 @@ test('assignment type round robin will auto-assign to new service requests', fun
 
     $latestServiceRequest = ServiceRequest::latest()->first();
     $getServiceRequestType = ServiceRequestType::where('assignment_type', ServiceRequestTypeAssignmentTypes::RoundRobin->value)->first();
-    expect($getServiceRequestType->last_assigned_id)->ToBe($team->users()->orderBy('name')->orderBy('id')->first()->getKey());
-    expect($latestServiceRequest->assignedTo->user_id)->ToBe($team->users()->orderBy('name')->orderBy('id')->first()->getKey());
-})->only()->repeat(10);
+    expect($getServiceRequestType->last_assigned_id)->toBe($team->users()->orderBy('name')->orderBy('id')->first()->getKey());
+    expect($latestServiceRequest->assignedTo->user_id)->toBe($team->users()->orderBy('name')->orderBy('id')->first()->getKey());
+});
 
 test('assignment type workload will auto-assign to new service requests', function () {
     asSuperAdmin();
@@ -599,6 +605,8 @@ test('assignment type workload will auto-assign to new service requests', functi
         ])->getKey(),
     ]));
 
+    travelTo(now()->subSeconds(3));
+
     foreach ($factoryUsers->take(3)->sortBy('id')->sortBy('name') as $user) {
         livewire(CreateServiceRequest::class)
             ->fillForm($request->toArray())
@@ -617,8 +625,10 @@ test('assignment type workload will auto-assign to new service requests', functi
         // This needs to be added due to a bug in Laravel
         // Laravel's uuidv4 orderedUuids is NOT same second safe
         // So until we update to UUID v7 we need to sleep for 1 second
-        sleep(1);
+        travelTo(now()->addSecond());
     }
+
+    travelBack();
 
     livewire(CreateServiceRequest::class)
         ->fillForm($request->toArray())
@@ -630,6 +640,6 @@ test('assignment type workload will auto-assign to new service requests', functi
 
     $latestServiceRequest = ServiceRequest::latest()->first();
     $getServiceRequestType = ServiceRequestType::where('assignment_type', ServiceRequestTypeAssignmentTypes::Workload->value)->first();
-    expect($getServiceRequestType->last_assigned_id)->ToBe($factoryUsers->take(3)->sortBy('id')->sortBy('name')->first()->getKey());
-    expect($latestServiceRequest->assignedTo->user_id)->ToBe($factoryUsers->take(3)->sortBy('id')->sortBy('name')->first()->getKey());
+    expect($getServiceRequestType->last_assigned_id)->toBe($factoryUsers->take(3)->sortBy('id')->sortBy('name')->first()->getKey());
+    expect($latestServiceRequest->assignedTo->user_id)->toBe($factoryUsers->take(3)->sortBy('id')->sortBy('name')->first()->getKey());
 });

--- a/phpstan-ci.neon
+++ b/phpstan-ci.neon
@@ -1,0 +1,6 @@
+includes:
+    - ./phpstan.neon.dist
+
+parameters:
+    tmpDir: tmp
+    errorFormat: github


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-538

### Technical Description

Adds caching to the CI testing to speed up tests.

Also optimizing CI running to be much more efficient and resolves issues with debug tools loading in all environments.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
