### PR TITLE
[AIDAPP-549]: Update canyongbs/filament-tiptap-editor to version 1.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "canyon-gbs/purchasing": "*",
         "canyon-gbs/report": "*",
         "canyongbs/common": "^1.1.1",
-        "canyongbs/filament-tiptap-editor": "^1.2.0",
+        "canyongbs/filament-tiptap-editor": "^1.2.3",
         "canyongbs/model-state-machine": "^1.0",
         "cknow/laravel-money": "^8.1",
         "composer/composer": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2ee5fb3327c12451c07d0e2600dac7e",
+    "content-hash": "1be9c2975aea06b966904b4b0ff97883",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2429,16 +2429,16 @@
         },
         {
             "name": "canyongbs/filament-tiptap-editor",
-            "version": "1.2.1",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/canyongbs/filament-tiptap-editor.git",
-                "reference": "d93400d65a27909e9f3ce20c3e3d2febd678606c"
+                "reference": "2a2aa8962f6aec5a4bc057f0515dd6d672f27e77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/canyongbs/filament-tiptap-editor/zipball/d93400d65a27909e9f3ce20c3e3d2febd678606c",
-                "reference": "d93400d65a27909e9f3ce20c3e3d2febd678606c",
+                "url": "https://api.github.com/repos/canyongbs/filament-tiptap-editor/zipball/2a2aa8962f6aec5a4bc057f0515dd6d672f27e77",
+                "reference": "2a2aa8962f6aec5a4bc057f0515dd6d672f27e77",
                 "shasum": ""
             },
             "require": {
@@ -2501,7 +2501,7 @@
             ],
             "support": {
                 "issues": "https://github.com/canyongbs/filament-tiptap-editor/issues",
-                "source": "https://github.com/canyongbs/filament-tiptap-editor/tree/1.2.1"
+                "source": "https://github.com/canyongbs/filament-tiptap-editor/tree/1.2.3"
             },
             "funding": [
                 {
@@ -2509,7 +2509,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-02T16:59:26+00:00"
+            "time": "2025-04-08T22:31:28+00:00"
         },
         {
             "name": "canyongbs/model-state-machine",


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-549

### Technical Description

Update canyongbs/filament-tiptap-editor to version 1.2.3

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
