### PR TITLE
[AIDAPP-560]: Remove the Knowledge Base menu page placeholder in the portal

### DIFF
--- a/app-modules/portal/routes/web.php
+++ b/app-modules/portal/routes/web.php
@@ -85,8 +85,6 @@ Route::prefix('portal')
                 ->name('services');
             Route::get('/incidents', RenderKnowledgeManagementPortal::class)
                 ->name('incidents');
-            Route::get('/knowledge-base', RenderKnowledgeManagementPortal::class)
-                ->name('knowledge-base');
             Route::get('/assets', RenderKnowledgeManagementPortal::class)
                 ->name('assets');
             Route::get('/licenses', RenderKnowledgeManagementPortal::class)

--- a/portals/knowledge-management/src/Components/Header.vue
+++ b/portals/knowledge-management/src/Components/Header.vue
@@ -96,11 +96,6 @@
             command: () => router.push({ name: 'incidents' }),
         },
         {
-            label: 'Knowledge Base',
-            routeName: 'knowledge-base',
-            command: () => router.push({ name: 'knowledge-base' }),
-        },
-        {
             label: 'Assets',
             routeName: 'assets',
             visible: hasAssets,

--- a/portals/knowledge-management/src/portal.js
+++ b/portals/knowledge-management/src/portal.js
@@ -113,11 +113,6 @@ customElements.define(
                         component: ComingSoon,
                     },
                     {
-                        path: baseUrl + '/knowledge-base',
-                        name: 'knowledge-base',
-                        component: ComingSoon,
-                    },
-                    {
                         path: baseUrl + '/assets',
                         name: 'assets',
                         component: ComingSoon,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-560

### Technical Description

Remove the Knowledge Base menu page placeholder in the portal

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
