### PR TITLE
[AIDAPP-561]: Just like service, incidents in the menu navigation should only show up if you are logged in

### DIFF
--- a/portals/knowledge-management/src/App.vue
+++ b/portals/knowledge-management/src/App.vue
@@ -459,7 +459,7 @@
 
         <div class="bg-white" v-else>
             <div
-                v-if="!userIsAuthenticated && (requiresAuthentication || showLogin)"
+                v-if="!userIsAuthenticated && (requiresAuthentication || showLogin || route.meta.requiresAuth)"
                 class="bg-gradient flex flex-col items-center justify-start min-h-screen"
             >
                 <div

--- a/portals/knowledge-management/src/Components/Header.vue
+++ b/portals/knowledge-management/src/Components/Header.vue
@@ -93,6 +93,7 @@
         {
             label: 'Incidents',
             routeName: 'incidents',
+            visible: user !== null,
             command: () => router.push({ name: 'incidents' }),
         },
         {

--- a/portals/knowledge-management/src/portal.js
+++ b/portals/knowledge-management/src/portal.js
@@ -91,26 +91,31 @@ customElements.define(
                         path: baseUrl + '/service-request-type/select',
                         name: 'create-service-request',
                         component: SelectServiceRequestType,
+                        meta: { requiresAuth: true },
                     },
                     {
                         path: baseUrl + '/service-request/create/:typeId',
                         name: 'create-service-request-from-type',
                         component: CreateServiceRequest,
+                        meta: { requiresAuth: true },
                     },
                     {
                         path: baseUrl + '/service-request/:serviceRequestId',
                         name: 'view-service-request',
                         component: ViewServiceRequest,
+                        meta: { requiresAuth: true },
                     },
                     {
                         path: baseUrl + '/services',
                         name: 'services',
                         component: Services,
+                        meta: { requiresAuth: true },
                     },
                     {
                         path: baseUrl + '/incidents',
                         name: 'incidents',
                         component: ComingSoon,
+                        meta: { requiresAuth: true },
                     },
                     {
                         path: baseUrl + '/knowledge-base',


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-561

### Technical Description

Just like service, incidents in the menu navigation should only show up if you are logged in

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
