### PR TITLE
[AIDAPP-570]: Error for too few arguments being passed to ServiceMonitoringJob

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -80,14 +80,14 @@ class Kernel extends ConsoleKernel
 
                     $schedule->call(function () use ($tenant) {
                         $tenant->execute(function () {
-                            (new ServiceMonitoringJob(ServiceMonitoringFrequency::OneHour))->dispatch();
+                            dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::OneHour));
                         });
                     })
                         ->hourly();
 
                     $schedule->call(function () use ($tenant) {
                         $tenant->execute(function () {
-                            (new ServiceMonitoringJob(ServiceMonitoringFrequency::TwentyFourHours))->dispatch();
+                            dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::TwentyFourHours));
                         });
                     })
                         ->daily();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-570

### Technical Description

Resolve an issue with the dispatching of the `ServiceMonitoringJob`'s during scheduler run.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
