### PR TITLE
[AIDAPP-578]: Populate the email templates for CSAT and NPS survey service request email notifications including the current messaging that is used

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -3282,10 +3282,6 @@ namespace AidingApp\ServiceManagement\Models{
  * @property bool $is_customers_service_request_status_change_notification_enabled
  * @property bool $is_customers_service_request_closed_email_enabled
  * @property bool $is_customers_service_request_closed_notification_enabled
- * @property bool $is_managers_survey_response_email_enabled
- * @property bool $is_managers_survey_response_notification_enabled
- * @property bool $is_auditors_survey_response_email_enabled
- * @property bool $is_auditors_survey_response_notification_enabled
  * @property bool $is_customers_survey_response_email_enabled
  * @property-read \App\Models\User|null $assignmentTypeIndividual
  * @property-read \AidingApp\ServiceManagement\Models\ServiceRequestTypeManager|\AidingApp\ServiceManagement\Models\ServiceRequestTypeAuditor|null $pivot
@@ -3328,8 +3324,6 @@ namespace AidingApp\ServiceManagement\Models{
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsAuditorsServiceRequestStatusChangeNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsAuditorsServiceRequestUpdateEmailEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsAuditorsServiceRequestUpdateNotificationEnabled($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsAuditorsSurveyResponseEmailEnabled($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsAuditorsSurveyResponseNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsCustomersServiceRequestAssignedEmailEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsCustomersServiceRequestAssignedNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsCustomersServiceRequestClosedEmailEnabled($value)
@@ -3351,8 +3345,6 @@ namespace AidingApp\ServiceManagement\Models{
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersServiceRequestStatusChangeNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersServiceRequestUpdateEmailEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersServiceRequestUpdateNotificationEnabled($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersSurveyResponseEmailEnabled($value)
- * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersSurveyResponseNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereLastAssignedId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereName($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereUpdatedAt($value)

--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 // @formatter:off
 // phpcs:ignoreFile
 /**

--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1,39 +1,5 @@
 <?php
 
-/*
-<COPYRIGHT>
-
-    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
-
-    Aiding App™ is licensed under the Elastic License 2.0. For more details,
-    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
-
-    Notice:
-
-    - You may not provide the software to third parties as a hosted or managed
-      service, where the service provides users with access to any substantial set of
-      the features or functionality of the software.
-    - You may not move, change, disable, or circumvent the license key functionality
-      in the software, and you may not remove or obscure any functionality in the
-      software that is protected by the license key.
-    - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
-      to applicable law.
-    - Canyon GBS LLC respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
-      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
-      vigorously.
-    - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS LLC.
-    - Use of this software implies agreement to the license terms and conditions as stated
-      in the Elastic License 2.0.
-
-    For more information or inquiries please visit our website at
-    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
-
-</COPYRIGHT>
-*/
-
 // @formatter:off
 // phpcs:ignoreFile
 /**
@@ -3316,6 +3282,11 @@ namespace AidingApp\ServiceManagement\Models{
  * @property bool $is_customers_service_request_status_change_notification_enabled
  * @property bool $is_customers_service_request_closed_email_enabled
  * @property bool $is_customers_service_request_closed_notification_enabled
+ * @property bool $is_managers_survey_response_email_enabled
+ * @property bool $is_managers_survey_response_notification_enabled
+ * @property bool $is_auditors_survey_response_email_enabled
+ * @property bool $is_auditors_survey_response_notification_enabled
+ * @property bool $is_customers_survey_response_email_enabled
  * @property-read \App\Models\User|null $assignmentTypeIndividual
  * @property-read \AidingApp\ServiceManagement\Models\ServiceRequestTypeManager|\AidingApp\ServiceManagement\Models\ServiceRequestTypeAuditor|null $pivot
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AidingApp\Team\Models\Team> $auditors
@@ -3357,6 +3328,8 @@ namespace AidingApp\ServiceManagement\Models{
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsAuditorsServiceRequestStatusChangeNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsAuditorsServiceRequestUpdateEmailEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsAuditorsServiceRequestUpdateNotificationEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsAuditorsSurveyResponseEmailEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsAuditorsSurveyResponseNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsCustomersServiceRequestAssignedEmailEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsCustomersServiceRequestAssignedNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsCustomersServiceRequestClosedEmailEnabled($value)
@@ -3367,6 +3340,7 @@ namespace AidingApp\ServiceManagement\Models{
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsCustomersServiceRequestStatusChangeNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsCustomersServiceRequestUpdateEmailEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsCustomersServiceRequestUpdateNotificationEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsCustomersSurveyResponseEmailEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersServiceRequestAssignedEmailEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersServiceRequestAssignedNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersServiceRequestClosedEmailEnabled($value)
@@ -3377,6 +3351,8 @@ namespace AidingApp\ServiceManagement\Models{
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersServiceRequestStatusChangeNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersServiceRequestUpdateEmailEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersServiceRequestUpdateNotificationEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersSurveyResponseEmailEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereIsManagersSurveyResponseNotificationEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereLastAssignedId($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereName($value)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|ServiceRequestType whereUpdatedAt($value)

--- a/app-modules/service-management/database/factories/ServiceRequestTypeEmailTemplateFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestTypeEmailTemplateFactory.php
@@ -59,7 +59,9 @@ class ServiceRequestTypeEmailTemplateFactory extends Factory
             'type' => fake()->randomElement(collect(ServiceRequestEmailTemplateType::cases())->values()->toArray()),
             'subject' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->sentence()]]]]],
             'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->sentence()]]]]],
-            'role' => fake()->randomElement(ServiceRequestTypeEmailTemplateRole::cases()),
+            'role' => fn (array $attributes) => $attributes['type'] === ServiceRequestEmailTemplateType::SurveyResponse
+              ? ServiceRequestTypeEmailTemplateRole::Customer
+              : fake()->randomElement(ServiceRequestTypeEmailTemplateRole::cases()),
         ];
     }
 }

--- a/app-modules/service-management/database/migrations/2025_05_09_113514_add_customers_survey_response_fields_in_service_request_types_table.php
+++ b/app-modules/service-management/database/migrations/2025_05_09_113514_add_customers_survey_response_fields_in_service_request_types_table.php
@@ -15,9 +15,7 @@ return new class () extends Migration {
     public function down(): void
     {
         Schema::table('service_request_types', function (Blueprint $table) {
-            $table->dropColumn([
-                'is_customers_survey_response_email_enabled',
-            ]);
+            $table->dropColumn('is_customers_survey_response_email_enabled');
         });
     }
 };

--- a/app-modules/service-management/database/migrations/2025_05_09_113514_add_customers_survey_response_fields_in_service_request_types_table.php
+++ b/app-modules/service-management/database/migrations/2025_05_09_113514_add_customers_survey_response_fields_in_service_request_types_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('service_request_types', function (Blueprint $table) {

--- a/app-modules/service-management/database/migrations/2025_05_09_113514_add_customers_survey_response_fields_in_service_request_types_table.php
+++ b/app-modules/service-management/database/migrations/2025_05_09_113514_add_customers_survey_response_fields_in_service_request_types_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_request_types', function (Blueprint $table) {
+            $table->boolean('is_customers_survey_response_email_enabled')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_request_types', function (Blueprint $table) {
+            $table->dropColumn([
+                'is_customers_survey_response_email_enabled',
+            ]);
+        });
+    }
+};

--- a/app-modules/service-management/database/migrations/2025_05_09_113514_add_customers_survey_response_fields_in_service_request_types_table.php
+++ b/app-modules/service-management/database/migrations/2025_05_09_113514_add_customers_survey_response_fields_in_service_request_types_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;

--- a/app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php
+++ b/app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php
@@ -8,17 +8,10 @@ return new class () extends Migration {
     public function up(): void
     {
         DB::transaction(function () {
-            $table = 'service_request_type_email_templates';
-            $chunkSize = 100;
-            DB::table($table)
+            DB::table('service_request_type_email_templates')
                 ->where('type', 'survey_response')
                 ->whereIn('role', ['auditor', 'manager'])
-                ->orderBy('id')
-                ->chunkById($chunkSize, function ($records) use ($table) {
-                    foreach ($records as $record) {
-                        DB::table($table)->where('id', $record->id)->delete();
-                    }
-                });
+                ->delete();
         });
 
         $subject = [

--- a/app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php
+++ b/app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php
@@ -12,118 +12,116 @@ return new class () extends Migration {
                 ->where('type', 'survey_response')
                 ->whereIn('role', ['auditor', 'manager'])
                 ->delete();
-        });
 
-        $subject = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'paragraph',
-                    'attrs' => [
-                        'class' => null,
-                        'style' => null,
-                        'textAlign' => 'start',
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Feedback survey for ',
-                            'type' => 'text',
+            $subject = [
+                'type' => 'doc',
+                'content' => [
+                    [
+                        'type' => 'paragraph',
+                        'attrs' => [
+                            'class' => null,
+                            'style' => null,
+                            'textAlign' => 'start',
                         ],
-                        [
-                            'type' => 'mergeTag',
-                            'attrs' => ['id' => 'service request number'],
-                        ],
-                    ],
-                ],
-            ],
-        ];
-
-        $body = [
-            'type' => 'doc',
-            'content' => [
-                [
-                    'type' => 'paragraph',
-                    'attrs' => [
-                        'class' => null,
-                        'style' => null,
-                        'textAlign' => 'start',
-                    ],
-                    'content' => [
-                        [
-                            'text' => 'Hi ',
-                            'type' => 'text',
-                            'marks' => [
-                                ['type' => 'bold'],
+                        'content' => [
+                            [
+                                'text' => 'Feedback survey for ',
+                                'type' => 'text',
                             ],
-                        ],
-                        [
-                            'type' => 'mergeTag',
-                            'attrs' => ['id' => 'assigned to'],
-                            'marks' => [
-                                ['type' => 'bold'],
-                            ],
-                        ],
-                        [
-                            'text' => ',',
-                            'type' => 'text',
-                            'marks' => [
-                                ['type' => 'bold'],
+                            [
+                                'type' => 'mergeTag',
+                                'attrs' => ['id' => 'service request number'],
                             ],
                         ],
                     ],
                 ],
-                [
-                    'type' => 'paragraph',
-                    'attrs' => [
-                        'class' => null,
-                        'style' => null,
-                        'textAlign' => 'start',
-                    ],
-                    'content' => [
-                        [
-                            'text' => "To help us serve you better in the future, we'd love to hear about your experience with our support team.",
-                            'type' => 'text',
-                        ],
-                    ],
-                ],
-                [
-                    'type' => 'tiptapBlock',
-                    'attrs' => [
-                        'data' => [
-                            'alignment' => 'center',
-                            'take_survey' => 'Take Survey',
-                        ],
-                        'type' => 'surveyResponseEmailTemplateTakeSurveyButtonBlock',
-                    ],
-                ],
-                [
-                    'type' => 'paragraph',
-                    'attrs' => [
-                        'class' => null,
-                        'style' => null,
-                        'textAlign' => 'start',
-                    ],
-                    'content' => [
-                        ['type' => 'hardBreak'],
-                        [
-                            'text' => 'We appreciate your time and we value your feedback!',
-                            'type' => 'text',
-                        ],
-                        ['type' => 'hardBreak'],
-                        [
-                            'text' => 'Thank You.',
-                            'type' => 'text',
-                        ],
-                        ['type' => 'hardBreak'],
-                    ],
-                ],
-            ],
-        ];
+            ];
 
-        $subjectJson = json_encode($subject);
-        $bodyJson = json_encode($body);
+            $body = [
+                'type' => 'doc',
+                'content' => [
+                    [
+                        'type' => 'paragraph',
+                        'attrs' => [
+                            'class' => null,
+                            'style' => null,
+                            'textAlign' => 'start',
+                        ],
+                        'content' => [
+                            [
+                                'text' => 'Hi ',
+                                'type' => 'text',
+                                'marks' => [
+                                    ['type' => 'bold'],
+                                ],
+                            ],
+                            [
+                                'type' => 'mergeTag',
+                                'attrs' => ['id' => 'assigned to'],
+                                'marks' => [
+                                    ['type' => 'bold'],
+                                ],
+                            ],
+                            [
+                                'text' => ',',
+                                'type' => 'text',
+                                'marks' => [
+                                    ['type' => 'bold'],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'paragraph',
+                        'attrs' => [
+                            'class' => null,
+                            'style' => null,
+                            'textAlign' => 'start',
+                        ],
+                        'content' => [
+                            [
+                                'text' => "To help us serve you better in the future, we'd love to hear about your experience with our support team.",
+                                'type' => 'text',
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'tiptapBlock',
+                        'attrs' => [
+                            'data' => [
+                                'alignment' => 'center',
+                                'take_survey' => 'Take Survey',
+                            ],
+                            'type' => 'surveyResponseEmailTemplateTakeSurveyButtonBlock',
+                        ],
+                    ],
+                    [
+                        'type' => 'paragraph',
+                        'attrs' => [
+                            'class' => null,
+                            'style' => null,
+                            'textAlign' => 'start',
+                        ],
+                        'content' => [
+                            ['type' => 'hardBreak'],
+                            [
+                                'text' => 'We appreciate your time and we value your feedback!',
+                                'type' => 'text',
+                            ],
+                            ['type' => 'hardBreak'],
+                            [
+                                'text' => 'Thank You.',
+                                'type' => 'text',
+                            ],
+                            ['type' => 'hardBreak'],
+                        ],
+                    ],
+                ],
+            ];
 
-        DB::transaction(function () use ($subjectJson, $bodyJson) {
+            $subjectJson = json_encode($subject);
+            $bodyJson = json_encode($body);
+
             DB::table('service_request_types')->orderBy('id')->chunkById(100, function ($types) use ($subjectJson, $bodyJson) {
                 foreach ($types as $type) {
                     $existing = DB::table('service_request_type_email_templates')->where([

--- a/app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php
+++ b/app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php
@@ -1,0 +1,158 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        $subject = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'attrs' => [
+                        'class' => null,
+                        'style' => null,
+                        'textAlign' => 'start',
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'Feedback survey for ',
+                            'type' => 'text',
+                        ],
+                        [
+                            'type' => 'mergeTag',
+                            'attrs' => ['id' => 'service request number'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $body = [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'attrs' => [
+                        'class' => null,
+                        'style' => null,
+                        'textAlign' => 'start',
+                    ],
+                    'content' => [
+                        [
+                            'text' => 'Hi ',
+                            'type' => 'text',
+                            'marks' => [
+                                ['type' => 'bold'],
+                            ],
+                        ],
+                        [
+                            'type' => 'mergeTag',
+                            'attrs' => ['id' => 'assigned to'],
+                            'marks' => [
+                                ['type' => 'bold'],
+                            ],
+                        ],
+                        [
+                            'text' => ',',
+                            'type' => 'text',
+                            'marks' => [
+                                ['type' => 'bold'],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'attrs' => [
+                        'class' => null,
+                        'style' => null,
+                        'textAlign' => 'start',
+                    ],
+                    'content' => [
+                        [
+                            'text' => "To help us serve you better in the future, we'd love to hear about your experience with our support team.",
+                            'type' => 'text',
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'tiptapBlock',
+                    'attrs' => [
+                        'data' => [
+                            'alignment' => 'center',
+                            'take_survey' => 'Take Survey',
+                        ],
+                        'type' => 'surveyResponseEmailTemplateTakeSurveyButtonBlock',
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'attrs' => [
+                        'class' => null,
+                        'style' => null,
+                        'textAlign' => 'start',
+                    ],
+                    'content' => [
+                        ['type' => 'hardBreak'],
+                        [
+                            'text' => 'We appreciate your time and we value your feedback!',
+                            'type' => 'text',
+                        ],
+                        ['type' => 'hardBreak'],
+                        [
+                            'text' => 'Thank You.',
+                            'type' => 'text',
+                        ],
+                        ['type' => 'hardBreak'],
+                    ],
+                ],
+            ],
+        ];
+
+        $subjectJson = json_encode($subject);
+        $bodyJson = json_encode($body);
+
+        DB::transaction(function () use ($subjectJson, $bodyJson) {
+            DB::table('service_request_types')->orderBy('id')->chunkById(100, function ($types) use ($subjectJson, $bodyJson) {
+                foreach ($types as $type) {
+                    $existing = DB::table('service_request_type_email_templates')->where([
+                        'service_request_type_id' => $type->id,
+                        'type' => 'survey_response',
+                        'role' => 'customer',
+                    ])->first();
+
+                    if ($existing) {
+                        DB::table('service_request_type_email_templates')->where('id', $existing->id)->update([
+                            'subject' => $subjectJson,
+                            'body' => $bodyJson,
+                            'updated_at' => now(),
+                        ]);
+                    } else {
+                        DB::table('service_request_type_email_templates')->insert([
+                            'id' => (string) Str::orderedUuid(),
+                            'service_request_type_id' => $type->id,
+                            'type' => 'survey_response',
+                            'role' => 'customer',
+                            'subject' => $subjectJson,
+                            'body' => $bodyJson,
+                            'created_at' => now(),
+                            'updated_at' => now(),
+                        ]);
+                    }
+                }
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::table('service_request_type_email_templates')
+            ->where('type', 'survey_response')
+            ->where('role', 'customer')
+            ->delete();
+    }
+};

--- a/app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php
+++ b/app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php
@@ -7,6 +7,20 @@ use Illuminate\Support\Str;
 return new class () extends Migration {
     public function up(): void
     {
+        DB::transaction(function () {
+            $table = 'service_request_type_email_templates';
+            $chunkSize = 100;
+            DB::table($table)
+                ->where('type', 'survey_response')
+                ->whereIn('role', ['auditor', 'manager'])
+                ->orderBy('id')
+                ->chunkById($chunkSize, function ($records) use ($table) {
+                    foreach ($records as $record) {
+                        DB::table($table)->where('id', $record->id)->delete();
+                    }
+                });
+        });
+
         $subject = [
             'type' => 'doc',
             'content' => [

--- a/app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php
+++ b/app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;

--- a/app-modules/service-management/resources/views/blocks/previews/take-survey-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/previews/take-survey-link.blade.php
@@ -1,3 +1,36 @@
+{{--
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+--}}
 <div style="text-align: {{ $alignment }}">
     <a
         href="{{ $url ?? '#' }}"

--- a/app-modules/service-management/resources/views/blocks/previews/take-survey-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/previews/take-survey-link.blade.php
@@ -1,0 +1,21 @@
+<div style="text-align: {{ $alignment }}">
+    <a
+        href="{{ $url ?? '#' }}"
+        style="display: inline-block; 
+               border-width: 8px; 
+               border-color: #3B82F6; 
+               background-color: #3B82F6; 
+               padding: 0.50rem 1rem;
+               font-size: 0.875rem; 
+               font-weight: 700; 
+               color: white; 
+               transition: border-color 0.3s ease, background-color 0.3s ease; 
+               text-decoration: none; 
+               border-radius: 0.375rem; 
+               cursor: pointer; 
+               box-sizing: border-box;"
+        target="_blank"
+    >
+        {{ $take_survey }}
+    </a>
+</div>

--- a/app-modules/service-management/resources/views/blocks/previews/take-survey-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/previews/take-survey-link.blade.php
@@ -16,6 +16,6 @@
                box-sizing: border-box;"
         target="_blank"
     >
-        {{ $take_survey }}
+        {{ $label }}
     </a>
 </div>

--- a/app-modules/service-management/resources/views/blocks/previews/take-survey-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/previews/take-survey-link.blade.php
@@ -16,6 +16,6 @@
                box-sizing: border-box;"
         target="_blank"
     >
-        {{ $label }}
+        {{ $label ?? 'Take Survey' }}
     </a>
 </div>

--- a/app-modules/service-management/resources/views/blocks/rendered/take-survey-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/rendered/take-survey-link.blade.php
@@ -1,3 +1,36 @@
+{{--
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+--}}
 <div style="text-align: {{ $alignment }}">
     <a
         href="{{ $url ?? '#' }}"

--- a/app-modules/service-management/resources/views/blocks/rendered/take-survey-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/rendered/take-survey-link.blade.php
@@ -1,0 +1,21 @@
+<div style="text-align: {{ $alignment }}">
+    <a
+        href="{{ $url ?? '#' }}"
+        style="display: inline-block; 
+               border-width: 8px; 
+               border-color: #3B82F6; 
+               background-color: #3B82F6; 
+               padding: 0.50rem 1rem;
+               font-size: 0.875rem; 
+               font-weight: 700; 
+               color: white; 
+               transition: border-color 0.3s ease, background-color 0.3s ease; 
+               text-decoration: none; 
+               border-radius: 0.375rem; 
+               cursor: pointer; 
+               box-sizing: border-box;"
+        target="_blank"
+    >
+        {{ $take_survey }}
+    </a>
+</div>

--- a/app-modules/service-management/resources/views/blocks/rendered/take-survey-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/rendered/take-survey-link.blade.php
@@ -16,6 +16,6 @@
                box-sizing: border-box;"
         target="_blank"
     >
-        {{ $take_survey }}
+        {{ $label }}
     </a>
 </div>

--- a/app-modules/service-management/resources/views/blocks/rendered/take-survey-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/rendered/take-survey-link.blade.php
@@ -16,6 +16,6 @@
                box-sizing: border-box;"
         target="_blank"
     >
-        {{ $label }}
+        {{ $label ?? 'Take Survey' }}
     </a>
 </div>

--- a/app-modules/service-management/resources/views/filament/resources/service-request-type-resource/pages/edit-service-request-type-notifications/matrix.blade.php
+++ b/app-modules/service-management/resources/views/filament/resources/service-request-type-resource/pages/edit-service-request-type-notifications/matrix.blade.php
@@ -74,11 +74,11 @@
         'service_request_update' => 'Service Request Update',
         'service_request_status_change' => 'Service Request Status Change',
         'service_request_closed' => 'Service Request Closed',
-
-        /** TODO: Remove this condition and inline 'survey_response' in $events when the SurveyResponseTemplate feature flag is removed. **/
-        if (SurveyResponseTemplate::active()) {
-            $events['survey_response'] = 'Survey Response';
-        }
+        ...SurveyResponseTemplate::active()
+            ? [
+                'survey_response' => 'Survey Response',
+            ]
+            : [],
     ] as $eventSlug => $event)
             <div
                 class="flex flex-col divide-y divide-gray-950/5 dark:divide-white/10 xl:flex-row xl:divide-x xl:divide-y-0">

--- a/app-modules/service-management/resources/views/filament/resources/service-request-type-resource/pages/edit-service-request-type-notifications/matrix.blade.php
+++ b/app-modules/service-management/resources/views/filament/resources/service-request-type-resource/pages/edit-service-request-type-notifications/matrix.blade.php
@@ -116,12 +116,7 @@
                                             <span class="xl:sr-only">{{ $type }}</span>
                                         </label>
                                     @else
-                                        <div class="xl:flex xl:w-16 xl:justify-center xl:px-3 xl:py-2">
-                                            <input
-                                                type="hidden"
-                                                wire:model="{{ $statePath . '.is_' . $roleSlug . '_' . $eventSlug . '_' . $typeSlug . '_enabled' }}"
-                                            />
-                                        </div>
+                                        <div class="xl:flex xl:w-16 xl:justify-center xl:px-3 xl:py-2"></div>
                                     @endif
                                 @endforeach
                             </div>

--- a/app-modules/service-management/resources/views/filament/resources/service-request-type-resource/pages/edit-service-request-type-notifications/matrix.blade.php
+++ b/app-modules/service-management/resources/views/filament/resources/service-request-type-resource/pages/edit-service-request-type-notifications/matrix.blade.php
@@ -34,6 +34,7 @@
 
 @php
     use Illuminate\Support\HtmlString;
+    use App\Features\SurveyResponseTemplate;
 
     $isDisabled = $isDisabled();
     $statePath = $getStatePath();
@@ -73,7 +74,11 @@
         'service_request_update' => 'Service Request Update',
         'service_request_status_change' => 'Service Request Status Change',
         'service_request_closed' => 'Service Request Closed',
-        'survey_response' => 'Survey Response',
+
+        /** TODO: Remove this condition and inline 'survey_response' in $events when the SurveyResponseTemplate feature flag is removed. **/
+        if (SurveyResponseTemplate::active()) {
+            $events['survey_response'] = 'Survey Response';
+        }
     ] as $eventSlug => $event)
             <div
                 class="flex flex-col divide-y divide-gray-950/5 dark:divide-white/10 xl:flex-row xl:divide-x xl:divide-y-0">

--- a/app-modules/service-management/resources/views/filament/resources/service-request-type-resource/pages/edit-service-request-type-notifications/matrix.blade.php
+++ b/app-modules/service-management/resources/views/filament/resources/service-request-type-resource/pages/edit-service-request-type-notifications/matrix.blade.php
@@ -73,6 +73,7 @@
         'service_request_update' => 'Service Request Update',
         'service_request_status_change' => 'Service Request Status Change',
         'service_request_closed' => 'Service Request Closed',
+        'survey_response' => 'Survey Response',
     ] as $eventSlug => $event)
             <div
                 class="flex flex-col divide-y divide-gray-950/5 dark:divide-white/10 xl:flex-row xl:divide-x xl:divide-y-0">
@@ -94,18 +95,29 @@
                             <div
                                 class="grid h-full grid-cols-2 gap-1 divide-gray-950/5 dark:divide-white/10 xl:gap-0 xl:divide-x">
                                 @foreach (['email' => 'Email', 'notification' => 'App'] as $typeSlug => $type)
-                                    <label
-                                        class="flex items-center gap-2 xl:flex xl:w-16 xl:justify-center xl:px-3 xl:py-2"
-                                    >
-                                        <x-filament::input.checkbox
-                                            :disabled="$isDisabled"
-                                            :wire:model="$statePath . '.is_' . $roleSlug . '_' . $eventSlug . '_' . $typeSlug . '_enabled'"
-                                        />
+                                    @php
+                                        $isSurveyResponse = $eventSlug === 'survey_response';
+                                        $shouldShow = !(($isSurveyResponse && in_array($roleSlug, ['managers', 'auditors'])) || ($isSurveyResponse && $roleSlug === 'customers' && $typeSlug === 'notification'));
+                                    @endphp
 
-                                        <span class="xl:sr-only">
-                                            {{ $type }}
-                                        </span>
-                                    </label>
+                                    @if ($shouldShow)
+                                        <label
+                                            class="flex items-center gap-2 xl:flex xl:w-16 xl:justify-center xl:px-3 xl:py-2"
+                                        >
+                                            <x-filament::input.checkbox
+                                                :disabled="$isDisabled"
+                                                :wire:model="$statePath . '.is_' . $roleSlug . '_' . $eventSlug . '_' . $typeSlug . '_enabled'"
+                                            />
+                                            <span class="xl:sr-only">{{ $type }}</span>
+                                        </label>
+                                    @else
+                                        <div class="xl:flex xl:w-16 xl:justify-center xl:px-3 xl:py-2">
+                                            <input
+                                                type="hidden"
+                                                wire:model="{{ $statePath . '.is_' . $roleSlug . '_' . $eventSlug . '_' . $typeSlug . '_enabled' }}"
+                                            />
+                                        </div>
+                                    @endif
                                 @endforeach
                             </div>
                         </div>

--- a/app-modules/service-management/src/Actions/GenerateServiceRequestTypeEmailTemplateContent.php
+++ b/app-modules/service-management/src/Actions/GenerateServiceRequestTypeEmailTemplateContent.php
@@ -38,7 +38,6 @@ namespace AidingApp\ServiceManagement\Actions;
 
 use AidingApp\ServiceManagement\Filament\Blocks\ServiceRequestTypeEmailTemplateButtonBlock;
 use AidingApp\ServiceManagement\Filament\Blocks\SurveyResponseEmailTemplateTakeSurveyButtonBlock;
-use App\Features\SurveyResponseTemplate;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 
@@ -50,26 +49,13 @@ class GenerateServiceRequestTypeEmailTemplateContent
      */
     public function __invoke(string|array $content, array $mergeData, Model $record, string $recordAttribute): HtmlString
     {
-
-        /** TODO: When the SurveyResponseTemplate feature flag is removed, directly chain the full blocks array like below:
-        ->blocks([
-          ServiceRequestTypeEmailTemplateButtonBlock::class,
-          SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
-        ])
-        and remove the conditional logic below. **/
-        $blocks = [
-          ServiceRequestTypeEmailTemplateButtonBlock::class,
-          ...(
-              SurveyResponseTemplate::active()
-                  ? [SurveyResponseEmailTemplateTakeSurveyButtonBlock::class]
-                  : []
-          ),
-        ];
-
         $content = tiptap_converter()
             ->mergeTagsMap($mergeData)
             ->record($record, $recordAttribute)
-            ->blocks($blocks)
+            ->blocks([
+                ServiceRequestTypeEmailTemplateButtonBlock::class,
+                SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
+            ])
             ->asHTML($content);
 
         return str($content)->sanitizeHtml()->toHtmlString();

--- a/app-modules/service-management/src/Actions/GenerateServiceRequestTypeEmailTemplateContent.php
+++ b/app-modules/service-management/src/Actions/GenerateServiceRequestTypeEmailTemplateContent.php
@@ -38,6 +38,7 @@ namespace AidingApp\ServiceManagement\Actions;
 
 use AidingApp\ServiceManagement\Filament\Blocks\ServiceRequestTypeEmailTemplateButtonBlock;
 use AidingApp\ServiceManagement\Filament\Blocks\SurveyResponseEmailTemplateTakeSurveyButtonBlock;
+use App\Features\SurveyResponseTemplate;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 
@@ -49,13 +50,26 @@ class GenerateServiceRequestTypeEmailTemplateContent
      */
     public function __invoke(string|array $content, array $mergeData, Model $record, string $recordAttribute): HtmlString
     {
+
+        /** TODO: When the SurveyResponseTemplate feature flag is removed, directly chain the full blocks array like below:
+        ->blocks([
+          ServiceRequestTypeEmailTemplateButtonBlock::class,
+          SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
+        ])
+        and remove the conditional logic below. **/
+        $blocks = [
+          ServiceRequestTypeEmailTemplateButtonBlock::class,
+          ...(
+              SurveyResponseTemplate::active()
+                  ? [SurveyResponseEmailTemplateTakeSurveyButtonBlock::class]
+                  : []
+          ),
+        ];
+
         $content = tiptap_converter()
             ->mergeTagsMap($mergeData)
             ->record($record, $recordAttribute)
-            ->blocks([
-                ServiceRequestTypeEmailTemplateButtonBlock::class,
-                SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
-            ])
+            ->blocks($blocks)
             ->asHTML($content);
 
         return str($content)->sanitizeHtml()->toHtmlString();

--- a/app-modules/service-management/src/Actions/GenerateServiceRequestTypeEmailTemplateContent.php
+++ b/app-modules/service-management/src/Actions/GenerateServiceRequestTypeEmailTemplateContent.php
@@ -36,6 +36,8 @@
 
 namespace AidingApp\ServiceManagement\Actions;
 
+use AidingApp\ServiceManagement\Filament\Blocks\ServiceRequestTypeEmailTemplateButtonBlock;
+use AidingApp\ServiceManagement\Filament\Blocks\SurveyResponseEmailTemplateTakeSurveyButtonBlock;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 
@@ -50,6 +52,10 @@ class GenerateServiceRequestTypeEmailTemplateContent
         $content = tiptap_converter()
             ->mergeTagsMap($mergeData)
             ->record($record, $recordAttribute)
+            ->blocks([
+                ServiceRequestTypeEmailTemplateButtonBlock::class,
+                SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
+            ])
             ->asHTML($content);
 
         return str($content)->sanitizeHtml()->toHtmlString();

--- a/app-modules/service-management/src/Filament/Blocks/SurveyResponseEmailTemplateTakeSurveyButtonBlock.php
+++ b/app-modules/service-management/src/Filament/Blocks/SurveyResponseEmailTemplateTakeSurveyButtonBlock.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AidingApp\ServiceManagement\Filament\Blocks;
+
+use Filament\Forms\Components\Component;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use FilamentTiptapEditor\TiptapBlock;
+
+class SurveyResponseEmailTemplateTakeSurveyButtonBlock extends TiptapBlock
+{
+    public string $preview = 'service-management::blocks.previews.take-survey-link';
+
+    public string $rendered = 'service-management::blocks.rendered.take-survey-link';
+
+    public ?string $icon = null;
+
+    public ?string $label = 'Take Survey';
+
+    public string $width = 'md';
+
+    /**
+     * @return array<int, Component>
+     */
+    public function getFormSchema(): array
+    {
+        return [
+            TextInput::make('take_survey')
+                ->label('Take Survey')
+                ->required()
+                ->default('Take Survey')
+                ->placeholder('Enter the button text (e.g. Take Survey)'),
+
+            Select::make('alignment')
+                ->label('Alignment')
+                ->options([
+                    'left' => 'Left',
+                    'right' => 'Right',
+                    'center' => 'Center',
+                ])
+                ->default('center')
+                ->required()
+                ->placeholder('Enter the button alignment (e.g. left, right, center)'),
+        ];
+    }
+}

--- a/app-modules/service-management/src/Filament/Blocks/SurveyResponseEmailTemplateTakeSurveyButtonBlock.php
+++ b/app-modules/service-management/src/Filament/Blocks/SurveyResponseEmailTemplateTakeSurveyButtonBlock.php
@@ -59,7 +59,7 @@ class SurveyResponseEmailTemplateTakeSurveyButtonBlock extends TiptapBlock
     public function getFormSchema(): array
     {
         return [
-            TextInput::make('take_survey')
+            TextInput::make('label')
                 ->label('Button Label')
                 ->required()
                 ->default('Take Survey')

--- a/app-modules/service-management/src/Filament/Blocks/SurveyResponseEmailTemplateTakeSurveyButtonBlock.php
+++ b/app-modules/service-management/src/Filament/Blocks/SurveyResponseEmailTemplateTakeSurveyButtonBlock.php
@@ -60,7 +60,7 @@ class SurveyResponseEmailTemplateTakeSurveyButtonBlock extends TiptapBlock
     {
         return [
             TextInput::make('take_survey')
-                ->label('Take Survey')
+                ->label('Button Label')
                 ->required()
                 ->default('Take Survey')
                 ->placeholder('Enter the button text (e.g. Take Survey)'),

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/EditServiceRequestTypeNotifications.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/EditServiceRequestTypeNotifications.php
@@ -87,6 +87,7 @@ class EditServiceRequestTypeNotifications extends EditRecord
                     'service_request_update',
                     'service_request_status_change',
                     'service_request_closed',
+                    'survey_response',
                 ] as $event
             ) {
                 $attributes[] = "is_{$role}_{$event}_email_enabled";

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/ServiceRequestTypeEmailTemplatePage.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/ServiceRequestTypeEmailTemplatePage.php
@@ -149,10 +149,10 @@ class ServiceRequestTypeEmailTemplatePage extends EditRecord
                 ->placeholder('Enter the email body here...')
                 ->extraInputAttributes(['style' => 'min-height: 12rem;'])
                 ->mergeTags(['service request number', 'created date', 'updated date', 'status', 'assigned to', 'title', 'description', 'type'])
-                // ->blocks([
-                //     ServiceRequestTypeEmailTemplateButtonBlock::class,
-                //     SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
-                // ])
+                ->blocks([
+                    ServiceRequestTypeEmailTemplateButtonBlock::class,
+                    SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
+                ])
                 ->columnSpanFull(),
         ];
     }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/ServiceRequestTypeEmailTemplatePage.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/ServiceRequestTypeEmailTemplatePage.php
@@ -39,6 +39,7 @@ namespace AidingApp\ServiceManagement\Filament\Resources\ServiceRequestTypeResou
 use AidingApp\ServiceManagement\Enums\ServiceRequestEmailTemplateType;
 use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
 use AidingApp\ServiceManagement\Filament\Blocks\ServiceRequestTypeEmailTemplateButtonBlock;
+use AidingApp\ServiceManagement\Filament\Blocks\SurveyResponseEmailTemplateTakeSurveyButtonBlock;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestTypeResource;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use AidingApp\ServiceManagement\Models\ServiceRequestTypeEmailTemplate;
@@ -72,6 +73,12 @@ class ServiceRequestTypeEmailTemplatePage extends EditRecord
 
     public function form(Form $form): Form
     {
+        $roles = ServiceRequestTypeEmailTemplateRole::cases();
+
+        if ($this->type === ServiceRequestEmailTemplateType::SurveyResponse) {
+            $roles = [ServiceRequestTypeEmailTemplateRole::Customer];
+        }
+
         return $form
             ->schema([
                 Tabs::make('Email template roles')
@@ -81,7 +88,7 @@ class ServiceRequestTypeEmailTemplatePage extends EditRecord
                         fn (ServiceRequestTypeEmailTemplateRole $role) => Tab::make($role->getLabel())
                             ->schema($this->getEmailTemplateFormSchema())
                             ->statePath($role->value),
-                        ServiceRequestTypeEmailTemplateRole::cases()
+                        $roles
                     ))
                     ->columnSpanFull(),
             ]);
@@ -142,9 +149,10 @@ class ServiceRequestTypeEmailTemplatePage extends EditRecord
                 ->placeholder('Enter the email body here...')
                 ->extraInputAttributes(['style' => 'min-height: 12rem;'])
                 ->mergeTags(['service request number', 'created date', 'updated date', 'status', 'assigned to', 'title', 'description', 'type'])
-                ->blocks([
-                    ServiceRequestTypeEmailTemplateButtonBlock::class,
-                ])
+                // ->blocks([
+                //     ServiceRequestTypeEmailTemplateButtonBlock::class,
+                //     SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
+                // ])
                 ->columnSpanFull(),
         ];
     }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/ServiceRequestTypeEmailTemplatePage.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestTypeResource/Pages/ServiceRequestTypeEmailTemplatePage.php
@@ -44,6 +44,7 @@ use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestTypeResource;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use AidingApp\ServiceManagement\Models\ServiceRequestTypeEmailTemplate;
 use App\Concerns\EditPageRedirection;
+use App\Features\SurveyResponseTemplate;
 use Filament\Forms\Components\Tabs;
 use Filament\Forms\Components\Tabs\Tab;
 use Filament\Forms\Form;
@@ -75,7 +76,7 @@ class ServiceRequestTypeEmailTemplatePage extends EditRecord
     {
         $roles = ServiceRequestTypeEmailTemplateRole::cases();
 
-        if ($this->type === ServiceRequestEmailTemplateType::SurveyResponse) {
+        if (SurveyResponseTemplate::active() && $this->type === ServiceRequestEmailTemplateType::SurveyResponse) {
             $roles = [ServiceRequestTypeEmailTemplateRole::Customer];
         }
 

--- a/app-modules/service-management/src/Models/ServiceRequestType.php
+++ b/app-modules/service-management/src/Models/ServiceRequestType.php
@@ -102,6 +102,8 @@ class ServiceRequestType extends BaseModel implements Auditable
         'is_customers_service_request_status_change_notification_enabled',
         'is_customers_service_request_closed_email_enabled',
         'is_customers_service_request_closed_notification_enabled',
+        'is_customers_service_request_closed_notification_enabled',
+        'is_customers_survey_response_email_enabled',
     ];
 
     protected $casts = [
@@ -139,6 +141,7 @@ class ServiceRequestType extends BaseModel implements Auditable
         'is_customers_service_request_status_change_notification_enabled' => 'boolean',
         'is_customers_service_request_closed_email_enabled' => 'boolean',
         'is_customers_service_request_closed_notification_enabled' => 'boolean',
+        'is_customers_survey_response_email_enabled' => 'boolean',
     ];
 
     public function serviceRequests(): HasManyThrough

--- a/app-modules/service-management/src/Notifications/Concerns/HandlesServiceRequestTemplateContent.php
+++ b/app-modules/service-management/src/Notifications/Concerns/HandlesServiceRequestTemplateContent.php
@@ -40,8 +40,6 @@ use AidingApp\ServiceManagement\Actions\GenerateServiceRequestTypeEmailTemplateC
 use AidingApp\ServiceManagement\Actions\GenerateServiceRequestTypeEmailTemplateSubject;
 use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource;
-use Exception;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\HtmlString;
 
 trait HandlesServiceRequestTemplateContent
@@ -125,7 +123,7 @@ trait HandlesServiceRequestTemplateContent
 
             return $block;
         }, $content['content']);
-        
+
         return $content;
     }
 }

--- a/app-modules/service-management/src/Notifications/Concerns/HandlesServiceRequestTemplateContent.php
+++ b/app-modules/service-management/src/Notifications/Concerns/HandlesServiceRequestTemplateContent.php
@@ -40,6 +40,7 @@ use AidingApp\ServiceManagement\Actions\GenerateServiceRequestTypeEmailTemplateC
 use AidingApp\ServiceManagement\Actions\GenerateServiceRequestTypeEmailTemplateSubject;
 use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource;
+use App\Features\SurveyResponseTemplate;
 use Illuminate\Support\HtmlString;
 
 trait HandlesServiceRequestTemplateContent
@@ -112,7 +113,8 @@ trait HandlesServiceRequestTemplateContent
                 ]);
             }
 
-            if ($block['type'] === 'tiptapBlock' &&
+            if (SurveyResponseTemplate::active() &&
+                $block['type'] === 'tiptapBlock' &&
                 ($block['attrs']['type'] ?? null) === 'surveyResponseEmailTemplateTakeSurveyButtonBlock') {
                 $block['attrs']['data']['url'] = route('feedback.service.request', $this->serviceRequest);
             }

--- a/app-modules/service-management/src/Notifications/Concerns/HandlesServiceRequestTemplateContent.php
+++ b/app-modules/service-management/src/Notifications/Concerns/HandlesServiceRequestTemplateContent.php
@@ -40,6 +40,8 @@ use AidingApp\ServiceManagement\Actions\GenerateServiceRequestTypeEmailTemplateC
 use AidingApp\ServiceManagement\Actions\GenerateServiceRequestTypeEmailTemplateSubject;
 use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestResource;
+use Exception;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\HtmlString;
 
 trait HandlesServiceRequestTemplateContent
@@ -112,13 +114,18 @@ trait HandlesServiceRequestTemplateContent
                 ]);
             }
 
+            if ($block['type'] === 'tiptapBlock' &&
+                ($block['attrs']['type'] ?? null) === 'surveyResponseEmailTemplateTakeSurveyButtonBlock') {
+                $block['attrs']['data']['url'] = route('feedback.service.request', $this->serviceRequest);
+            }
+
             if (isset($block['content']) && is_array($block['content'])) {
                 $block = $this->injectButtonUrlIntoTiptapContent($block);
             }
 
             return $block;
         }, $content['content']);
-
+        
         return $content;
     }
 }

--- a/app-modules/service-management/src/Notifications/SendClosedServiceFeedbackNotification.php
+++ b/app-modules/service-management/src/Notifications/SendClosedServiceFeedbackNotification.php
@@ -73,7 +73,7 @@ class SendClosedServiceFeedbackNotification extends Notification implements Shou
     public function toMail(object $notifiable): MailMessage
     {
         $template = $this->emailTemplate;
-        
+
         /** @var Educatable $educatable */
         $educatable = $notifiable;
 
@@ -82,14 +82,14 @@ class SendClosedServiceFeedbackNotification extends Notification implements Shou
         };
 
         if (! $template) {
-          return MailMessage::make()
-            ->settings($this->resolveNotificationSetting($notifiable))
-            ->subject("Feedback survey for {$this->serviceRequest->service_request_number}")
-            ->greeting("Hi {$name},")
-            ->line('To help us serve you better in the future, we’d love to hear about your experience with our support team.')
-            ->action('Rate Service', route('feedback.service.request', $this->serviceRequest->id))
-            ->line('We appreciate your time and we value your feedback!')
-            ->salutation('Thank you.');
+            return MailMessage::make()
+                ->settings($this->resolveNotificationSetting($notifiable))
+                ->subject("Feedback survey for {$this->serviceRequest->service_request_number}")
+                ->greeting("Hi {$name},")
+                ->line('To help us serve you better in the future, we’d love to hear about your experience with our support team.')
+                ->action('Rate Service', route('feedback.service.request', $this->serviceRequest->id))
+                ->line('We appreciate your time and we value your feedback!')
+                ->salutation('Thank you.');
         }
 
         $subject = $this->getSubject($template->subject);

--- a/app-modules/service-management/src/Notifications/SendClosedServiceFeedbackNotification.php
+++ b/app-modules/service-management/src/Notifications/SendClosedServiceFeedbackNotification.php
@@ -59,7 +59,7 @@ class SendClosedServiceFeedbackNotification extends Notification implements Shou
 
     public function __construct(
         protected ServiceRequest $serviceRequest,
-        public ?ServiceRequestTypeEmailTemplate $emailTemplate,
+        public ?ServiceRequestTypeEmailTemplate $emailTemplate = null, // TODO: When the SurveyResponseTemplate feature flag is removed, then remove the `= null` default.
     ) {}
 
     /**

--- a/app-modules/service-management/src/Notifications/SendClosedServiceFeedbackNotification.php
+++ b/app-modules/service-management/src/Notifications/SendClosedServiceFeedbackNotification.php
@@ -43,6 +43,8 @@ use AidingApp\Notification\Models\Contracts\Message;
 use AidingApp\Notification\Notifications\Contracts\HasBeforeSendHook;
 use AidingApp\Notification\Notifications\Messages\MailMessage;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestTypeEmailTemplate;
+use AidingApp\ServiceManagement\Notifications\Concerns\HandlesServiceRequestTemplateContent;
 use App\Models\Contracts\Educatable;
 use App\Models\NotificationSetting;
 use Illuminate\Bus\Queueable;
@@ -53,9 +55,11 @@ use Illuminate\Notifications\Notification;
 class SendClosedServiceFeedbackNotification extends Notification implements ShouldQueue, HasBeforeSendHook
 {
     use Queueable;
+    use HandlesServiceRequestTemplateContent;
 
     public function __construct(
         protected ServiceRequest $serviceRequest,
+        public ?ServiceRequestTypeEmailTemplate $emailTemplate,
     ) {}
 
     /**
@@ -68,6 +72,8 @@ class SendClosedServiceFeedbackNotification extends Notification implements Shou
 
     public function toMail(object $notifiable): MailMessage
     {
+        $template = $this->emailTemplate;
+        
         /** @var Educatable $educatable */
         $educatable = $notifiable;
 
@@ -75,7 +81,8 @@ class SendClosedServiceFeedbackNotification extends Notification implements Shou
             Contact::class => $educatable->first_name,
         };
 
-        return MailMessage::make()
+        if (! $template) {
+          return MailMessage::make()
             ->settings($this->resolveNotificationSetting($notifiable))
             ->subject("Feedback survey for {$this->serviceRequest->service_request_number}")
             ->greeting("Hi {$name},")
@@ -83,6 +90,18 @@ class SendClosedServiceFeedbackNotification extends Notification implements Shou
             ->action('Rate Service', route('feedback.service.request', $this->serviceRequest->id))
             ->line('We appreciate your time and we value your feedback!')
             ->salutation('Thank you.');
+        }
+
+        $subject = $this->getSubject($template->subject);
+
+        $body = $this->getBody($template->body);
+
+        $test = MailMessage::make()
+            ->settings($this->resolveNotificationSetting($notifiable))
+            ->subject(strip_tags($subject))
+            ->content($body);
+
+        return $test;
     }
 
     public function beforeSend(AnonymousNotifiable|CanBeNotified $notifiable, Message $message, NotificationChannel $channel): void

--- a/app-modules/service-management/src/Observers/ServiceRequestObserver.php
+++ b/app-modules/service-management/src/Observers/ServiceRequestObserver.php
@@ -169,12 +169,6 @@ class ServiceRequestObserver
             $serviceRequest->respondent->notify(new SendEducatableServiceRequestClosedNotification($serviceRequest, $customerEmailTemplate));
         }
 
-        $customerEmailTemplateForSurveyResponse = $this->fetchTemplate(
-            $serviceRequest->priority->type,
-            ServiceRequestEmailTemplateType::SurveyResponse,
-            ServiceRequestTypeEmailTemplateRole::Customer
-        );
-
         if (
             Gate::check(Feature::FeedbackManagement->getGateName()) &&
             $serviceRequest?->priority?->type?->has_enabled_feedback_collection &&
@@ -182,6 +176,12 @@ class ServiceRequestObserver
             ! $serviceRequest?->feedback()->count()
         ) {
             if(SurveyResponseTemplate::active() && $serviceRequest->priority->type->is_customers_survey_response_email_enabled) {
+                $customerEmailTemplateForSurveyResponse = $this->fetchTemplate(
+                    $serviceRequest->priority->type,
+                    ServiceRequestEmailTemplateType::SurveyResponse,
+                    ServiceRequestTypeEmailTemplateRole::Customer
+                );
+                
                 $serviceRequest->respondent->notify(new SendClosedServiceFeedbackNotification($serviceRequest, $customerEmailTemplateForSurveyResponse));
             } else {
                 $serviceRequest->respondent->notify(new SendClosedServiceFeedbackNotification($serviceRequest));

--- a/app-modules/service-management/src/Observers/ServiceRequestObserver.php
+++ b/app-modules/service-management/src/Observers/ServiceRequestObserver.php
@@ -175,13 +175,13 @@ class ServiceRequestObserver
             $serviceRequest?->status?->classification == SystemServiceRequestClassification::Closed &&
             ! $serviceRequest?->feedback()->count()
         ) {
-            if(SurveyResponseTemplate::active() && $serviceRequest->priority->type->is_customers_survey_response_email_enabled) {
+            if (SurveyResponseTemplate::active() && $serviceRequest->priority->type->is_customers_survey_response_email_enabled) {
                 $customerEmailTemplateForSurveyResponse = $this->fetchTemplate(
                     $serviceRequest->priority->type,
                     ServiceRequestEmailTemplateType::SurveyResponse,
                     ServiceRequestTypeEmailTemplateRole::Customer
                 );
-                
+
                 $serviceRequest->respondent->notify(new SendClosedServiceFeedbackNotification($serviceRequest, $customerEmailTemplateForSurveyResponse));
             } else {
                 $serviceRequest->respondent->notify(new SendClosedServiceFeedbackNotification($serviceRequest));

--- a/app-modules/service-management/src/Observers/ServiceRequestObserver.php
+++ b/app-modules/service-management/src/Observers/ServiceRequestObserver.php
@@ -59,7 +59,6 @@ use App\Enums\Feature;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Log;
 
 class ServiceRequestObserver
 {
@@ -179,7 +178,7 @@ class ServiceRequestObserver
             Gate::check(Feature::FeedbackManagement->getGateName()) &&
             $serviceRequest?->priority?->type?->has_enabled_feedback_collection &&
             $serviceRequest?->status?->classification == SystemServiceRequestClassification::Closed &&
-            $serviceRequest->priority?->type->is_customers_survey_response_email_enabled &&
+            $serviceRequest->priority->type->is_customers_survey_response_email_enabled &&
             ! $serviceRequest?->feedback()->count()
         ) {
             $serviceRequest->respondent->notify(new SendClosedServiceFeedbackNotification($serviceRequest, $customerEmailTemplateForSurveyResponse));

--- a/app-modules/service-management/src/Providers/ServiceManagementServiceProvider.php
+++ b/app-modules/service-management/src/Providers/ServiceManagementServiceProvider.php
@@ -36,6 +36,8 @@
 
 namespace AidingApp\ServiceManagement\Providers;
 
+use AidingApp\ServiceManagement\Filament\Blocks\ServiceRequestTypeEmailTemplateButtonBlock;
+use AidingApp\ServiceManagement\Filament\Blocks\SurveyResponseEmailTemplateTakeSurveyButtonBlock;
 use AidingApp\ServiceManagement\Models\ChangeRequest;
 use AidingApp\ServiceManagement\Models\ChangeRequestResponse;
 use AidingApp\ServiceManagement\Models\ChangeRequestStatus;
@@ -64,6 +66,7 @@ use AidingApp\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceR
 use AidingApp\ServiceManagement\Services\ServiceRequestNumber\SqidPlusSixServiceRequestNumberGenerator;
 use App\Concerns\ImplementsGraphQL;
 use Filament\Panel;
+use FilamentTiptapEditor\TiptapEditor;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\ServiceProvider;
 
@@ -74,6 +77,14 @@ class ServiceManagementServiceProvider extends ServiceProvider
     public function register(): void
     {
         Panel::configureUsing(fn (Panel $panel) => ($panel->getId() !== 'admin') || $panel->plugin(new ServiceManagementPlugin()));
+
+        TiptapEditor::configureUsing(function (TiptapEditor $component) {
+            $component
+                ->blocks([
+                    ServiceRequestTypeEmailTemplateButtonBlock::class,
+                    SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
+                ]);
+        });
 
         $this->app->bind(ServiceRequestNumberGenerator::class, SqidPlusSixServiceRequestNumberGenerator::class);
     }

--- a/app-modules/service-management/src/Providers/ServiceManagementServiceProvider.php
+++ b/app-modules/service-management/src/Providers/ServiceManagementServiceProvider.php
@@ -36,8 +36,6 @@
 
 namespace AidingApp\ServiceManagement\Providers;
 
-use AidingApp\ServiceManagement\Filament\Blocks\ServiceRequestTypeEmailTemplateButtonBlock;
-use AidingApp\ServiceManagement\Filament\Blocks\SurveyResponseEmailTemplateTakeSurveyButtonBlock;
 use AidingApp\ServiceManagement\Models\ChangeRequest;
 use AidingApp\ServiceManagement\Models\ChangeRequestResponse;
 use AidingApp\ServiceManagement\Models\ChangeRequestStatus;
@@ -66,7 +64,6 @@ use AidingApp\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceR
 use AidingApp\ServiceManagement\Services\ServiceRequestNumber\SqidPlusSixServiceRequestNumberGenerator;
 use App\Concerns\ImplementsGraphQL;
 use Filament\Panel;
-use FilamentTiptapEditor\TiptapEditor;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\ServiceProvider;
 
@@ -77,14 +74,6 @@ class ServiceManagementServiceProvider extends ServiceProvider
     public function register(): void
     {
         Panel::configureUsing(fn (Panel $panel) => ($panel->getId() !== 'admin') || $panel->plugin(new ServiceManagementPlugin()));
-
-        TiptapEditor::configureUsing(function (TiptapEditor $component) {
-            $component
-                ->blocks([
-                    ServiceRequestTypeEmailTemplateButtonBlock::class,
-                    SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
-                ]);
-        });
 
         $this->app->bind(ServiceRequestNumberGenerator::class, SqidPlusSixServiceRequestNumberGenerator::class);
     }

--- a/app-modules/service-management/tests/ServiceRequest/EditServiceRequestTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/EditServiceRequestTest.php
@@ -364,6 +364,7 @@ test('send feedback email if service request is closed', function () {
         'has_enabled_feedback_collection' => true,
         'has_enabled_csat' => true,
         'has_enabled_nps' => true,
+        'is_customers_survey_response_email_enabled' => true,
     ]);
 
     $serviceRequestType->managers()->attach($team);

--- a/app-modules/service-management/tests/ServiceRequestType/ServiceRequestTypeEmailTemplatePageTest.php
+++ b/app-modules/service-management/tests/ServiceRequestType/ServiceRequestTypeEmailTemplatePageTest.php
@@ -57,7 +57,9 @@ test('it creates a ServiceRequestTypeEmailTemplate if it did not already exist',
 
     $type = collect(ServiceRequestEmailTemplateType::cases())->random();
 
-    $role = collect(ServiceRequestTypeEmailTemplateRole::cases())->random();
+    $role = $type === ServiceRequestEmailTemplateType::SurveyResponse
+              ? ServiceRequestTypeEmailTemplateRole::Customer
+              : collect(ServiceRequestTypeEmailTemplateRole::cases())->random();
 
     livewire(ServiceRequestTypeEmailTemplatePage::class, [
         'record' => $serviceRequestType->getKey(),
@@ -85,7 +87,6 @@ test('it updates a ServiceRequestTypeEmailTemplate if it already exists', functi
     asSuperAdmin();
 
     $request = ServiceRequestTypeEmailTemplateRequestFactory::new()->create();
-
     expect($emailTemplate->subject)->not->toEqualCanonicalizing($request['subject'])
         ->and($emailTemplate->body)->not->toEqualCanonicalizing($request['body']);
 
@@ -101,7 +102,6 @@ test('it updates a ServiceRequestTypeEmailTemplate if it already exists', functi
         ->assertHasNoFormErrors();
 
     $emailTemplate->refresh();
-
     expect($emailTemplate->subject)->toEqualCanonicalizing($request['subject'])
         ->and($emailTemplate->body)->toEqualCanonicalizing($request['body']);
 });

--- a/app/Features/SurveyResponseTemplate.php
+++ b/app/Features/SurveyResponseTemplate.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/app/Features/SurveyResponseTemplate.php
+++ b/app/Features/SurveyResponseTemplate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class SurveyResponseTemplate extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/database/migrations/2025_05_13_073325_data_activate_feature_flag_survey_response_template.php
+++ b/database/migrations/2025_05_13_073325_data_activate_feature_flag_survey_response_template.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Features\SurveyResponseTemplate;
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        SurveyResponseTemplate::activate();
+    }
+
+    public function down(): void
+    {
+        SurveyResponseTemplate::deactivate();
+    }
+};

--- a/database/migrations/2025_05_13_073325_data_activate_feature_flag_survey_response_template.php
+++ b/database/migrations/2025_05_13_073325_data_activate_feature_flag_survey_response_template.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\SurveyResponseTemplate;
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;

--- a/database/migrations/2025_05_13_073325_data_activate_feature_flag_survey_response_template.php
+++ b/database/migrations/2025_05_13_073325_data_activate_feature_flag_survey_response_template.php
@@ -36,11 +36,8 @@
 
 use App\Features\SurveyResponseTemplate;
 use Illuminate\Database\Migrations\Migration;
-use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
-use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         SurveyResponseTemplate::activate();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-578

### Technical Description

> Add survey response email functionality and UI components
- Introduced migration to add 'is_customers_survey_response_email_enabled' field to service_request_types table.
- Created new Blade components for survey response link previews and rendered views.
- Updated service request type notifications to include survey response options.
- Implemented survey response email template block for Filament.
- Enhanced service request observer to handle survey response notifications.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> Yes. Feature flag: `SurveyResponseTemplate`
Temporary data migration:
`app-modules/service-management/database/migrations/2025_05_12_101058_tmp_data_seed_for_survey_response_in_service_request_type_email_templates.php`

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
