### PR TITLE
[AIDAPP-586]: Introduce the ability to set a custom label on the button for viewing service requests in the email notification blocks for customers, managers, and auditors

### DIFF
--- a/app-modules/service-management/resources/views/blocks/previews/service-request-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/previews/service-request-link.blade.php
@@ -49,6 +49,6 @@
                box-sizing: border-box;"
         target="_blank"
     >
-        View Service Request
+        {{ $view_service_request ?? 'View Service Request' }}
     </a>
 </div>

--- a/app-modules/service-management/resources/views/blocks/previews/service-request-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/previews/service-request-link.blade.php
@@ -49,6 +49,6 @@
                box-sizing: border-box;"
         target="_blank"
     >
-        {{ $view_service_request ?? 'View Service Request' }}
+        {{ $label ?? 'View Service Request' }}
     </a>
 </div>

--- a/app-modules/service-management/resources/views/blocks/rendered/service-request-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/rendered/service-request-link.blade.php
@@ -49,6 +49,6 @@
                box-sizing: border-box;"
         target="_blank"
     >
-        View Service Request
+        {{ $view_service_request ?? 'View Service Request' }}
     </a>
 </div>

--- a/app-modules/service-management/resources/views/blocks/rendered/service-request-link.blade.php
+++ b/app-modules/service-management/resources/views/blocks/rendered/service-request-link.blade.php
@@ -49,6 +49,6 @@
                box-sizing: border-box;"
         target="_blank"
     >
-        {{ $view_service_request ?? 'View Service Request' }}
+        {{ $label ?? 'View Service Request' }}
     </a>
 </div>

--- a/app-modules/service-management/src/Filament/Blocks/ServiceRequestTypeEmailTemplateButtonBlock.php
+++ b/app-modules/service-management/src/Filament/Blocks/ServiceRequestTypeEmailTemplateButtonBlock.php
@@ -59,7 +59,7 @@ class ServiceRequestTypeEmailTemplateButtonBlock extends TiptapBlock
     public function getFormSchema(): array
     {
         return [
-            TextInput::make('view_service_request')
+            TextInput::make('label')
                 ->label('Button Label')
                 ->required()
                 ->default('View Service Request')

--- a/app-modules/service-management/src/Filament/Blocks/ServiceRequestTypeEmailTemplateButtonBlock.php
+++ b/app-modules/service-management/src/Filament/Blocks/ServiceRequestTypeEmailTemplateButtonBlock.php
@@ -38,6 +38,7 @@ namespace AidingApp\ServiceManagement\Filament\Blocks;
 
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use FilamentTiptapEditor\TiptapBlock;
 
 class ServiceRequestTypeEmailTemplateButtonBlock extends TiptapBlock
@@ -58,6 +59,12 @@ class ServiceRequestTypeEmailTemplateButtonBlock extends TiptapBlock
     public function getFormSchema(): array
     {
         return [
+            TextInput::make('view_service_request')
+                ->label('Button Label')
+                ->required()
+                ->default('View Service Request')
+                ->placeholder('Enter the button text (e.g. View Service Request)'),
+                
             Select::make('alignment')
                 ->label('Alignment')
                 ->options([

--- a/app-modules/service-management/src/Filament/Blocks/ServiceRequestTypeEmailTemplateButtonBlock.php
+++ b/app-modules/service-management/src/Filament/Blocks/ServiceRequestTypeEmailTemplateButtonBlock.php
@@ -64,7 +64,7 @@ class ServiceRequestTypeEmailTemplateButtonBlock extends TiptapBlock
                 ->required()
                 ->default('View Service Request')
                 ->placeholder('Enter the button text (e.g. View Service Request)'),
-                
+
             Select::make('alignment')
                 ->label('Alignment')
                 ->options([


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-586

### Technical Description

> Introduce the ability to set a custom label on the button for viewing service requests in the email notification blocks for customers, managers, and auditors.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
