### PR TITLE
[AIDAPP-571]: Implement a new portal navigation page for status

### DIFF
--- a/portals/knowledge-management/src/Components/Header.vue
+++ b/portals/knowledge-management/src/Components/Header.vue
@@ -91,6 +91,12 @@
             command: () => router.push({ name: 'services' }),
         },
         {
+            label: 'Status',
+            routeName: 'status',
+            visible: user !== null,
+            command: () => router.push({ name: 'status' }),
+        },
+        {
             label: 'Incidents',
             routeName: 'incidents',
             visible: user !== null,

--- a/portals/knowledge-management/src/portal.js
+++ b/portals/knowledge-management/src/portal.js
@@ -112,6 +112,12 @@ customElements.define(
                         meta: { requiresAuth: true },
                     },
                     {
+                        path: baseUrl + '/status',
+                        name: 'status',
+                        component: ComingSoon,
+                        meta: { requiresAuth: true },
+                    },
+                    {
                         path: baseUrl + '/incidents',
                         name: 'incidents',
                         component: ComingSoon,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-571

### Technical Description

> Show new navigation option 'Status' on portal navigation only if user is logged in.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
