### PR TITLE
[AIDAPP-582]: ServiceMonitoringCheckJob fails and throws an error if it's target requires more than 5 redirects

### DIFF
--- a/app-modules/service-management/src/Jobs/ServiceMonitoringCheckJob.php
+++ b/app-modules/service-management/src/Jobs/ServiceMonitoringCheckJob.php
@@ -80,7 +80,7 @@ class ServiceMonitoringCheckJob implements ShouldQueue, ShouldBeUnique
     public function handle(): void
     {
         $response = Http::maxRedirects(15)
-                          ->get($this->serviceMonitoringTarget->domain);
+            ->get($this->serviceMonitoringTarget->domain);
 
         $history = $this->serviceMonitoringTarget->histories()->create([
             'response' => $response->status(),

--- a/app-modules/service-management/src/Jobs/ServiceMonitoringCheckJob.php
+++ b/app-modules/service-management/src/Jobs/ServiceMonitoringCheckJob.php
@@ -79,7 +79,12 @@ class ServiceMonitoringCheckJob implements ShouldQueue, ShouldBeUnique
 
     public function handle(): void
     {
-        $response = Http::get($this->serviceMonitoringTarget->domain);
+        $response = Http::withOptions([
+                            'allow_redirects' => [
+                              'max' => 15,
+                            ],
+                          ])
+                          ->get($this->serviceMonitoringTarget->domain);
 
         $history = $this->serviceMonitoringTarget->histories()->create([
             'response' => $response->status(),

--- a/app-modules/service-management/src/Jobs/ServiceMonitoringCheckJob.php
+++ b/app-modules/service-management/src/Jobs/ServiceMonitoringCheckJob.php
@@ -79,11 +79,7 @@ class ServiceMonitoringCheckJob implements ShouldQueue, ShouldBeUnique
 
     public function handle(): void
     {
-        $response = Http::withOptions([
-                            'allow_redirects' => [
-                              'max' => 15,
-                            ],
-                          ])
+        $response = Http::maxRedirects(15)
                           ->get($this->serviceMonitoringTarget->domain);
 
         $history = $this->serviceMonitoringTarget->histories()->create([


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-582

### Technical Description

> Fixed: ServiceMonitoringCheckJob fails and throws an error if it's target requires more than 5 redirects.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
