### PR TITLE
[AIDAPP-604]: Update all factories to use the local usage of faker and enforce this as an architecture test

### DIFF
--- a/app-modules/alert/database/factories/AlertFactory.php
+++ b/app-modules/alert/database/factories/AlertFactory.php
@@ -51,7 +51,7 @@ class AlertFactory extends Factory
     public function definition(): array
     {
         return [
-            'concern_type' => fake()->randomElement([(new Contact())->getMorphClass()]),
+            'concern_type' => $this->faker->randomElement([(new Contact())->getMorphClass()]),
             'concern_id' => function (array $attributes) {
                 $concernClass = Relation::getMorphedModel($attributes['concern_type']);
 
@@ -62,10 +62,10 @@ class AlertFactory extends Factory
 
                 return $concern->getKey();
             },
-            'description' => fake()->sentence(),
-            'severity' => fake()->randomElement(AlertSeverity::cases()),
-            'status' => fake()->randomElement(AlertStatus::cases()),
-            'suggested_intervention' => fake()->sentence(),
+            'description' => $this->faker->sentence(),
+            'severity' => $this->faker->randomElement(AlertSeverity::cases()),
+            'status' => $this->faker->randomElement(AlertStatus::cases()),
+            'suggested_intervention' => $this->faker->sentence(),
         ];
     }
 }

--- a/app-modules/authorization/database/factories/PermissionFactory.php
+++ b/app-modules/authorization/database/factories/PermissionFactory.php
@@ -46,8 +46,8 @@ class PermissionFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word,
-            'guard_name' => fake()->randomElement(['web', 'api']),
+            'name' => $this->faker->word,
+            'guard_name' => $this->faker->randomElement(['web', 'api']),
         ];
     }
 }

--- a/app-modules/authorization/database/factories/RoleFactory.php
+++ b/app-modules/authorization/database/factories/RoleFactory.php
@@ -47,7 +47,7 @@ class RoleFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->text(25),
+            'name' => $this->faker->text(25),
             'guard_name' => 'web',
         ];
     }

--- a/app-modules/contact/database/factories/ContactFactory.php
+++ b/app-modules/contact/database/factories/ContactFactory.php
@@ -49,9 +49,9 @@ class ContactFactory extends Factory
 {
     public function definition(): array
     {
-        $firstName = fake()->firstName();
-        $lastName = fake()->lastName();
-        $address3 = fake()->optional()->words(asText: true);
+        $firstName = $this->faker->firstName();
+        $lastName = $this->faker->lastName();
+        $address3 = $this->faker->optional()->words(asText: true);
 
         return [
             'status_id' => ContactStatus::inRandomOrder()->first() ?? ContactStatus::factory(),
@@ -59,19 +59,19 @@ class ContactFactory extends Factory
             'first_name' => $firstName,
             'last_name' => $lastName,
             'full_name' => "{$firstName} {$lastName}",
-            'preferred' => fake()->firstName(),
-            'description' => fake()->paragraph(),
-            'email' => fake()->unique()->email(),
-            'mobile' => fake()->e164PhoneNumber(),
-            'sms_opt_out' => fake()->boolean(),
-            'email_bounce' => fake()->boolean(),
-            'phone' => fake()->e164PhoneNumber(),
-            'address' => fake()->streetAddress(),
-            'address_2' => fake()->secondaryAddress(),
+            'preferred' => $this->faker->firstName(),
+            'description' => $this->faker->paragraph(),
+            'email' => $this->faker->unique()->email(),
+            'mobile' => $this->faker->e164PhoneNumber(),
+            'sms_opt_out' => $this->faker->boolean(),
+            'email_bounce' => $this->faker->boolean(),
+            'phone' => $this->faker->e164PhoneNumber(),
+            'address' => $this->faker->streetAddress(),
+            'address_2' => $this->faker->secondaryAddress(),
             'address_3' => $address3 ? str($address3)->headline()->toString() : null,
-            'city' => fake()->city(),
-            'state' => fake()->stateAbbr(),
-            'postal' => str(fake()->postcode())->before('-')->toString(),
+            'city' => $this->faker->city(),
+            'state' => $this->faker->stateAbbr(),
+            'postal' => str($this->faker->postcode())->before('-')->toString(),
             'assigned_to_id' => User::factory(),
             'created_by_id' => User::factory(),
         ];

--- a/app-modules/contact/database/factories/OrganizationFactory.php
+++ b/app-modules/contact/database/factories/OrganizationFactory.php
@@ -53,23 +53,23 @@ class OrganizationFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->company(),
-            'email' => fake()->companyEmail(),
-            'domains' => array_map(fn () => ['domain' => fake()->domainName()], range(1, 3)),
-            'phone_number' => fake()->e164PhoneNumber(),
-            'website' => fake()->url(),
+            'name' => $this->faker->company(),
+            'email' => $this->faker->companyEmail(),
+            'domains' => array_map(fn () => ['domain' => $this->faker->domainName()], range(1, 3)),
+            'phone_number' => $this->faker->e164PhoneNumber(),
+            'website' => $this->faker->url(),
             'industry_id' => OrganizationIndustry::factory(),
             'type_id' => OrganizationType::factory(),
-            'description' => fake()->text(),
-            'number_of_employees' => fake()->randomNumber(),
-            'address' => fake()->address(),
-            'city' => fake()->city(),
-            'state' => fake()->state(),
-            'postalcode' => fake()->postcode(),
-            'country' => fake()->country(),
-            'linkedin_url' => fake()->url(),
-            'facebook_url' => fake()->url(),
-            'twitter_url' => fake()->url(),
+            'description' => $this->faker->text(),
+            'number_of_employees' => $this->faker->randomNumber(),
+            'address' => $this->faker->address(),
+            'city' => $this->faker->city(),
+            'state' => $this->faker->state(),
+            'postalcode' => $this->faker->postcode(),
+            'country' => $this->faker->country(),
+            'linkedin_url' => $this->faker->url(),
+            'facebook_url' => $this->faker->url(),
+            'twitter_url' => $this->faker->url(),
         ];
     }
 }

--- a/app-modules/contact/database/factories/OrganizationIndustryFactory.php
+++ b/app-modules/contact/database/factories/OrganizationIndustryFactory.php
@@ -51,7 +51,7 @@ class OrganizationIndustryFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->word(),
+            'name' => $this->faker->unique()->word(),
         ];
     }
 }

--- a/app-modules/contact/database/factories/OrganizationTypeFactory.php
+++ b/app-modules/contact/database/factories/OrganizationTypeFactory.php
@@ -51,7 +51,7 @@ class OrganizationTypeFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->word(),
+            'name' => $this->faker->unique()->word(),
         ];
     }
 }

--- a/app-modules/contract-management/database/factories/ContractFactory.php
+++ b/app-modules/contract-management/database/factories/ContractFactory.php
@@ -54,16 +54,16 @@ class ContractFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->sentence(),
-            'description' => fake()->paragraph(),
+            'name' => $this->faker->sentence(),
+            'description' => $this->faker->paragraph(),
             'contract_type_id' => ContractType::factory(),
-            'vendor_name' => fake()->name(),
-            'start_date' => fake()->dateTimeBetween('-1 year', '+1 year'),
-            'end_date' => fn (array $attributes) => fake()->dateTimeBetween(
+            'vendor_name' => $this->faker->name(),
+            'start_date' => $this->faker->dateTimeBetween('-1 year', '+1 year'),
+            'end_date' => fn (array $attributes) => $this->faker->dateTimeBetween(
                 (clone $attributes['start_date'])->modify('+1 day'),
                 (clone $attributes['start_date'])->modify('+1 year')
             ),
-            'contract_value' => Money::parseByDecimal((string) fake()->randomNumber(), config('money.defaultCurrency')),
+            'contract_value' => Money::parseByDecimal((string) $this->faker->randomNumber(), config('money.defaultCurrency')),
         ];
     }
 }

--- a/app-modules/contract-management/database/factories/ContractTypeFactory.php
+++ b/app-modules/contract-management/database/factories/ContractTypeFactory.php
@@ -54,7 +54,7 @@ class ContractTypeFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
             'is_default' => false,
             'order' => $this->getNewOrder(),
         ];

--- a/app-modules/division/database/factories/DivisionFactory.php
+++ b/app-modules/division/database/factories/DivisionFactory.php
@@ -50,9 +50,9 @@ class DivisionFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->company(),
-            'code' => fake()->unique()->word(),
-            'description' => fake()->optional()->sentences(asText: true),
+            'name' => $this->faker->unique()->company(),
+            'code' => $this->faker->unique()->word(),
+            'description' => $this->faker->optional()->sentences(asText: true),
             'is_default' => false,
         ];
     }

--- a/app-modules/engagement/database/factories/EmailTemplateFactory.php
+++ b/app-modules/engagement/database/factories/EmailTemplateFactory.php
@@ -47,9 +47,9 @@ class EmailTemplateFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
-            'description' => fake()->sentence(),
-            'content' => fake()->paragraph(),
+            'name' => $this->faker->word(),
+            'description' => $this->faker->sentence(),
+            'content' => $this->faker->paragraph(),
         ];
     }
 }

--- a/app-modules/engagement/database/factories/EngagementBatchFactory.php
+++ b/app-modules/engagement/database/factories/EngagementBatchFactory.php
@@ -49,9 +49,9 @@ class EngagementBatchFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
-            'subject' => fake()->sentence,
-            'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->paragraph]]]]],
-            'scheduled_at' => fake()->dateTimeBetween('-1 year', '-1 day'),
+            'subject' => $this->faker->sentence,
+            'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->paragraph]]]]],
+            'scheduled_at' => $this->faker->dateTimeBetween('-1 year', '-1 day'),
             'channel' => NotificationChannel::Email,
         ];
     }
@@ -66,7 +66,7 @@ class EngagementBatchFactory extends Factory
     public function deliverLater(): self
     {
         return $this->state([
-            'scheduled_at' => fake()->dateTimeBetween('+1 day', '+1 week'),
+            'scheduled_at' => $this->faker->dateTimeBetween('+1 day', '+1 week'),
         ]);
     }
 

--- a/app-modules/engagement/database/factories/EngagementFactory.php
+++ b/app-modules/engagement/database/factories/EngagementFactory.php
@@ -54,9 +54,9 @@ class EngagementFactory extends Factory
             'user_id' => User::factory(),
             'recipient_type' => (new Contact())->getMorphClass(),
             'recipient_id' => Contact::factory(),
-            'subject' => fake()->sentence,
-            'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->paragraph]]]]],
-            'scheduled_at' => fake()->dateTimeBetween('-1 year', '-1 day'),
+            'subject' => $this->faker->sentence,
+            'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->paragraph]]]]],
+            'scheduled_at' => $this->faker->dateTimeBetween('-1 year', '-1 day'),
             'channel' => NotificationChannel::Email,
         ];
     }
@@ -71,7 +71,7 @@ class EngagementFactory extends Factory
     public function deliverLater(): self
     {
         return $this->state([
-            'scheduled_at' => fake()->dateTimeBetween('+1 day', '+1 week'),
+            'scheduled_at' => $this->faker->dateTimeBetween('+1 day', '+1 week'),
         ]);
     }
 

--- a/app-modules/engagement/database/factories/EngagementResponseFactory.php
+++ b/app-modules/engagement/database/factories/EngagementResponseFactory.php
@@ -51,10 +51,10 @@ class EngagementResponseFactory extends Factory
         return [
             'sender_type' => (new Contact())->getMorphClass(),
             'sender_id' => Contact::factory(),
-            'content' => fake()->sentence(),
-            'sent_at' => fake()->dateTimeBetween('-1 year', '-1 day'),
-            'type' => fake()->randomElement(EngagementResponseType::cases()),
-            'subject' => fake()->sentence(),
+            'content' => $this->faker->sentence(),
+            'sent_at' => $this->faker->dateTimeBetween('-1 year', '-1 day'),
+            'type' => $this->faker->randomElement(EngagementResponseType::cases()),
+            'subject' => $this->faker->sentence(),
             // Bring in a raw value here for testing later
             'raw' => null,
         ];

--- a/app-modules/inventory-management/database/factories/AssetCheckInFactory.php
+++ b/app-modules/inventory-management/database/factories/AssetCheckInFactory.php
@@ -55,7 +55,7 @@ class AssetCheckInFactory extends Factory
             'asset_id' => Asset::factory(),
             'checked_in_by_type' => $checkedInBy->getMorphClass(),
             'checked_in_by_id' => $checkedInBy->getKey(),
-            'checked_in_from_type' => fake()->randomElement([
+            'checked_in_from_type' => $this->faker->randomElement([
                 (new Contact())->getMorphClass(),
             ]),
             'checked_in_from_id' => function (array $attributes) {
@@ -68,8 +68,8 @@ class AssetCheckInFactory extends Factory
 
                 return $checkedInFromModel->getKey();
             },
-            'checked_in_at' => fake()->dateTimeBetween('-1 year', 'now'),
-            'notes' => fake()->paragraph(),
+            'checked_in_at' => $this->faker->dateTimeBetween('-1 year', 'now'),
+            'notes' => $this->faker->paragraph(),
         ];
     }
 }

--- a/app-modules/inventory-management/database/factories/AssetCheckOutFactory.php
+++ b/app-modules/inventory-management/database/factories/AssetCheckOutFactory.php
@@ -57,7 +57,7 @@ class AssetCheckOutFactory extends Factory
             'asset_check_in_id' => null,
             'checked_out_by_type' => $checkedOutBy->getMorphClass(),
             'checked_out_by_id' => $checkedOutBy->getKey(),
-            'checked_out_to_type' => fake()->randomElement([
+            'checked_out_to_type' => $this->faker->randomElement([
                 (new Contact())->getMorphClass(),
             ]),
             'checked_out_to_id' => function (array $attributes) {
@@ -70,13 +70,13 @@ class AssetCheckOutFactory extends Factory
 
                 return $checkedOutToModel->getKey();
             },
-            'checked_out_at' => fake()->dateTimeBetween('-1 year', 'now'),
+            'checked_out_at' => $this->faker->dateTimeBetween('-1 year', 'now'),
             'expected_check_in_at' => function (array $attributes) {
                 $checkedOutAt = Carbon::parse($attributes['checked_out_at']);
 
-                return fake()->dateTimeBetween($checkedOutAt->addDays(1), $checkedOutAt->addDays(50));
+                return $this->faker->dateTimeBetween($checkedOutAt->addDays(1), $checkedOutAt->addDays(50));
             },
-            'notes' => fake()->paragraph(),
+            'notes' => $this->faker->paragraph(),
         ];
     }
 }

--- a/app-modules/inventory-management/database/factories/AssetFactory.php
+++ b/app-modules/inventory-management/database/factories/AssetFactory.php
@@ -49,13 +49,13 @@ class AssetFactory extends Factory
     public function definition(): array
     {
         return [
-            'serial_number' => fake()->isbn13(),
-            'name' => fake()->catchPhrase(),
-            'description' => fake()->paragraph(),
+            'serial_number' => $this->faker->isbn13(),
+            'name' => $this->faker->catchPhrase(),
+            'description' => $this->faker->paragraph(),
             'type_id' => AssetType::inRandomOrder()->first() ?? AssetType::factory()->create(),
             'status_id' => AssetStatus::inRandomOrder()->first() ?? AssetStatus::factory()->create(),
             'location_id' => AssetLocation::inRandomOrder()->first() ?? AssetLocation::factory()->create(),
-            'purchase_date' => fake()->dateTime(),
+            'purchase_date' => $this->faker->dateTime(),
         ];
     }
 

--- a/app-modules/inventory-management/database/factories/AssetLocationFactory.php
+++ b/app-modules/inventory-management/database/factories/AssetLocationFactory.php
@@ -46,7 +46,7 @@ class AssetLocationFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/app-modules/inventory-management/database/factories/AssetStatusFactory.php
+++ b/app-modules/inventory-management/database/factories/AssetStatusFactory.php
@@ -48,7 +48,7 @@ class AssetStatusFactory extends Factory
     {
         return [
             'classification' => SystemAssetStatusClassification::Unavailable,
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 

--- a/app-modules/inventory-management/database/factories/AssetTypeFactory.php
+++ b/app-modules/inventory-management/database/factories/AssetTypeFactory.php
@@ -46,7 +46,7 @@ class AssetTypeFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/app-modules/inventory-management/database/factories/MaintenanceActivityFactory.php
+++ b/app-modules/inventory-management/database/factories/MaintenanceActivityFactory.php
@@ -51,14 +51,14 @@ class MaintenanceActivityFactory extends Factory
 
     public function definition(): array
     {
-        $date = fake()->date();
+        $date = $this->faker->date();
 
         return [
             'asset_id' => Asset::factory(),
             'completed_date' => $date,
-            'details' => fake()->sentence(),
+            'details' => $this->faker->sentence(),
             'maintenance_provider_id' => MaintenanceProvider::factory(),
-            'notes' => fake()->paragraph(),
+            'notes' => $this->faker->paragraph(),
             'scheduled_date' => $date,
         ];
     }

--- a/app-modules/inventory-management/database/factories/MaintenanceProviderFactory.php
+++ b/app-modules/inventory-management/database/factories/MaintenanceProviderFactory.php
@@ -46,7 +46,7 @@ class MaintenanceProviderFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->company(),
+            'name' => $this->faker->company(),
         ];
     }
 }

--- a/app-modules/knowledge-base/database/factories/KnowledgeBaseCategoryFactory.php
+++ b/app-modules/knowledge-base/database/factories/KnowledgeBaseCategoryFactory.php
@@ -49,10 +49,10 @@ class KnowledgeBaseCategoryFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => str(fake()->word())->ucfirst()->toString(),
-            'description' => fake()->optional()->sentences(2, true),
-            'icon' => fake()->optional()->randomElement($this->icons()),
-            'slug' => fake()->slug(),
+            'name' => str($this->faker->word())->ucfirst()->toString(),
+            'description' => $this->faker->optional()->sentences(2, true),
+            'icon' => $this->faker->optional()->randomElement($this->icons()),
+            'slug' => $this->faker->slug(),
         ];
     }
 

--- a/app-modules/knowledge-base/database/factories/KnowledgeBaseItemFactory.php
+++ b/app-modules/knowledge-base/database/factories/KnowledgeBaseItemFactory.php
@@ -51,10 +51,10 @@ class KnowledgeBaseItemFactory extends Factory
     public function definition(): array
     {
         return [
-            'public' => fake()->boolean(),
-            'title' => fake()->sentence(),
-            'article_details' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->paragraph()]]]]],
-            'notes' => fake()->paragraph(),
+            'public' => $this->faker->boolean(),
+            'title' => $this->faker->sentence(),
+            'article_details' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->paragraph()]]]]],
+            'notes' => $this->faker->paragraph(),
             'quality_id' => KnowledgeBaseQuality::inRandomOrder()->first() ?? KnowledgeBaseQuality::factory(),
             'status_id' => KnowledgeBaseStatus::inRandomOrder()->first() ?? KnowledgeBaseStatus::factory(),
             'category_id' => KnowledgeBaseCategory::inRandomOrder()->first() ?? KnowledgeBaseCategory::factory(),

--- a/app-modules/license-management/database/factories/ProductFactory.php
+++ b/app-modules/license-management/database/factories/ProductFactory.php
@@ -52,11 +52,11 @@ class ProductFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
-            'url' => fake()->url(),
-            'description' => fake()->paragraph(),
-            'version' => fake()->numerify('#.#.#'),
-            'additional_notes' => fake()->paragraph(),
+            'name' => $this->faker->word(),
+            'url' => $this->faker->url(),
+            'description' => $this->faker->paragraph(),
+            'version' => $this->faker->numerify('#.#.#'),
+            'additional_notes' => $this->faker->paragraph(),
         ];
     }
 }

--- a/app-modules/license-management/database/factories/ProductLicenseFactory.php
+++ b/app-modules/license-management/database/factories/ProductLicenseFactory.php
@@ -54,11 +54,11 @@ class ProductLicenseFactory extends Factory
     public function definition(): array
     {
         return [
-            'license' => fake()->uuid(),
+            'license' => $this->faker->uuid(),
             'product_id' => Product::factory(),
             'assigned_to' => Contact::factory(),
-            'start_date' => fake()->dateTimeBetween('-1 year', '+1 year'),
-            'expiration_date' => fn (array $attributes) => fake()->dateTimeBetween(
+            'start_date' => $this->faker->dateTimeBetween('-1 year', '+1 year'),
+            'expiration_date' => fn (array $attributes) => $this->faker->dateTimeBetween(
                 (clone $attributes['start_date'])->modify('+1 day'),
                 (clone $attributes['start_date'])->modify('+1 year')
             ),

--- a/app-modules/portal/database/factories/KnowledgeBaseArticleVoteFactory.php
+++ b/app-modules/portal/database/factories/KnowledgeBaseArticleVoteFactory.php
@@ -54,7 +54,7 @@ class KnowledgeBaseArticleVoteFactory extends Factory
     public function definition(): array
     {
         return [
-            'is_helpful' => fake()->boolean(),
+            'is_helpful' => $this->faker->boolean(),
             'voter_id' => Contact::factory(),
             'voter_type' => (new Contact())->getMorphClass(),
             'article_id' => KnowledgeBaseItem::factory(),

--- a/app-modules/service-management/database/factories/ChangeRequestFactory.php
+++ b/app-modules/service-management/database/factories/ChangeRequestFactory.php
@@ -52,14 +52,14 @@ class ChangeRequestFactory extends Factory
             'created_by' => User::factory(),
             'change_request_type_id' => ChangeRequestType::factory(),
             'change_request_status_id' => ChangeRequestStatus::factory(),
-            'title' => fake()->sentence(),
-            'description' => fake()->text(),
-            'reason' => fake()->paragraphs(1, true),
-            'backout_strategy' => fake()->paragraphs(1, true),
-            'impact' => fake()->numberBetween(1, 5),
-            'likelihood' => fake()->numberBetween(1, 5),
-            'start_time' => fake()->dateTime(),
-            'end_time' => fake()->dateTime(),
+            'title' => $this->faker->sentence(),
+            'description' => $this->faker->text(),
+            'reason' => $this->faker->paragraphs(1, true),
+            'backout_strategy' => $this->faker->paragraphs(1, true),
+            'impact' => $this->faker->numberBetween(1, 5),
+            'likelihood' => $this->faker->numberBetween(1, 5),
+            'start_time' => $this->faker->dateTime(),
+            'end_time' => $this->faker->dateTime(),
         ];
     }
 }

--- a/app-modules/service-management/database/factories/ChangeRequestStatusFactory.php
+++ b/app-modules/service-management/database/factories/ChangeRequestStatusFactory.php
@@ -47,8 +47,8 @@ class ChangeRequestStatusFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
-            'classification' => fake()->randomElement(SystemChangeRequestClassification::cases()),
+            'name' => $this->faker->word(),
+            'classification' => $this->faker->randomElement(SystemChangeRequestClassification::cases()),
         ];
     }
 }

--- a/app-modules/service-management/database/factories/ChangeRequestTypeFactory.php
+++ b/app-modules/service-management/database/factories/ChangeRequestTypeFactory.php
@@ -46,8 +46,8 @@ class ChangeRequestTypeFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
-            'number_of_required_approvals' => fake()->numberBetween(0, 2),
+            'name' => $this->faker->word(),
+            'number_of_required_approvals' => $this->faker->numberBetween(0, 2),
         ];
     }
 }

--- a/app-modules/service-management/database/factories/IncidentFactory.php
+++ b/app-modules/service-management/database/factories/IncidentFactory.php
@@ -55,8 +55,8 @@ class IncidentFactory extends Factory
     public function definition(): array
     {
         return [
-            'title' => fake()->word(20),
-            'description' => fake()->paragraph(),
+            'title' => $this->faker->word(20),
+            'description' => $this->faker->paragraph(),
             'severity_id' => IncidentSeverity::factory(),
             'status_id' => IncidentStatus::factory(),
             'assigned_team_id' => Team::factory(),

--- a/app-modules/service-management/database/factories/IncidentSeverityFactory.php
+++ b/app-modules/service-management/database/factories/IncidentSeverityFactory.php
@@ -53,8 +53,8 @@ class IncidentSeverityFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(10),
-            'color' => fake()->randomElement(
+            'name' => $this->faker->word(10),
+            'color' => $this->faker->randomElement(
                 collect(Color::all())->keys()
             ),
         ];

--- a/app-modules/service-management/database/factories/IncidentStatusFactory.php
+++ b/app-modules/service-management/database/factories/IncidentStatusFactory.php
@@ -53,8 +53,8 @@ class IncidentStatusFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(10),
-            'classification' => fake()->randomElement(SystemIncidentStatusClassification::cases()),
+            'name' => $this->faker->word(10),
+            'classification' => $this->faker->randomElement(SystemIncidentStatusClassification::cases()),
         ];
     }
 }

--- a/app-modules/service-management/database/factories/IncidentUpdateFactory.php
+++ b/app-modules/service-management/database/factories/IncidentUpdateFactory.php
@@ -49,8 +49,8 @@ class IncidentUpdateFactory extends Factory
     {
         return [
             'incident_id' => Incident::factory(),
-            'update' => fake()->sentence(),
-            'internal' => fake()->boolean(),
+            'update' => $this->faker->sentence(),
+            'internal' => $this->faker->boolean(),
         ];
     }
 }

--- a/app-modules/service-management/database/factories/ServiceMonitoringTargetFactory.php
+++ b/app-modules/service-management/database/factories/ServiceMonitoringTargetFactory.php
@@ -53,10 +53,10 @@ class ServiceMonitoringTargetFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(10),
-            'description' => fake()->paragraph(),
-            'domain' => fake()->url(),
-            'frequency' => fake()->randomElement(ServiceMonitoringFrequency::cases()),
+            'name' => $this->faker->word(10),
+            'description' => $this->faker->paragraph(),
+            'domain' => $this->faker->url(),
+            'frequency' => $this->faker->randomElement(ServiceMonitoringFrequency::cases()),
         ];
     }
 }

--- a/app-modules/service-management/database/factories/ServiceRequestAssignmentFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestAssignmentFactory.php
@@ -52,7 +52,7 @@ class ServiceRequestAssignmentFactory extends Factory
             'service_request_id' => ServiceRequest::factory(),
             'user_id' => User::factory(),
             'assigned_by_id' => User::factory(),
-            'assigned_at' => fake()->dateTimeBetween('-1 year', now()),
+            'assigned_at' => $this->faker->dateTimeBetween('-1 year', now()),
         ];
     }
 

--- a/app-modules/service-management/database/factories/ServiceRequestFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestFactory.php
@@ -56,9 +56,9 @@ class ServiceRequestFactory extends Factory
             'respondent_type' => function (array $attributes) {
                 return Contact::find($attributes['respondent_id'])->getMorphClass();
             },
-            'title' => str(fake()->words(asText: true))->headline()->toString(),
-            'close_details' => fake()->sentence(),
-            'res_details' => fake()->sentence(),
+            'title' => str($this->faker->words(asText: true))->headline()->toString(),
+            'close_details' => $this->faker->sentence(),
+            'res_details' => $this->faker->sentence(),
             'division_id' => Division::inRandomOrder()->first()?->id ?? Division::factory(),
             'status_id' => ServiceRequestStatus::inRandomOrder()->first() ?? ServiceRequestStatus::factory(),
             'priority_id' => ServiceRequestPriority::inRandomOrder()->first() ?? ServiceRequestPriority::factory(),

--- a/app-modules/service-management/database/factories/ServiceRequestTypeEmailTemplateFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestTypeEmailTemplateFactory.php
@@ -56,12 +56,12 @@ class ServiceRequestTypeEmailTemplateFactory extends Factory
     {
         return [
             'service_request_type_id' => ServiceRequestType::factory(),
-            'type' => fake()->randomElement(collect(ServiceRequestEmailTemplateType::cases())->values()->toArray()),
-            'subject' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->sentence()]]]]],
-            'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->sentence()]]]]],
+            'type' => $this->faker->randomElement(collect(ServiceRequestEmailTemplateType::cases())->values()->toArray()),
+            'subject' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->sentence()]]]]],
+            'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->sentence()]]]]],
             'role' => fn (array $attributes) => $attributes['type'] === ServiceRequestEmailTemplateType::SurveyResponse
               ? ServiceRequestTypeEmailTemplateRole::Customer
-              : fake()->randomElement(ServiceRequestTypeEmailTemplateRole::cases()),
+              : $this->faker->randomElement(ServiceRequestTypeEmailTemplateRole::cases()),
         ];
     }
 }

--- a/app-modules/service-management/database/factories/ServiceRequestTypeFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestTypeFactory.php
@@ -49,9 +49,9 @@ class ServiceRequestTypeFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => str(fake()->word())->ucfirst()->toString(),
-            'description' => fake()->optional()->sentences(2, true),
-            'icon' => fake()->optional()->randomElement($this->icons()),
+            'name' => str($this->faker->word())->ucfirst()->toString(),
+            'description' => $this->faker->optional()->sentences(2, true),
+            'icon' => $this->faker->optional()->randomElement($this->icons()),
         ];
     }
 

--- a/app-modules/task/database/factories/TaskFactory.php
+++ b/app-modules/task/database/factories/TaskFactory.php
@@ -50,9 +50,9 @@ class TaskFactory extends Factory
     public function definition(): array
     {
         return [
-            'title' => str(fake()->words(asText: 3))->title()->toString(),
-            'description' => fake()->sentence(),
-            'status' => fake()->randomElement(TaskStatus::cases())->value,
+            'title' => str($this->faker->words(asText: 3))->title()->toString(),
+            'description' => $this->faker->sentence(),
+            'status' => $this->faker->randomElement(TaskStatus::cases())->value,
             'due' => null,
             'assigned_to' => null,
             'created_by' => User::factory(),
@@ -77,14 +77,14 @@ class TaskFactory extends Factory
     public function pastDue(): self
     {
         return $this->state([
-            'due' => fake()->dateTimeBetween('-2 weeks', '-1 week'),
+            'due' => $this->faker->dateTimeBetween('-2 weeks', '-1 week'),
         ]);
     }
 
     public function dueLater(): self
     {
         return $this->state([
-            'due' => fake()->dateTimeBetween('+1 week', '+2 weeks'),
+            'due' => $this->faker->dateTimeBetween('+1 week', '+2 weeks'),
         ]);
     }
 }

--- a/app-modules/team/database/factories/TeamFactory.php
+++ b/app-modules/team/database/factories/TeamFactory.php
@@ -48,15 +48,15 @@ class TeamFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->catchPhrase(),
-            'description' => fake()->sentence(),
+            'name' => $this->faker->unique()->catchPhrase(),
+            'description' => $this->faker->sentence(),
         ];
     }
 
     public function configure(): TeamFactory|Factory
     {
         return $this->afterMaking(function (Team $team) {
-            $team->division()->associate(fake()->randomElement([Division::inRandomOrder()->first(), null]));
+            $team->division()->associate($this->faker->randomElement([Division::inRandomOrder()->first(), null]));
         });
     }
 }

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -51,7 +51,7 @@ class TagFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->words(asText: true),
+            'name' => $this->faker->words(asText: true),
         ];
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -53,16 +53,16 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),
             'is_external' => false,
-            'job_title' => fake()->jobTitle(),
-            'work_number' => fake()->numerify('+1 ### ### ####'),
-            'work_extension' => fake()->randomNumber(4),
-            'mobile' => fake()->numerify('+1 ### ### ####'),
+            'job_title' => $this->faker->jobTitle(),
+            'work_number' => $this->faker->numerify('+1 ### ### ####'),
+            'work_extension' => $this->faker->randomNumber(4),
+            'mobile' => $this->faker->numerify('+1 ### ### ####'),
         ];
     }
 

--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -50,6 +50,10 @@ arch('All Core Models should not use HasUuids trait')
     ->extending(Model::class)
     ->not->toUseTrait('Illuminate\Database\Eloquent\Concerns\HasUuids');
 
+arch('All Core Factories should not use the fake global function')
+    ->expect('Database\Factories')
+    ->not->toUse('fake');
+
 app(ModuleRegistry::class, [
     'modules_path' => 'app-modules',
     'cache_path' => 'cache/modules.php',
@@ -62,6 +66,10 @@ app(ModuleRegistry::class, [
         ->expect($module->namespace() . 'Models')
         ->extending(Model::class)
         ->not->toUseTrait('Illuminate\Database\Eloquent\Concerns\HasUuids');
+
+    arch("All {$module->name} Factories should not use the fake global function")
+        ->expect($module->namespace() . 'Database\Factories')
+        ->not->toUse('fake');
 });
 
 test('pages extending EditRecord have the EditPageRedirection test', function () {

--- a/tests/Unit/ArchTest.php
+++ b/tests/Unit/ArchTest.php
@@ -37,7 +37,6 @@
 use App\Concerns\EditPageRedirection;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Collection;
 use InterNACHI\Modular\Support\ModuleConfig;
 use InterNACHI\Modular\Support\ModuleRegistry;
 use PHPUnit\Framework\Assert;
@@ -46,6 +45,11 @@ arch('All Core Settings classes should have defaults for all properties')
     ->expect('App\Settings')
     ->toHaveDefaultsForAllProperties();
 
+arch('All Core Models should not use HasUuids trait')
+    ->expect('App\Models')
+    ->extending(Model::class)
+    ->not->toUseTrait('Illuminate\Database\Eloquent\Concerns\HasUuids');
+
 app(ModuleRegistry::class, [
     'modules_path' => 'app-modules',
     'cache_path' => 'cache/modules.php',
@@ -53,6 +57,11 @@ app(ModuleRegistry::class, [
     arch("All {$module->name} Settings classes should have defaults for all properties")
         ->expect($module->namespace() . 'Settings')
         ->toHaveDefaultsForAllProperties();
+
+    arch("All {$module->name} Models should not use HasUuids trait")
+        ->expect($module->namespace() . 'Models')
+        ->extending(Model::class)
+        ->not->toUseTrait('Illuminate\Database\Eloquent\Concerns\HasUuids');
 });
 
 test('pages extending EditRecord have the EditPageRedirection test', function () {
@@ -74,22 +83,4 @@ test('pages extending EditRecord have the EditPageRedirection test', function ()
             "Class [{$class}] does not use the EditPageRedirection trait.",
         );
     }
-});
-
-arch('All Core Models should not use HasUuids trait')
-    ->expect('App\Models')
-    ->extending(Model::class)
-    ->not->toUseTrait('Illuminate\Database\Eloquent\Concerns\HasUuids');
-
-/** @var Collection<int, ModuleConfig> $modules */
-$modules = app(ModuleRegistry::class, [
-    'modules_path' => 'app-modules',
-    'cache_path' => 'cache/modules.php',
-])->modules();
-
-$modules->each(function (ModuleConfig $module) {
-    arch("All {$module->name} Models should not use HasUuids trait")
-        ->expect($module->namespace() . 'Models')
-        ->extending(Model::class)
-        ->not->toUseTrait('Illuminate\Database\Eloquent\Concerns\HasUuids');
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-604

### Technical Description

Updates all factories to use the local usage of faker and gets rid of calls to `fake()`. Adds arch tests enforcing that `fake()` is no longer used in factories.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
