### PR TITLE
[AIDAPP-609]: KnowledgeBase Articles in Production had empty or corrupted data causing the fulltext search data migration to fail

### DIFF
--- a/app-modules/knowledge-base/database/migrations/2025_05_26_103749_data_migrate_article_details_to_article_details_fulltext_in_knowledge_base_articles.php
+++ b/app-modules/knowledge-base/database/migrations/2025_05_26_103749_data_migrate_article_details_to_article_details_fulltext_in_knowledge_base_articles.php
@@ -45,11 +45,15 @@ return new class () extends Migration {
         DB::table('knowledge_base_articles')->chunkById(100, function ($articles) {
             foreach ($articles as $article) {
                 if (! blank($article->article_details)) {
-                    $articleDetails = strip_tags(tiptap_converter()->asHTML($article->article_details));
+                    try {
+                        $articleDetails = strip_tags(tiptap_converter()->asHTML($article->article_details));
 
-                    DB::table('knowledge_base_articles')
-                        ->where('id', $article->id)
-                        ->update(['article_details_fulltext' => $articleDetails]);
+                        DB::table('knowledge_base_articles')
+                            ->where('id', $article->id)
+                            ->update(['article_details_fulltext' => $articleDetails]);
+                    } catch (Throwable $e) {
+                        report($e);
+                    }
                 }
             }
         });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-609

### Technical Description

In Prod some Knowledgebase articles have empty data. Prevents this from stopping the rest of them from being migrated.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
