### PR TITLE
[Bugfix]: Users not having profile images causes Azure to throw error to Sentry unnecessarily

### DIFF
--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -43,6 +43,8 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
@@ -95,9 +97,10 @@ class SocialiteController extends Controller
         if ($provider === SocialiteProvider::Azure) {
             try {
                 $request = Http::withToken($socialiteUser->token)
+                    ->dontTruncateExceptions()
                     ->retry(3, 500)
                     ->get('https://graph.microsoft.com/v1.0/me/photo/$value')
-                    ->throw();
+                    ->throwIf(fn (Response $response) => $response->failed() && $response->status() !== 404);
 
                 $mimeType = $request->header('Content-Type');
 
@@ -111,6 +114,10 @@ class SocialiteController extends Controller
                     }
                 } else {
                     throw new InvalidUserAvatarMimeType($mimeType, $user);
+                }
+            } catch (RequestException $e) {
+                if (! str_contains($e->getMessage(), 'Microsoft.Fast.Profile.Core.Exception.ImageNotFoundException')) {
+                    report($e);
                 }
             } catch (Throwable $e) {
                 report($e);

--- a/app-modules/authorization/tests/Feature/Filament/Resources/UserResources/Pages/EditUserTest.php
+++ b/app-modules/authorization/tests/Feature/Filament/Resources/UserResources/Pages/EditUserTest.php
@@ -43,6 +43,7 @@ use App\Models\User;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Select;
 use Filament\Tables\Actions\AttachAction;
+use Illuminate\Support\Collection;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -181,7 +182,7 @@ test('EditUser is gated with proper access control', function () {
             ])
         )->assertSuccessful();
 
-    $request = collect(User::factory()->make());
+    $request = new Collection(User::factory()->make());
 
     livewire(EditUser::class, [
         'record' => $anotherUser->getRouteKey(),

--- a/composer.lock
+++ b/composer.lock
@@ -6222,20 +6222,20 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.13.0",
+            "version": "v12.19.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "52b588bcd8efc6d01bc1493d2d67848f8065f269"
+                "reference": "4e6ec689ef704bb4bd282f29d9dd658dfb4fb262"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/52b588bcd8efc6d01bc1493d2d67848f8065f269",
-                "reference": "52b588bcd8efc6d01bc1493d2d67848f8065f269",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/4e6ec689ef704bb4bd282f29d9dd658dfb4fb262",
+                "reference": "4e6ec689ef704bb4bd282f29d9dd658dfb4fb262",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.11|^0.12",
+                "brick/math": "^0.11|^0.12|^0.13",
                 "composer-runtime-api": "^2.2",
                 "doctrine/inflector": "^2.0.5",
                 "dragonmantank/cron-expression": "^3.4",
@@ -6433,7 +6433,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-05-07T17:29:01+00:00"
+            "time": "2025-06-18T12:56:23+00:00"
         },
         {
             "name": "laravel/octane",


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Fix an issue where Azure login logs an error that is not needed if they don't have a profile image.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
