### PR TITLE
[AIDAPP-627]: Introduce dynamic user representation for From Name in outbound engagements

### DIFF
--- a/app-modules/engagement/src/Notifications/EngagementNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementNotification.php
@@ -38,6 +38,7 @@ namespace AidingApp\Engagement\Notifications;
 
 use AidingApp\Engagement\Models\Engagement;
 use AidingApp\Engagement\Models\EngagementBatch;
+use AidingApp\IntegrationAwsSesEventHandling\Settings\SesSettings;
 use AidingApp\Notification\DataTransferObjects\NotificationResultData;
 use AidingApp\Notification\Enums\NotificationChannel;
 use AidingApp\Notification\Models\Contracts\CanBeNotified;
@@ -75,11 +76,17 @@ class EngagementNotification extends Notification implements ShouldQueue, HasBef
 
     public function toMail(object $notifiable): MailMessage
     {
-        return MailMessage::make()
+        $mail = MailMessage::make()
             ->settings($this->resolveNotificationSetting($this->engagement->user))
             ->subject($this->engagement->subject)
             ->greeting("Hello {$this->engagement->recipient->display_name}!")
             ->content($this->engagement->getBody());
+
+        if(app(SesSettings::class)->dynamic_engagements === true) {
+            $mail->from(config('mail.from.address'), $this->engagement->user->name);
+        }
+
+        return $mail;
     }
 
     public function toSms(object $notifiable): TwilioMessage

--- a/app-modules/integration-aws-ses-event-handling/database/migrations/2025_06_24_152234_create_dynamic_engagement_ses_setting.php
+++ b/app-modules/integration-aws-ses-event-handling/database/migrations/2025_06_24_152234_create_dynamic_engagement_ses_setting.php
@@ -1,0 +1,13 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        $this->migrator->inGroup('ses', function (SettingsBlueprint $blueprint): void {
+            $blueprint->add('dynamic_engagements', false);
+        });
+    }
+};

--- a/app-modules/integration-aws-ses-event-handling/src/Filament/Pages/ManageAmazonSesSettings.php
+++ b/app-modules/integration-aws-ses-event-handling/src/Filament/Pages/ManageAmazonSesSettings.php
@@ -91,8 +91,10 @@ class ManageAmazonSesSettings extends SettingsPage
                     ->schema([
                         TextInput::make('configuration_set')
                             ->label('Configuration Set'),
+                        Toggle::make('dynamic_engagements')
+                            ->label('Dynamic Engagements'),
                         TextInput::make('fromName')
-                            ->label('From Name')
+                            ->label('Fallback From Name')
                             ->string()
                             ->maxLength(150)
                             ->required(),

--- a/app-modules/integration-aws-ses-event-handling/src/Settings/SesSettings.php
+++ b/app-modules/integration-aws-ses-event-handling/src/Settings/SesSettings.php
@@ -42,6 +42,8 @@ class SesSettings extends Settings
 {
     public ?string $configuration_set = null;
 
+    public bool $dynamic_engagements = false;
+
     public static function group(): string
     {
         return 'ses';


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-627

### Technical Description

Create setting to toggle whether the sender's name or default is provided in engagements

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
