### PR TITLE
[AIDAPP-632]: Resolve the security issue tracked under CVE-2025-6545 & [AIDAPP-633]: Resolve the security issue tracked under CVE-2025-6547

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "tapp/filament-timezone-field": "^3.0",
         "tpetry/laravel-postgresql-enhanced": "^3.0",
         "twilio/sdk": "^8.5.0",
-        "ysfkaya/filament-phone-input": "^3.1"
+        "ysfkaya/filament-phone-input": "^3.2.2"
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f178a4ffd66a8cab792a6700c31c97cf",
+    "content-hash": "6c02459f81369bea11a6f2442fc45d3b",
     "packages": [
         {
             "name": "amphp/amp",
@@ -17691,36 +17691,36 @@
         },
         {
             "name": "ysfkaya/filament-phone-input",
-            "version": "v3.1.8",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ysfkaya/filament-phone-input.git",
-                "reference": "f081ddde737627761065b6c5305f63cf65a51398"
+                "reference": "797b8826b0defc646969cb4146b5a31b84652c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ysfkaya/filament-phone-input/zipball/f081ddde737627761065b6c5305f63cf65a51398",
-                "reference": "f081ddde737627761065b6c5305f63cf65a51398",
+                "url": "https://api.github.com/repos/ysfkaya/filament-phone-input/zipball/797b8826b0defc646969cb4146b5a31b84652c3c",
+                "reference": "797b8826b0defc646969cb4146b5a31b84652c3c",
                 "shasum": ""
             },
             "require": {
                 "filament/filament": "^3.0",
                 "php": "^8.1",
-                "propaganistas/laravel-phone": "^5.0",
-                "spatie/laravel-package-tools": "^1.16"
+                "propaganistas/laravel-phone": "^5.0|^6.0",
+                "spatie/laravel-package-tools": "^1.92"
             },
             "require-dev": {
                 "laravel/pint": "^1.0",
-                "nunomaduro/collision": "^7.9",
-                "nunomaduro/larastan": "^2.0.1",
-                "orchestra/testbench-dusk": "^8.0",
-                "pestphp/pest": "^2.0",
-                "pestphp/pest-plugin-arch": "^2.0",
-                "pestphp/pest-plugin-laravel": "^2.0",
-                "pestphp/pest-plugin-livewire": "^2.1",
+                "nunomaduro/collision": "^7.9|^8.1",
+                "nunomaduro/larastan": "^2.0|^3.0",
+                "orchestra/testbench-dusk": "^8.0|^9.0|^10.0",
+                "pestphp/pest": "^2.0|^3.0",
+                "pestphp/pest-plugin-arch": "^2.0|^3.0",
+                "pestphp/pest-plugin-laravel": "^2.0|^3.0",
+                "pestphp/pest-plugin-livewire": "^2.1|^3.0",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.0"
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.0|^2.0"
             },
             "type": "library",
             "extra": {
@@ -17749,9 +17749,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ysfkaya/filament-phone-input/issues",
-                "source": "https://github.com/ysfkaya/filament-phone-input/tree/v3.1.8"
+                "source": "https://github.com/ysfkaya/filament-phone-input/tree/v3.2.2"
             },
-            "time": "2025-03-23T20:59:45+00:00"
+            "time": "2025-06-29T11:33:18+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-632
- https://canyongbs.atlassian.net/browse/AIDAPP-633

### Technical Description

Update `ysfkaya/filament-phone-input` in `composer.json` and our lock file to go to the updated version without a reference to a package with CVE within its JavaScript developer dependencies.

We were not vulnerable to this vulnerability, as it was not installed on our system; it was only referenced in this downstream dependency as a JavaScript developer dependency. Updating to silence scanners.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
