### PR TITLE
[Bugfix]: ServiceRequestAssignmentObserver missing relation issue

### DIFF
--- a/app-modules/service-management/src/Observers/ServiceRequestAssignmentObserver.php
+++ b/app-modules/service-management/src/Observers/ServiceRequestAssignmentObserver.php
@@ -56,6 +56,8 @@ class ServiceRequestAssignmentObserver
 
     public function creating(ServiceRequestAssignment $serviceRequestAssignment): void
     {
+        $serviceRequestAssignment->loadMissing('serviceRequest');
+
         throw_if(! in_array($serviceRequestAssignment->user_id, $serviceRequestAssignment->serviceRequest->priority->type?->managers
             ->flatMap(fn ($managers) => $managers->users)
             ->pluck('id')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Work to fix an issue where the serviceRequest relation may not yet be loaded in within `ServiceRequestAssignmentObserver`.

https://canyongbs.sentry.io/issues/6713712757/events/fae876f5ba624b6a9d4b0df7cef5dd75/

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
