### PR TITLE
[AIDAPP-653]: Rename product administration to settings in the main navigation

### DIFF
--- a/app-modules/authorization/src/Enums/PermissionDescription.php
+++ b/app-modules/authorization/src/Enums/PermissionDescription.php
@@ -64,7 +64,7 @@ enum PermissionDescription: string
     case Organization = 'This permission group enables the display and management of the Organization feature in the primary navigation group Clients. Permission options include create, view, update, and delete organizations.';
     case Permission = 'This permission group enables the display and management of the Permission feature in the primary navigation group User Management. Permission options include view permissions.';
     case Product = 'This permission group enables the display and management of the License Management feature in the primary navigation group Purchasing. Permission options include create, view, update, and delete products.';
-    case ProductAdmin = 'This permission group enables access of the primary navigation group Product Administration.';
+    case ProductAdmin = 'This permission group enables access of the primary navigation group Settings.';
     case ProductLicense = 'This permission group enables the display and management of the Product License feature in the tertiary navigation group View License. Permission options include create, view, update, and delete product licenses.';
     case Project = 'This permission group enables the display of the Project feature in the primary navigation group Projects. It is coming soon. Permission options will include create, view, update, and delete';
     case RealtimeChat = 'This permission group enables the display of the Realtime Chat feature in the primary navigation group Staff Engagement. Permission options include view realtime chat.';

--- a/app-modules/contact/src/Policies/ContactSourcePolicy.php
+++ b/app-modules/contact/src/Policies/ContactSourcePolicy.php
@@ -55,12 +55,13 @@ class ContactSourcePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
-                denyResponse: 'You do not have permission to view any contact sources.'
+                denyResponse: 'You do not have permission to view contact sources.'
             );
         }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view contact sources.'
@@ -69,7 +70,7 @@ class ContactSourcePolicy
 
     public function view(Authenticatable $authenticatable, ContactSource $contactSource): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this contact source.'
@@ -84,7 +85,7 @@ class ContactSourcePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create contact sources.'
@@ -99,7 +100,7 @@ class ContactSourcePolicy
 
     public function update(Authenticatable $authenticatable, ContactSource $contactSource): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this contact source.'
@@ -114,7 +115,7 @@ class ContactSourcePolicy
 
     public function delete(Authenticatable $authenticatable, ContactSource $contactSource): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this contact source.'
@@ -129,7 +130,7 @@ class ContactSourcePolicy
 
     public function restore(Authenticatable $authenticatable, ContactSource $contactSource): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this contact source.'
@@ -144,7 +145,7 @@ class ContactSourcePolicy
 
     public function forceDelete(Authenticatable $authenticatable, ContactSource $contactSource): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to force delete this contact source.'

--- a/app-modules/contact/src/Policies/ContactSourcePolicy.php
+++ b/app-modules/contact/src/Policies/ContactSourcePolicy.php
@@ -58,7 +58,7 @@ class ContactSourcePolicy
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
-                denyResponse: 'You do not have permission to view contact sources.'
+                denyResponse: 'You do not have permission to view any contact sources.'
             );
         }
         return $authenticatable->canOrElse(

--- a/app-modules/contact/src/Policies/ContactSourcePolicy.php
+++ b/app-modules/contact/src/Policies/ContactSourcePolicy.php
@@ -38,6 +38,7 @@ namespace AidingApp\Contact\Policies;
 
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Contact\Models\ContactSource;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -54,6 +55,12 @@ class ContactSourcePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view contact sources.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view contact sources.'
@@ -62,6 +69,13 @@ class ContactSourcePolicy
 
     public function view(Authenticatable $authenticatable, ContactSource $contactSource): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this contact source.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactSource->getKey()}.view"],
             denyResponse: 'You do not have permission to view this contact source.'
@@ -70,6 +84,13 @@ class ContactSourcePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create contact sources.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create contact sources.'
@@ -78,6 +99,13 @@ class ContactSourcePolicy
 
     public function update(Authenticatable $authenticatable, ContactSource $contactSource): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this contact source.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactSource->getKey()}.update"],
             denyResponse: 'You do not have permission to update this contact source.'
@@ -86,6 +114,13 @@ class ContactSourcePolicy
 
     public function delete(Authenticatable $authenticatable, ContactSource $contactSource): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this contact source.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactSource->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this contact source.'
@@ -94,6 +129,13 @@ class ContactSourcePolicy
 
     public function restore(Authenticatable $authenticatable, ContactSource $contactSource): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this contact source.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactSource->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this contact source.'
@@ -102,6 +144,13 @@ class ContactSourcePolicy
 
     public function forceDelete(Authenticatable $authenticatable, ContactSource $contactSource): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to force delete this contact source.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactSource->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to force delete this contact source.'

--- a/app-modules/contact/src/Policies/ContactStatusPolicy.php
+++ b/app-modules/contact/src/Policies/ContactStatusPolicy.php
@@ -55,7 +55,7 @@ class ContactStatusPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view contact statuses.'
@@ -70,22 +70,22 @@ class ContactStatusPolicy
 
     public function view(Authenticatable $authenticatable, ContactStatus $contactStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
-                denyResponse: 'You do not have permission to view contact statuses.'
+                denyResponse: 'You do not have permission to view contact status.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactStatus->getKey()}.view"],
-            denyResponse: 'You do not have permission to view contact statuses.'
+            denyResponse: 'You do not have permission to view contact status.'
         );
     }
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create contact statuses.'
@@ -100,61 +100,61 @@ class ContactStatusPolicy
 
     public function update(Authenticatable $authenticatable, ContactStatus $contactStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
-                denyResponse: 'You do not have permission to update contact statuses.'
+                denyResponse: 'You do not have permission to update contact status.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactStatus->getKey()}.update"],
-            denyResponse: 'You do not have permission to update contact statuses.'
+            denyResponse: 'You do not have permission to update contact status.'
         );
     }
 
     public function delete(Authenticatable $authenticatable, ContactStatus $contactStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
-                denyResponse: 'You do not have permission to delete contact statuses.'
+                denyResponse: 'You do not have permission to delete contact status.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactStatus->getKey()}.delete"],
-            denyResponse: 'You do not have permission to delete contact statuses.'
+            denyResponse: 'You do not have permission to delete contact status.'
         );
     }
 
     public function restore(Authenticatable $authenticatable, ContactStatus $contactStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
-                denyResponse: 'You do not have permission to restore contact statuses.'
+                denyResponse: 'You do not have permission to restore contact status.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactStatus->getKey()}.restore"],
-            denyResponse: 'You do not have permission to restore contact statuses.'
+            denyResponse: 'You do not have permission to restore contact status.'
         );
     }
 
     public function forceDelete(Authenticatable $authenticatable, ContactStatus $contactStatus): Response
     {
-        if(SettingsPermissions::active()){
-           return $authenticatable->canOrElse(
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
-                denyResponse: 'You do not have permission to force delete contact statuses.'
+                denyResponse: 'You do not have permission to force delete contact status.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactStatus->getKey()}.force-delete"],
-            denyResponse: 'You do not have permission to force delete contact statuses.'
+            denyResponse: 'You do not have permission to force delete contact status.'
         );
     }
 }

--- a/app-modules/contact/src/Policies/ContactStatusPolicy.php
+++ b/app-modules/contact/src/Policies/ContactStatusPolicy.php
@@ -38,6 +38,7 @@ namespace AidingApp\Contact\Policies;
 
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Contact\Models\ContactStatus;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -54,6 +55,13 @@ class ContactStatusPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view contact statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view contact statuses.'
@@ -62,6 +70,13 @@ class ContactStatusPolicy
 
     public function view(Authenticatable $authenticatable, ContactStatus $contactStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view contact statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactStatus->getKey()}.view"],
             denyResponse: 'You do not have permission to view contact statuses.'
@@ -70,6 +85,13 @@ class ContactStatusPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create contact statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create contact statuses.'
@@ -78,6 +100,13 @@ class ContactStatusPolicy
 
     public function update(Authenticatable $authenticatable, ContactStatus $contactStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update contact statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactStatus->getKey()}.update"],
             denyResponse: 'You do not have permission to update contact statuses.'
@@ -86,6 +115,13 @@ class ContactStatusPolicy
 
     public function delete(Authenticatable $authenticatable, ContactStatus $contactStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete contact statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactStatus->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete contact statuses.'
@@ -94,6 +130,13 @@ class ContactStatusPolicy
 
     public function restore(Authenticatable $authenticatable, ContactStatus $contactStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore contact statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactStatus->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore contact statuses.'
@@ -102,6 +145,13 @@ class ContactStatusPolicy
 
     public function forceDelete(Authenticatable $authenticatable, ContactStatus $contactStatus): Response
     {
+        if(SettingsPermissions::active()){
+           return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to force delete contact statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contactStatus->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to force delete contact statuses.'

--- a/app-modules/contact/src/Policies/OrganizationIndustryPolicy.php
+++ b/app-modules/contact/src/Policies/OrganizationIndustryPolicy.php
@@ -55,13 +55,13 @@ class OrganizationIndustryPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view organization industries.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view organization industries.'
@@ -70,7 +70,7 @@ class OrganizationIndustryPolicy
 
     public function view(Authenticatable $authenticatable, OrganizationIndustry $organizationIndustry): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this organization industry.'
@@ -85,7 +85,7 @@ class OrganizationIndustryPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create organization industries.'
@@ -100,7 +100,7 @@ class OrganizationIndustryPolicy
 
     public function update(Authenticatable $authenticatable, OrganizationIndustry $organizationIndustry): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this organization industry.'
@@ -115,7 +115,7 @@ class OrganizationIndustryPolicy
 
     public function delete(Authenticatable $authenticatable, OrganizationIndustry $organizationIndustry): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this organization industry.'
@@ -130,7 +130,7 @@ class OrganizationIndustryPolicy
 
     public function restore(Authenticatable $authenticatable, OrganizationIndustry $organizationIndustry): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this organization industry.'
@@ -145,13 +145,13 @@ class OrganizationIndustryPolicy
 
     public function forceDelete(Authenticatable $authenticatable, OrganizationIndustry $organizationIndustry): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to force delete this organization industry.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationIndustry->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to force delete this organization industry.'

--- a/app-modules/contact/src/Policies/OrganizationIndustryPolicy.php
+++ b/app-modules/contact/src/Policies/OrganizationIndustryPolicy.php
@@ -38,6 +38,7 @@ namespace AidingApp\Contact\Policies;
 
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Contact\Models\OrganizationIndustry;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -54,6 +55,13 @@ class OrganizationIndustryPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view organization industries.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view organization industries.'
@@ -62,6 +70,13 @@ class OrganizationIndustryPolicy
 
     public function view(Authenticatable $authenticatable, OrganizationIndustry $organizationIndustry): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this organization industry.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationIndustry->getKey()}.view"],
             denyResponse: 'You do not have permission to view this organization industry.'
@@ -70,6 +85,13 @@ class OrganizationIndustryPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create organization industries.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create organization industries.'
@@ -78,6 +100,13 @@ class OrganizationIndustryPolicy
 
     public function update(Authenticatable $authenticatable, OrganizationIndustry $organizationIndustry): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this organization industry.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationIndustry->getKey()}.update"],
             denyResponse: 'You do not have permission to update this organization industry.'
@@ -86,6 +115,13 @@ class OrganizationIndustryPolicy
 
     public function delete(Authenticatable $authenticatable, OrganizationIndustry $organizationIndustry): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this organization industry.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationIndustry->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this organization industry.'
@@ -94,6 +130,13 @@ class OrganizationIndustryPolicy
 
     public function restore(Authenticatable $authenticatable, OrganizationIndustry $organizationIndustry): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this organization industry.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationIndustry->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this organization industry.'
@@ -102,6 +145,13 @@ class OrganizationIndustryPolicy
 
     public function forceDelete(Authenticatable $authenticatable, OrganizationIndustry $organizationIndustry): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to force delete this organization industry.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationIndustry->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to force delete this organization industry.'

--- a/app-modules/contact/src/Policies/OrganizationTypePolicy.php
+++ b/app-modules/contact/src/Policies/OrganizationTypePolicy.php
@@ -55,13 +55,13 @@ class OrganizationTypePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view organization types.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view organization types.'
@@ -70,7 +70,7 @@ class OrganizationTypePolicy
 
     public function view(Authenticatable $authenticatable, OrganizationType $organizationType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this organization type.'
@@ -85,7 +85,7 @@ class OrganizationTypePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create organization types.'
@@ -100,7 +100,7 @@ class OrganizationTypePolicy
 
     public function update(Authenticatable $authenticatable, OrganizationType $organizationType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this organization type.'
@@ -115,7 +115,7 @@ class OrganizationTypePolicy
 
     public function delete(Authenticatable $authenticatable, OrganizationType $organizationType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this organization type.'
@@ -130,7 +130,7 @@ class OrganizationTypePolicy
 
     public function restore(Authenticatable $authenticatable, OrganizationType $organizationType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this organization type.'
@@ -145,7 +145,7 @@ class OrganizationTypePolicy
 
     public function forceDelete(Authenticatable $authenticatable, OrganizationType $organizationType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to force delete this organization type.'

--- a/app-modules/contact/src/Policies/OrganizationTypePolicy.php
+++ b/app-modules/contact/src/Policies/OrganizationTypePolicy.php
@@ -73,13 +73,13 @@ class OrganizationTypePolicy
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
-                denyResponse: 'You do not have permission to view this organization types.'
+                denyResponse: 'You do not have permission to view this organization type.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationType->getKey()}.view"],
-            denyResponse: 'You do not have permission to view this organization types.'
+            denyResponse: 'You do not have permission to view this organization type.'
         );
     }
 

--- a/app-modules/contact/src/Policies/OrganizationTypePolicy.php
+++ b/app-modules/contact/src/Policies/OrganizationTypePolicy.php
@@ -38,6 +38,7 @@ namespace AidingApp\Contact\Policies;
 
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Contact\Models\OrganizationType;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -54,6 +55,13 @@ class OrganizationTypePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view organization types.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view organization types.'
@@ -62,6 +70,13 @@ class OrganizationTypePolicy
 
     public function view(Authenticatable $authenticatable, OrganizationType $organizationType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this organization types.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationType->getKey()}.view"],
             denyResponse: 'You do not have permission to view this organization types.'
@@ -70,6 +85,13 @@ class OrganizationTypePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create organization types.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create organization types.'
@@ -78,6 +100,13 @@ class OrganizationTypePolicy
 
     public function update(Authenticatable $authenticatable, OrganizationType $organizationType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this organization type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationType->getKey()}.update"],
             denyResponse: 'You do not have permission to update this organization type.'
@@ -86,6 +115,13 @@ class OrganizationTypePolicy
 
     public function delete(Authenticatable $authenticatable, OrganizationType $organizationType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this organization type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationType->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this organization type.'
@@ -94,6 +130,13 @@ class OrganizationTypePolicy
 
     public function restore(Authenticatable $authenticatable, OrganizationType $organizationType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this organization type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationType->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this organization type.'
@@ -102,6 +145,13 @@ class OrganizationTypePolicy
 
     public function forceDelete(Authenticatable $authenticatable, OrganizationType $organizationType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to force delete this organization type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$organizationType->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to force delete this organization type.'

--- a/app-modules/contact/tests/Tenant/ContactSource/CreateContactSourceTest.php
+++ b/app-modules/contact/tests/Tenant/ContactSource/CreateContactSourceTest.php
@@ -95,8 +95,8 @@ test('CreateContactSource is gated with proper access control', function () {
     livewire(ContactSourceResource\Pages\CreateContactSource::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/ContactSource/EditContactSourceTest.php
+++ b/app-modules/contact/tests/Tenant/ContactSource/EditContactSourceTest.php
@@ -114,8 +114,8 @@ test('EditContactSource is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/ContactSource/ListContactSourcesTest.php
+++ b/app-modules/contact/tests/Tenant/ContactSource/ListContactSourcesTest.php
@@ -89,7 +89,7 @@ test('ListContactSources is gated with proper access control', function () {
             ContactSourceResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/ContactSource/ViewContactSourceTest.php
+++ b/app-modules/contact/tests/Tenant/ContactSource/ViewContactSourceTest.php
@@ -74,8 +74,8 @@ test('ViewContactSource is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/ContactStatus/CreateContactStatusTest.php
+++ b/app-modules/contact/tests/Tenant/ContactStatus/CreateContactStatusTest.php
@@ -98,8 +98,8 @@ test('CreateContactStatus is gated with proper access control', function () {
     livewire(ContactStatusResource\Pages\CreateContactStatus::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/ContactStatus/EditContactStatusTest.php
+++ b/app-modules/contact/tests/Tenant/ContactStatus/EditContactStatusTest.php
@@ -123,8 +123,8 @@ test('EditContactStatus is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/ContactStatus/ListContactStatusesTest.php
+++ b/app-modules/contact/tests/Tenant/ContactStatus/ListContactStatusesTest.php
@@ -99,7 +99,7 @@ test('ListContactStatuses is gated with proper access control', function () {
             ContactStatusResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/ContactStatus/ViewContactStatusTest.php
+++ b/app-modules/contact/tests/Tenant/ContactStatus/ViewContactStatusTest.php
@@ -78,8 +78,8 @@ test('ViewContactStatus is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/OrganizationIndustry/CreateOrganizationIndustryTest.php
+++ b/app-modules/contact/tests/Tenant/OrganizationIndustry/CreateOrganizationIndustryTest.php
@@ -57,8 +57,8 @@ test('Create Organization Industry is gated with proper access control', functio
     livewire(CreateOrganizationIndustry::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -68,8 +68,8 @@ test('Create Organization Industry is gated with proper access control', functio
 test('Create New Organization Industry', function () {
     $user = User::factory()->licensed(Contact::getLicenseType())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user);
 

--- a/app-modules/contact/tests/Tenant/OrganizationIndustry/EditOrganizationIndustryTest.php
+++ b/app-modules/contact/tests/Tenant/OrganizationIndustry/EditOrganizationIndustryTest.php
@@ -60,8 +60,8 @@ test('Edit Organization Industry is gated with proper access control', function 
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -78,8 +78,8 @@ test('Edit Organization Industry Record', function () {
     $user = User::factory()->licensed(Contact::getLicenseType())->create();
     $organizationIndustry = OrganizationIndustry::factory()->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user);
 

--- a/app-modules/contact/tests/Tenant/OrganizationIndustry/ListOrganizationIndustryTest.php
+++ b/app-modules/contact/tests/Tenant/OrganizationIndustry/ListOrganizationIndustryTest.php
@@ -48,7 +48,7 @@ test('List OrganizationIndustry is gated with proper access control', function (
             OrganizationIndustryResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/OrganizationIndustry/ViewOrganizationIndustryTest.php
+++ b/app-modules/contact/tests/Tenant/OrganizationIndustry/ViewOrganizationIndustryTest.php
@@ -53,8 +53,8 @@ test('View OrganizationIndustry is gated with proper access control', function (
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/OrganizationType/CreateOrganizationTypeTest.php
+++ b/app-modules/contact/tests/Tenant/OrganizationType/CreateOrganizationTypeTest.php
@@ -57,8 +57,8 @@ test('Create Organization Type is gated with proper access control', function ()
     livewire(CreateOrganizationType::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -72,8 +72,8 @@ test('Create Organization Type is gated with proper access control', function ()
 test('Create New Organization Type', function () {
     $user = User::factory()->licensed(Contact::getLicenseType())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/OrganizationType/EditOrganizationTypeTest.php
+++ b/app-modules/contact/tests/Tenant/OrganizationType/EditOrganizationTypeTest.php
@@ -60,8 +60,8 @@ test('Edit Organization Type is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -79,8 +79,8 @@ test('Edit Organization Type Record', function () {
     $user = User::factory()->licensed(Contact::getLicenseType())->create();
     $organizationType = OrganizationType::factory()->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user);
 

--- a/app-modules/contact/tests/Tenant/OrganizationType/ListOrganizationTypeTest.php
+++ b/app-modules/contact/tests/Tenant/OrganizationType/ListOrganizationTypeTest.php
@@ -48,7 +48,7 @@ test('List OrganizationType is gated with proper access control', function () {
             OrganizationTypeResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/contact/tests/Tenant/OrganizationType/ViewOrganizationTypeTest.php
+++ b/app-modules/contact/tests/Tenant/OrganizationType/ViewOrganizationTypeTest.php
@@ -53,8 +53,8 @@ test('View OrganizationType is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(

--- a/app-modules/contract-management/src/Policies/ContractTypePolicy.php
+++ b/app-modules/contract-management/src/Policies/ContractTypePolicy.php
@@ -55,13 +55,13 @@ class ContractTypePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view contract types.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view contract types.'
@@ -70,7 +70,7 @@ class ContractTypePolicy
 
     public function view(Authenticatable $authenticatable, ContractType $contractType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this contract type.'
@@ -85,7 +85,7 @@ class ContractTypePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create contract types.'
@@ -100,7 +100,7 @@ class ContractTypePolicy
 
     public function update(Authenticatable $authenticatable, ContractType $contractType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this contract type.'
@@ -115,7 +115,7 @@ class ContractTypePolicy
 
     public function delete(Authenticatable $authenticatable, ContractType $contractType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this contract type.'
@@ -130,7 +130,7 @@ class ContractTypePolicy
 
     public function restore(Authenticatable $authenticatable, ContractType $contractType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this contract type.'
@@ -145,7 +145,7 @@ class ContractTypePolicy
 
     public function forceDelete(Authenticatable $authenticatable, ContractType $contractType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this contract type.'

--- a/app-modules/contract-management/src/Policies/ContractTypePolicy.php
+++ b/app-modules/contract-management/src/Policies/ContractTypePolicy.php
@@ -38,6 +38,7 @@ namespace AidingApp\ContractManagement\Policies;
 
 use AidingApp\Contact\Models\Contact;
 use AidingApp\ContractManagement\Models\ContractType;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -54,6 +55,13 @@ class ContractTypePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view contract types.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view contract types.'
@@ -62,6 +70,13 @@ class ContractTypePolicy
 
     public function view(Authenticatable $authenticatable, ContractType $contractType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this contract type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contractType->getKey()}.view"],
             denyResponse: 'You do not have permission to view this contract type.'
@@ -70,6 +85,13 @@ class ContractTypePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create contract types.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create contract types.'
@@ -78,6 +100,13 @@ class ContractTypePolicy
 
     public function update(Authenticatable $authenticatable, ContractType $contractType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this contract type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contractType->getKey()}.update"],
             denyResponse: 'You do not have permission to update this contract type.'
@@ -86,6 +115,13 @@ class ContractTypePolicy
 
     public function delete(Authenticatable $authenticatable, ContractType $contractType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this contract type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contractType->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this contract type.'
@@ -94,6 +130,13 @@ class ContractTypePolicy
 
     public function restore(Authenticatable $authenticatable, ContractType $contractType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this contract type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contractType->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this contract type.'
@@ -102,6 +145,13 @@ class ContractTypePolicy
 
     public function forceDelete(Authenticatable $authenticatable, ContractType $contractType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this contract type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$contractType->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this contract type.'

--- a/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
@@ -55,13 +55,13 @@ class EmailTemplatePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view email templates.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view email templates.'
@@ -70,9 +70,9 @@ class EmailTemplatePolicy
 
     public function view(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.view",
+                abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this email template.'
             );
         }
@@ -85,7 +85,7 @@ class EmailTemplatePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create email templates.'
@@ -100,9 +100,9 @@ class EmailTemplatePolicy
 
     public function update(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.update",
+                abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this email template.'
             );
         }
@@ -115,7 +115,7 @@ class EmailTemplatePolicy
 
     public function delete(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this email template.'
@@ -130,7 +130,7 @@ class EmailTemplatePolicy
 
     public function restore(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this email template.'
@@ -145,13 +145,13 @@ class EmailTemplatePolicy
 
     public function forceDelete(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this email template.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this email template.'

--- a/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
@@ -38,6 +38,7 @@ namespace AidingApp\Engagement\Policies;
 
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Engagement\Models\EmailTemplate;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -54,6 +55,13 @@ class EmailTemplatePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view email templates.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view email templates.'
@@ -62,6 +70,13 @@ class EmailTemplatePolicy
 
     public function view(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.view",
+                denyResponse: 'You do not have permission to view this email template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.view'],
             denyResponse: 'You do not have permission to view this email template.'
@@ -70,6 +85,13 @@ class EmailTemplatePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create email templates.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create email templates.'
@@ -78,6 +100,13 @@ class EmailTemplatePolicy
 
     public function update(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.update",
+                denyResponse: 'You do not have permission to update this email template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.update'],
             denyResponse: 'You do not have permission to update this email template.'
@@ -86,6 +115,13 @@ class EmailTemplatePolicy
 
     public function delete(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this email template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.delete'],
             denyResponse: 'You do not have permission to delete this email template.'
@@ -94,6 +130,13 @@ class EmailTemplatePolicy
 
     public function restore(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this email template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.restore'],
             denyResponse: 'You do not have permission to restore this email template.'
@@ -102,6 +145,13 @@ class EmailTemplatePolicy
 
     public function forceDelete(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this email template.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this email template.'

--- a/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
@@ -57,7 +57,7 @@ class EmailTemplatePolicy
     {
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
-                abilities: 'settings.*.view',
+                abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view email templates.'
             );
         }

--- a/app-modules/inventory-management/src/Policies/MaintenanceProviderPolicy.php
+++ b/app-modules/inventory-management/src/Policies/MaintenanceProviderPolicy.php
@@ -37,7 +37,6 @@
 namespace AidingApp\InventoryManagement\Policies;
 
 use AidingApp\InventoryManagement\Models\MaintenanceProvider;
-use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -45,13 +44,6 @@ class MaintenanceProviderPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
-            return $authenticatable->canOrElse(
-                abilities: 'settings.view-any',
-                denyResponse: 'You do not have permission to view maintenance providers.'
-            );
-        }
-
         return $authenticatable->canOrElse(
             abilities: 'maintenance_provider.view-any',
             denyResponse: 'You do not have permission to view maintenance providers.'
@@ -60,12 +52,6 @@ class MaintenanceProviderPolicy
 
     public function view(Authenticatable $authenticatable, MaintenanceProvider $maintenanceProvider): Response
     {
-        if(SettingsPermissions::active()){
-            return $authenticatable->canOrElse(
-                abilities: 'settings.*.view',
-                denyResponse: 'You do not have permission to view this maintenance provider.'
-            );
-        }
         return $authenticatable->canOrElse(
             abilities: ['maintenance_provider.*.view', "maintenance_provider.{$maintenanceProvider->id}.view"],
             denyResponse: 'You do not have permission to view this maintenance provider.'
@@ -74,12 +60,6 @@ class MaintenanceProviderPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
-            return $authenticatable->canOrElse(
-                abilities: 'settings.create',
-                denyResponse: 'You do not have permission to create maintenance providers.'
-            );
-        }
         return $authenticatable->canOrElse(
             abilities: 'maintenance_provider.create',
             denyResponse: 'You do not have permission to create maintenance providers.'
@@ -88,13 +68,6 @@ class MaintenanceProviderPolicy
 
     public function update(Authenticatable $authenticatable, MaintenanceProvider $maintenanceProvider): Response
     {
-        if(SettingsPermissions::active()){
-            return $authenticatable->canOrElse(
-                abilities: ['settings.*.update'],
-                denyResponse: 'You do not have permission to update this maintenance provider.'
-            );
-        }
-
         return $authenticatable->canOrElse(
             abilities: ['maintenance_provider.*.update', "maintenance_provider.{$maintenanceProvider->id}.update"],
             denyResponse: 'You do not have permission to update this maintenance provider.'
@@ -103,13 +76,6 @@ class MaintenanceProviderPolicy
 
     public function delete(Authenticatable $authenticatable, MaintenanceProvider $maintenanceProvider): Response
     {
-        if(SettingsPermissions::active()){
-            return $authenticatable->canOrElse(
-                abilities: ['settings.*.delete'],
-                denyResponse: 'You do not have permission to delete this maintenance provider.'
-            );
-        }
-
         return $authenticatable->canOrElse(
             abilities: ['maintenance_provider.*.delete', "maintenance_provider.{$maintenanceProvider->id}.delete"],
             denyResponse: 'You do not have permission to delete this maintenance provider.'
@@ -118,13 +84,6 @@ class MaintenanceProviderPolicy
 
     public function restore(Authenticatable $authenticatable, MaintenanceProvider $maintenanceProvider): Response
     {
-        if(SettingsPermissions::active()){
-            return $authenticatable->canOrElse(
-                abilities: ['settings.*.restore'],
-                denyResponse: 'You do not have permission to restore this maintenance provider.'
-            );
-        }
-
         return $authenticatable->canOrElse(
             abilities: ['maintenance_provider.*.restore', "maintenance_provider.{$maintenanceProvider->id}.restore"],
             denyResponse: 'You do not have permission to restore this maintenance provider.'
@@ -133,13 +92,6 @@ class MaintenanceProviderPolicy
 
     public function forceDelete(Authenticatable $authenticatable, MaintenanceProvider $maintenanceProvider): Response
     {
-        if(SettingsPermissions::active()){
-            return $authenticatable->canOrElse(
-                abilities: ['settings.*.force-delete'],
-                denyResponse: 'You do not have permission to permanently delete this maintenance provider.'
-            );
-        }
-
         return $authenticatable->canOrElse(
             abilities: ['maintenance_provider.*.force-delete', "maintenance_provider.{$maintenanceProvider->id}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this maintenance provider.'

--- a/app-modules/inventory-management/src/Policies/MaintenanceProviderPolicy.php
+++ b/app-modules/inventory-management/src/Policies/MaintenanceProviderPolicy.php
@@ -37,6 +37,7 @@
 namespace AidingApp\InventoryManagement\Policies;
 
 use AidingApp\InventoryManagement\Models\MaintenanceProvider;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -44,6 +45,13 @@ class MaintenanceProviderPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view maintenance providers.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'maintenance_provider.view-any',
             denyResponse: 'You do not have permission to view maintenance providers.'
@@ -52,6 +60,12 @@ class MaintenanceProviderPolicy
 
     public function view(Authenticatable $authenticatable, MaintenanceProvider $maintenanceProvider): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this maintenance provider.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: ['maintenance_provider.*.view', "maintenance_provider.{$maintenanceProvider->id}.view"],
             denyResponse: 'You do not have permission to view this maintenance provider.'
@@ -60,6 +74,12 @@ class MaintenanceProviderPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create maintenance providers.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: 'maintenance_provider.create',
             denyResponse: 'You do not have permission to create maintenance providers.'
@@ -68,6 +88,13 @@ class MaintenanceProviderPolicy
 
     public function update(Authenticatable $authenticatable, MaintenanceProvider $maintenanceProvider): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update this maintenance provider.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['maintenance_provider.*.update', "maintenance_provider.{$maintenanceProvider->id}.update"],
             denyResponse: 'You do not have permission to update this maintenance provider.'
@@ -76,6 +103,13 @@ class MaintenanceProviderPolicy
 
     public function delete(Authenticatable $authenticatable, MaintenanceProvider $maintenanceProvider): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permission to delete this maintenance provider.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['maintenance_provider.*.delete', "maintenance_provider.{$maintenanceProvider->id}.delete"],
             denyResponse: 'You do not have permission to delete this maintenance provider.'
@@ -84,6 +118,13 @@ class MaintenanceProviderPolicy
 
     public function restore(Authenticatable $authenticatable, MaintenanceProvider $maintenanceProvider): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permission to restore this maintenance provider.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['maintenance_provider.*.restore', "maintenance_provider.{$maintenanceProvider->id}.restore"],
             denyResponse: 'You do not have permission to restore this maintenance provider.'
@@ -92,6 +133,13 @@ class MaintenanceProviderPolicy
 
     public function forceDelete(Authenticatable $authenticatable, MaintenanceProvider $maintenanceProvider): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permission to permanently delete this maintenance provider.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['maintenance_provider.*.force-delete', "maintenance_provider.{$maintenanceProvider->id}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this maintenance provider.'

--- a/app-modules/knowledge-base/src/Policies/KnowledgeBaseCategoryPolicy.php
+++ b/app-modules/knowledge-base/src/Policies/KnowledgeBaseCategoryPolicy.php
@@ -65,14 +65,14 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
     }
 
     public function viewAny(Authenticatable $authenticatable): Response
-    {   
-        if(SettingsPermissions::active()){
+    {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permissions to view knowledge base categories.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permissions to view knowledge base categories.'
@@ -81,7 +81,7 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, KnowledgeBaseCategory $knowledgeBaseCategory): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permissions to view this knowledge base category.'
@@ -96,7 +96,7 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permissions to create knowledge base categories.'
@@ -111,7 +111,7 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, KnowledgeBaseCategory $knowledgeBaseCategory): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permissions to update this knowledge base category.'
@@ -126,7 +126,7 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, KnowledgeBaseCategory $knowledgeBaseCategory): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permissions to delete this knowledge base category.'
@@ -141,7 +141,7 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, KnowledgeBaseCategory $knowledgeBaseCategory): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permissions to restore this knowledge base category.'
@@ -156,13 +156,13 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, KnowledgeBaseCategory $knowledgeBaseCategory): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permissions to permanently delete this knowledge base category.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseCategory->getKey()}.force-delete"],
             denyResponse: 'You do not have permissions to permanently delete this knowledge base category.'

--- a/app-modules/knowledge-base/src/Policies/KnowledgeBaseCategoryPolicy.php
+++ b/app-modules/knowledge-base/src/Policies/KnowledgeBaseCategoryPolicy.php
@@ -41,6 +41,7 @@ use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -64,7 +65,14 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
     }
 
     public function viewAny(Authenticatable $authenticatable): Response
-    {
+    {   
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permissions to view knowledge base categories.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permissions to view knowledge base categories.'
@@ -73,6 +81,13 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, KnowledgeBaseCategory $knowledgeBaseCategory): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permissions to view this knowledge base category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseCategory->getKey()}.view"],
             denyResponse: 'You do not have permissions to view this knowledge base category.'
@@ -81,6 +96,13 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permissions to create knowledge base categories.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permissions to create knowledge base categories.'
@@ -89,6 +111,13 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, KnowledgeBaseCategory $knowledgeBaseCategory): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permissions to update this knowledge base category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseCategory->getKey()}.update"],
             denyResponse: 'You do not have permissions to update this knowledge base category.'
@@ -97,6 +126,13 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, KnowledgeBaseCategory $knowledgeBaseCategory): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permissions to delete this knowledge base category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseCategory->getKey()}.delete"],
             denyResponse: 'You do not have permissions to delete this knowledge base category.'
@@ -105,6 +141,13 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, KnowledgeBaseCategory $knowledgeBaseCategory): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permissions to restore this knowledge base category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseCategory->getKey()}.restore"],
             denyResponse: 'You do not have permissions to restore this knowledge base category.'
@@ -113,6 +156,13 @@ class KnowledgeBaseCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, KnowledgeBaseCategory $knowledgeBaseCategory): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permissions to permanently delete this knowledge base category.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseCategory->getKey()}.force-delete"],
             denyResponse: 'You do not have permissions to permanently delete this knowledge base category.'

--- a/app-modules/knowledge-base/src/Policies/KnowledgeBaseQualityPolicy.php
+++ b/app-modules/knowledge-base/src/Policies/KnowledgeBaseQualityPolicy.php
@@ -66,13 +66,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view any knowledge base qualities.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view any knowledge base qualities.'
@@ -81,9 +81,9 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, KnowledgeBaseQuality $knowledgeBaseQuality): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.view",
+                abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this knowledge base quality.'
             );
         }
@@ -96,7 +96,7 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create knowledge base qualities.'
@@ -111,9 +111,9 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, KnowledgeBaseQuality $knowledgeBaseQuality): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.update",
+                abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this knowledge base quality.'
             );
         }
@@ -126,12 +126,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, KnowledgeBaseQuality $knowledgeBaseQuality): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.delete",
+                abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this knowledge base quality.'
             );
         }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this knowledge base quality.'
@@ -140,9 +141,9 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, KnowledgeBaseQuality $knowledgeBaseQuality): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.restore",
+                abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this knowledge base quality.'
             );
         }
@@ -155,13 +156,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, KnowledgeBaseQuality $knowledgeBaseQuality): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.force-delete",
+                abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this knowledge base quality.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this knowledge base quality.'

--- a/app-modules/knowledge-base/src/Policies/KnowledgeBaseQualityPolicy.php
+++ b/app-modules/knowledge-base/src/Policies/KnowledgeBaseQualityPolicy.php
@@ -68,14 +68,14 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
     {
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
-                abilities: 'product_admin.view-any',
-                denyResponse: 'You do not have permission to view any knowledge base categories.'
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view any knowledge base qualities.'
             );
         }
         
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
-            denyResponse: 'You do not have permission to view any knowledge base categories.'
+            denyResponse: 'You do not have permission to view any knowledge base qualities.'
         );
     }
 
@@ -84,13 +84,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: "settings.*.view",
-                denyResponse: 'You do not have permission to view this knowledge base category.'
+                denyResponse: 'You do not have permission to view this knowledge base quality.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.view"],
-            denyResponse: 'You do not have permission to view this knowledge base category.'
+            denyResponse: 'You do not have permission to view this knowledge base quality.'
         );
     }
 
@@ -98,14 +98,14 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
     {
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
-                abilities: 'settings.*.create',
-                denyResponse: 'You do not have permission to create knowledge base categories.'
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create knowledge base qualities.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
-            denyResponse: 'You do not have permission to create knowledge base categories.'
+            denyResponse: 'You do not have permission to create knowledge base qualities.'
         );
     }
 
@@ -114,13 +114,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: "settings.*.update",
-                denyResponse: 'You do not have permission to update this knowledge base category.'
+                denyResponse: 'You do not have permission to update this knowledge base quality.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.update"],
-            denyResponse: 'You do not have permission to update this knowledge base category.'
+            denyResponse: 'You do not have permission to update this knowledge base quality.'
         );
     }
 
@@ -129,12 +129,12 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: "settings.*.delete",
-                denyResponse: 'You do not have permission to delete this knowledge base category.'
+                denyResponse: 'You do not have permission to delete this knowledge base quality.'
             );
         }
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.delete"],
-            denyResponse: 'You do not have permission to delete this knowledge base category.'
+            denyResponse: 'You do not have permission to delete this knowledge base quality.'
         );
     }
 
@@ -143,13 +143,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: "settings.*.restore",
-                denyResponse: 'You do not have permission to restore this knowledge base category.'
+                denyResponse: 'You do not have permission to restore this knowledge base quality.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.restore"],
-            denyResponse: 'You do not have permission to restore this knowledge base category.'
+            denyResponse: 'You do not have permission to restore this knowledge base quality.'
         );
     }
 
@@ -158,13 +158,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: "settings.*.force-delete",
-                denyResponse: 'You do not have permission to permanently delete this knowledge base category.'
+                denyResponse: 'You do not have permission to permanently delete this knowledge base quality.'
             );
         }
         
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.force-delete"],
-            denyResponse: 'You do not have permission to permanently delete this knowledge base category.'
+            denyResponse: 'You do not have permission to permanently delete this knowledge base quality.'
         );
     }
 

--- a/app-modules/knowledge-base/src/Policies/KnowledgeBaseQualityPolicy.php
+++ b/app-modules/knowledge-base/src/Policies/KnowledgeBaseQualityPolicy.php
@@ -41,6 +41,7 @@ use AidingApp\KnowledgeBase\Models\KnowledgeBaseQuality;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -65,6 +66,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'product_admin.view-any',
+                denyResponse: 'You do not have permission to view any knowledge base categories.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view any knowledge base categories.'
@@ -73,6 +81,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, KnowledgeBaseQuality $knowledgeBaseQuality): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.view",
+                denyResponse: 'You do not have permission to view this knowledge base category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.view"],
             denyResponse: 'You do not have permission to view this knowledge base category.'
@@ -81,6 +96,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.create',
+                denyResponse: 'You do not have permission to create knowledge base categories.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create knowledge base categories.'
@@ -89,6 +111,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, KnowledgeBaseQuality $knowledgeBaseQuality): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.update",
+                denyResponse: 'You do not have permission to update this knowledge base category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.update"],
             denyResponse: 'You do not have permission to update this knowledge base category.'
@@ -97,6 +126,12 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, KnowledgeBaseQuality $knowledgeBaseQuality): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.delete",
+                denyResponse: 'You do not have permission to delete this knowledge base category.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this knowledge base category.'
@@ -105,6 +140,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, KnowledgeBaseQuality $knowledgeBaseQuality): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.restore",
+                denyResponse: 'You do not have permission to restore this knowledge base category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this knowledge base category.'
@@ -113,6 +155,13 @@ class KnowledgeBaseQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, KnowledgeBaseQuality $knowledgeBaseQuality): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.force-delete",
+                denyResponse: 'You do not have permission to permanently delete this knowledge base category.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseQuality->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this knowledge base category.'

--- a/app-modules/knowledge-base/src/Policies/KnowledgeBaseStatusPolicy.php
+++ b/app-modules/knowledge-base/src/Policies/KnowledgeBaseStatusPolicy.php
@@ -41,6 +41,7 @@ use AidingApp\KnowledgeBase\Models\KnowledgeBaseStatus;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -65,6 +66,13 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view any knowledge base statuses.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view any knowledge base statuses.'
@@ -73,6 +81,13 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, KnowledgeBaseStatus $knowledgeBaseStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.view",
+                denyResponse: 'You do not have permission to view this knowledge base status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseStatus->getKey()}.view"],
             denyResponse: 'You do not have permission to view this knowledge base status.'
@@ -81,6 +96,13 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create knowledge base statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create knowledge base statuses.'
@@ -89,6 +111,13 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, KnowledgeBaseStatus $knowledgeBaseStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.update",
+                denyResponse: 'You do not have permission to update this knowledge base status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseStatus->getKey()}.update"],
             denyResponse: 'You do not have permission to update this knowledge base status.'
@@ -97,6 +126,13 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, KnowledgeBaseStatus $knowledgeBaseStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.delete",
+                denyResponse: 'You do not have permission to delete this knowledge base status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseStatus->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this knowledge base status.'
@@ -105,6 +141,13 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, KnowledgeBaseStatus $knowledgeBaseStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.restore",
+                denyResponse: 'You do not have permission to restore this knowledge base status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseStatus->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this knowledge base status.'
@@ -113,6 +156,13 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, KnowledgeBaseStatus $knowledgeBaseStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.force-delete",
+                denyResponse: 'You do not have permission to permanently delete this knowledge base status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$knowledgeBaseStatus->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this knowledge base status.'

--- a/app-modules/knowledge-base/src/Policies/KnowledgeBaseStatusPolicy.php
+++ b/app-modules/knowledge-base/src/Policies/KnowledgeBaseStatusPolicy.php
@@ -66,13 +66,13 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view any knowledge base statuses.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view any knowledge base statuses.'
@@ -81,9 +81,9 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, KnowledgeBaseStatus $knowledgeBaseStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.view",
+                abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this knowledge base status.'
             );
         }
@@ -96,7 +96,7 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create knowledge base statuses.'
@@ -111,9 +111,9 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, KnowledgeBaseStatus $knowledgeBaseStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.update",
+                abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this knowledge base status.'
             );
         }
@@ -126,9 +126,9 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, KnowledgeBaseStatus $knowledgeBaseStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.delete",
+                abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this knowledge base status.'
             );
         }
@@ -141,9 +141,9 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, KnowledgeBaseStatus $knowledgeBaseStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.restore",
+                abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this knowledge base status.'
             );
         }
@@ -156,9 +156,9 @@ class KnowledgeBaseStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, KnowledgeBaseStatus $knowledgeBaseStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.force-delete",
+                abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this knowledge base status.'
             );
         }

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseCategory/CreateKnowledgeBaseCategoryTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseCategory/CreateKnowledgeBaseCategoryTest.php
@@ -64,8 +64,8 @@ test('CreateKnowledgeBaseCategory is gated with proper access control', function
     livewire(KnowledgeBaseCategoryResource\Pages\CreateKnowledgeBaseCategory::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -93,8 +93,8 @@ test('CreateKnowledgeBaseCategory is gated with proper feature access control', 
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseCategory/EditKnowledgeBaseCategoryTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseCategory/EditKnowledgeBaseCategoryTest.php
@@ -74,8 +74,8 @@ test('EditKnowledgeBaseCategory is gated with proper access control', function (
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -105,8 +105,8 @@ test('EditKnowledgeBaseCategory is gated with proper feature access control', fu
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $knowledgeBaseCategory = KnowledgeBaseCategory::factory()->create();
 
@@ -148,9 +148,9 @@ test('EditKnowledgeBaseCategory is gated with proper feature access control', fu
 test('can create subcategory', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user);
 
@@ -177,8 +177,8 @@ test('can create subcategory', function () {
 test('exclude already attached subcategories in search', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user);
 
@@ -207,8 +207,8 @@ test('exclude already attached subcategories in search', function () {
 test('can attach subcategories into categories', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user);
 

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseCategory/ListKnowledgeBaseCategoryTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseCategory/ListKnowledgeBaseCategoryTest.php
@@ -56,7 +56,7 @@ test('ListKnowledgeBaseCategory is gated with proper access control', function (
             KnowledgeBaseCategoryResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -73,7 +73,7 @@ test('ListKnowledgeBaseCategory is gated with proper feature access control', fu
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -102,7 +102,7 @@ test('ListKnowledgeBaseCategory is gated with proper license access control', fu
 
     // And the authenticatable has the correct permissions
     // But they do not have the appropriate license
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     // They should not be able to access the resource
     actingAs($user)

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseCategory/ViewKnowledgeBaseCategoryTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseCategory/ViewKnowledgeBaseCategoryTest.php
@@ -59,8 +59,8 @@ test('ViewKnowledgeBaseCategory is gated with proper access control', function (
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(
@@ -79,8 +79,8 @@ test('ViewKnowledgeBaseCategory is gated with proper feature access control', fu
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $knowledgeBaseCategory = KnowledgeBaseCategory::factory()->create();
 

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseQuality/CreateKnowledgeBaseQualityTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseQuality/CreateKnowledgeBaseQualityTest.php
@@ -64,8 +64,8 @@ test('CreateKnowledgeBaseQuality is gated with proper access control', function 
     livewire(KnowledgeBaseQualityResource\Pages\CreateKnowledgeBaseQuality::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -93,8 +93,8 @@ test('CreateKnowledgeBaseQuality is gated with proper feature ccess control', fu
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseQuality/EditKnowledgeBaseCategoryTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseQuality/EditKnowledgeBaseCategoryTest.php
@@ -69,8 +69,8 @@ test('EditKnowledgeBaseQuality is gated with proper access control', function ()
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -100,8 +100,8 @@ test('EditKnowledgeBaseQuality is gated with proper feature access control', fun
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $knowledgeBaseQuality = KnowledgeBaseQuality::factory()->create();
 

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseQuality/ListKnowledgeBaseQualityTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseQuality/ListKnowledgeBaseQualityTest.php
@@ -56,7 +56,7 @@ test('ListKnowledgeBaseQuality is gated with proper access control', function ()
             KnowledgeBaseQualityResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -73,7 +73,7 @@ test('ListKnowledgeBaseQuality is gated with proper feature access control', fun
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -102,7 +102,7 @@ test('ListKnowledgeBaseQuality is gated with proper license access control', fun
 
     // And the authenticatable has the correct permissions
     // But they do not have the appropriate license
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     // They should not be able to access the resource
     actingAs($user)

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseQuality/ViewKnowledgeBaseQualityTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseQuality/ViewKnowledgeBaseQualityTest.php
@@ -59,8 +59,8 @@ test('ViewKnowledgeBaseQuality is gated with proper access control', function ()
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(
@@ -79,8 +79,8 @@ test('ViewKnowledgeBaseQuality is gated with proper feature access control', fun
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $knowledgeBaseQuality = KnowledgeBaseQuality::factory()->create();
 

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseStatus/CreateKnowledgeBaseStatusTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseStatus/CreateKnowledgeBaseStatusTest.php
@@ -64,8 +64,8 @@ test('CreateKnowledgeBaseStatus is gated with proper access control', function (
     livewire(KnowledgeBaseStatusResource\Pages\CreateKnowledgeBaseStatus::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -93,8 +93,8 @@ test('CreateKnowledgeBaseStatus is gated with proper feature access control', fu
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseStatus/EditKnowledgeBaseStatusTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseStatus/EditKnowledgeBaseStatusTest.php
@@ -69,8 +69,8 @@ test('EditKnowledgeBaseStatus is gated with proper access control', function () 
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -100,8 +100,8 @@ test('EditKnowledgeBaseStatus is gated with proper feature access control', func
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $knowledgeBaseStatus = KnowledgeBaseStatus::factory()->create();
 

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseStatus/ListKnowledgeBaseStatusesTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseStatus/ListKnowledgeBaseStatusesTest.php
@@ -56,7 +56,7 @@ test('ListKnowledgeBaseStatuses is gated with proper access control', function (
             KnowledgeBaseStatusResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -73,7 +73,7 @@ test('ListKnowledgeBaseStatuses is gated with proper feature access control', fu
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -102,7 +102,7 @@ test('ListKnowledgeBaseStatus is gated with proper license access control', func
 
     // And the authenticatable has the correct permissions
     // But they do not have the appropriate license
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     // They should not be able to access the resource
     actingAs($user)

--- a/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseStatus/ViewKnowledgeBaseStatusTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/KnowledgeBaseStatus/ViewKnowledgeBaseStatusTest.php
@@ -59,8 +59,8 @@ test('ViewKnowledgeBaseStatus is gated with proper access control', function () 
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(
@@ -79,8 +79,8 @@ test('ViewKnowledgeBaseStatus is gated with proper feature access control', func
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $knowledgeBaseStatus = KnowledgeBaseStatus::factory()->create();
 

--- a/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
+++ b/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
@@ -41,6 +41,7 @@ use AidingApp\Portal\Enums\GdprBannerButtonLabel;
 use AidingApp\Portal\Enums\GdprDeclineOptions;
 use AidingApp\Portal\Settings\PortalSettings;
 use App\Enums\Feature;
+use App\Features\SettingsPermissions;
 use App\Filament\Forms\Components\ColorSelect;
 use App\Models\User;
 use App\Rules\ValidUrl;
@@ -70,14 +71,14 @@ class ManagePortalSettings extends SettingsPage
 
     protected static ?string $title = 'Client Portal';
 
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     public static function canAccess(): bool
     {
         /** @var User $user */
         $user = auth()->user();
 
-        return $user->can(['product_admin.view-any']);
+        return SettingsPermissions::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
     }
 
     public function form(Form $form): Form

--- a/app-modules/service-management/src/Policies/IncidentSeverityPolicy.php
+++ b/app-modules/service-management/src/Policies/IncidentSeverityPolicy.php
@@ -37,6 +37,7 @@
 namespace AidingApp\ServiceManagement\Policies;
 
 use AidingApp\ServiceManagement\Models\IncidentSeverity;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -44,6 +45,13 @@ class IncidentSeverityPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view any incident severities.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view any incident severities.'
@@ -52,6 +60,13 @@ class IncidentSeverityPolicy
 
     public function view(Authenticatable $authenticatable, IncidentSeverity $incidentSeverity): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this incident severity.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$incidentSeverity->getKey()}.view"],
             denyResponse: 'You do not have permission to view this incident severity.'
@@ -60,6 +75,13 @@ class IncidentSeverityPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create incident severities.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create incident severities.'
@@ -68,6 +90,13 @@ class IncidentSeverityPolicy
 
     public function update(Authenticatable $authenticatable, IncidentSeverity $incidentSeverity): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this incident severity.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$incidentSeverity->getKey()}.update"],
             denyResponse: 'You do not have permission to update this incident severity.'
@@ -80,6 +109,13 @@ class IncidentSeverityPolicy
             return Response::deny('The incident severity cannot be deleted because it is associated with a incident.');
         }
 
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this incident severity.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$incidentSeverity->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this incident severity.'
@@ -88,6 +124,13 @@ class IncidentSeverityPolicy
 
     public function restore(Authenticatable $authenticatable, IncidentSeverity $incidentSeverity): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this incident severity.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$incidentSeverity->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this incident severity.'
@@ -98,6 +141,13 @@ class IncidentSeverityPolicy
     {
         if ($incidentSeverity->incidents()->exists()) {
             return Response::deny('The incident severity cannot be deleted because it is associated with a incident.');
+        }
+
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this incident severity.'
+            );
         }
 
         return $authenticatable->canOrElse(

--- a/app-modules/service-management/src/Policies/IncidentSeverityPolicy.php
+++ b/app-modules/service-management/src/Policies/IncidentSeverityPolicy.php
@@ -45,7 +45,7 @@ class IncidentSeverityPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view any incident severities.'
@@ -60,7 +60,7 @@ class IncidentSeverityPolicy
 
     public function view(Authenticatable $authenticatable, IncidentSeverity $incidentSeverity): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this incident severity.'
@@ -75,7 +75,7 @@ class IncidentSeverityPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create incident severities.'
@@ -90,7 +90,7 @@ class IncidentSeverityPolicy
 
     public function update(Authenticatable $authenticatable, IncidentSeverity $incidentSeverity): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this incident severity.'
@@ -109,7 +109,7 @@ class IncidentSeverityPolicy
             return Response::deny('The incident severity cannot be deleted because it is associated with a incident.');
         }
 
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this incident severity.'
@@ -124,7 +124,7 @@ class IncidentSeverityPolicy
 
     public function restore(Authenticatable $authenticatable, IncidentSeverity $incidentSeverity): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this incident severity.'
@@ -143,7 +143,7 @@ class IncidentSeverityPolicy
             return Response::deny('The incident severity cannot be deleted because it is associated with a incident.');
         }
 
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this incident severity.'

--- a/app-modules/service-management/src/Policies/IncidentStatusPolicy.php
+++ b/app-modules/service-management/src/Policies/IncidentStatusPolicy.php
@@ -45,13 +45,13 @@ class IncidentStatusPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view any incident statuses.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view any incident statuses.'
@@ -60,7 +60,7 @@ class IncidentStatusPolicy
 
     public function view(Authenticatable $authenticatable, IncidentStatus $incidentStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this incident status.'
@@ -75,7 +75,7 @@ class IncidentStatusPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create incident statuses.'
@@ -90,7 +90,7 @@ class IncidentStatusPolicy
 
     public function update(Authenticatable $authenticatable, IncidentStatus $incidentStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this incident status.'
@@ -109,7 +109,7 @@ class IncidentStatusPolicy
             return Response::deny('The incident status cannot be deleted because it is associated with a incident.');
         }
 
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this incident status.'
@@ -124,7 +124,7 @@ class IncidentStatusPolicy
 
     public function restore(Authenticatable $authenticatable, IncidentStatus $incidentStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this incident status.'
@@ -143,7 +143,7 @@ class IncidentStatusPolicy
             return Response::deny('The incident status cannot be deleted because it is associated with a incident.');
         }
 
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this incident status.'

--- a/app-modules/service-management/src/Policies/IncidentStatusPolicy.php
+++ b/app-modules/service-management/src/Policies/IncidentStatusPolicy.php
@@ -37,6 +37,7 @@
 namespace AidingApp\ServiceManagement\Policies;
 
 use AidingApp\ServiceManagement\Models\IncidentStatus;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -44,6 +45,13 @@ class IncidentStatusPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view any incident statuses.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view any incident statuses.'
@@ -52,6 +60,13 @@ class IncidentStatusPolicy
 
     public function view(Authenticatable $authenticatable, IncidentStatus $incidentStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this incident status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$incidentStatus->getKey()}.view"],
             denyResponse: 'You do not have permission to view this incident status.'
@@ -60,6 +75,13 @@ class IncidentStatusPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create incident statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create incident statuses.'
@@ -68,6 +90,13 @@ class IncidentStatusPolicy
 
     public function update(Authenticatable $authenticatable, IncidentStatus $incidentStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this incident status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$incidentStatus->getKey()}.update"],
             denyResponse: 'You do not have permission to update this incident status.'
@@ -80,6 +109,13 @@ class IncidentStatusPolicy
             return Response::deny('The incident status cannot be deleted because it is associated with a incident.');
         }
 
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this incident status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$incidentStatus->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this incident status.'
@@ -88,6 +124,13 @@ class IncidentStatusPolicy
 
     public function restore(Authenticatable $authenticatable, IncidentStatus $incidentStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this incident status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$incidentStatus->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this incident status.'
@@ -98,6 +141,13 @@ class IncidentStatusPolicy
     {
         if ($incidentStatus->incidents()->exists()) {
             return Response::deny('The incident status cannot be deleted because it is associated with a incident.');
+        }
+
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this incident status.'
+            );
         }
 
         return $authenticatable->canOrElse(

--- a/app-modules/service-management/src/Policies/ServiceRequestFormPolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestFormPolicy.php
@@ -41,6 +41,7 @@ use AidingApp\ServiceManagement\Models\ServiceRequestForm;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -65,6 +66,13 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view service request forms.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view service request forms.'
@@ -73,6 +81,12 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, ServiceRequestForm $serviceRequestForm): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this service request form.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestForm->getKey()}.view"],
             denyResponse: 'You do not have permission to view this service request form.'
@@ -81,6 +95,13 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create service request forms.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create service request forms.'
@@ -89,6 +110,13 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, ServiceRequestForm $serviceRequestForm): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this service request form.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestForm->getKey()}.update"],
             denyResponse: 'You do not have permission to update this service request form.'
@@ -97,6 +125,13 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, ServiceRequestForm $serviceRequestForm): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this service request form.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestForm->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this service request form.'
@@ -105,6 +140,13 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, ServiceRequestForm $serviceRequestForm): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this service request form.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestForm->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this service request form.'
@@ -113,6 +155,13 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, ServiceRequestForm $serviceRequestForm): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this service request form.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestForm->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this service request form.'

--- a/app-modules/service-management/src/Policies/ServiceRequestFormPolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestFormPolicy.php
@@ -66,7 +66,7 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view service request forms.'
@@ -81,12 +81,13 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, ServiceRequestForm $serviceRequestForm): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this service request form.'
             );
         }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestForm->getKey()}.view"],
             denyResponse: 'You do not have permission to view this service request form.'
@@ -95,7 +96,7 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create service request forms.'
@@ -110,7 +111,7 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, ServiceRequestForm $serviceRequestForm): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this service request form.'
@@ -125,7 +126,7 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, ServiceRequestForm $serviceRequestForm): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this service request form.'
@@ -140,7 +141,7 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, ServiceRequestForm $serviceRequestForm): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this service request form.'
@@ -155,7 +156,7 @@ class ServiceRequestFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, ServiceRequestForm $serviceRequestForm): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this service request form.'

--- a/app-modules/service-management/src/Policies/ServiceRequestStatusPolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestStatusPolicy.php
@@ -39,6 +39,7 @@ namespace AidingApp\ServiceManagement\Policies;
 use AidingApp\Contact\Models\Contact;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use App\Enums\Feature;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Support\FeatureAccessResponse;
 use Illuminate\Auth\Access\Response;
@@ -63,6 +64,13 @@ class ServiceRequestStatusPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permissions to view service request statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permissions to view service request statuses.'
@@ -71,6 +79,13 @@ class ServiceRequestStatusPolicy
 
     public function view(Authenticatable $authenticatable, ServiceRequestStatus $serviceRequestStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permissions to view this service request status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestStatus->getKey()}.view"],
             denyResponse: 'You do not have permissions to view this service request status.'
@@ -79,6 +94,13 @@ class ServiceRequestStatusPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permissions to create service request statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permissions to create service request statuses.'
@@ -89,6 +111,13 @@ class ServiceRequestStatusPolicy
     {
         if ($serviceRequestStatus->is_system_protected) {
             return Response::deny('You cannot update this service request status because it is system protected.');
+        }
+
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permissions to update this service request status.'
+            );
         }
 
         return $authenticatable->canOrElse(
@@ -103,6 +132,13 @@ class ServiceRequestStatusPolicy
             return Response::deny('You cannot delete this service request status because it is system protected.');
         }
 
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permissions to delete this service request status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestStatus->getKey()}.delete"],
             denyResponse: 'You do not have permissions to delete this service request status.'
@@ -111,6 +147,13 @@ class ServiceRequestStatusPolicy
 
     public function restore(Authenticatable $authenticatable, ServiceRequestStatus $serviceRequestStatus): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permissions to restore this service request status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestStatus->getKey()}.restore"],
             denyResponse: 'You do not have permissions to restore this service request status.'
@@ -125,6 +168,13 @@ class ServiceRequestStatusPolicy
 
         if ($serviceRequestStatus->serviceRequests()->exists()) {
             return Response::deny('You cannot force delete this service request status because it has associated service requests.');
+        }
+
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permissions to force delete this service request status.'
+            );
         }
 
         return $authenticatable->canOrElse(

--- a/app-modules/service-management/src/Policies/ServiceRequestStatusPolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestStatusPolicy.php
@@ -64,7 +64,7 @@ class ServiceRequestStatusPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permissions to view service request statuses.'
@@ -79,7 +79,7 @@ class ServiceRequestStatusPolicy
 
     public function view(Authenticatable $authenticatable, ServiceRequestStatus $serviceRequestStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permissions to view this service request status.'
@@ -94,7 +94,7 @@ class ServiceRequestStatusPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permissions to create service request statuses.'
@@ -113,7 +113,7 @@ class ServiceRequestStatusPolicy
             return Response::deny('You cannot update this service request status because it is system protected.');
         }
 
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permissions to update this service request status.'
@@ -132,7 +132,7 @@ class ServiceRequestStatusPolicy
             return Response::deny('You cannot delete this service request status because it is system protected.');
         }
 
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permissions to delete this service request status.'
@@ -147,7 +147,7 @@ class ServiceRequestStatusPolicy
 
     public function restore(Authenticatable $authenticatable, ServiceRequestStatus $serviceRequestStatus): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permissions to restore this service request status.'
@@ -170,7 +170,7 @@ class ServiceRequestStatusPolicy
             return Response::deny('You cannot force delete this service request status because it has associated service requests.');
         }
 
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permissions to force delete this service request status.'

--- a/app-modules/service-management/src/Policies/ServiceRequestTypePolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestTypePolicy.php
@@ -39,6 +39,7 @@ namespace AidingApp\ServiceManagement\Policies;
 use AidingApp\Contact\Models\Contact;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use App\Enums\Feature;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Support\FeatureAccessResponse;
 use Illuminate\Auth\Access\Response;
@@ -63,6 +64,13 @@ class ServiceRequestTypePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permissions to view service request types.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permissions to view service request types.'
@@ -71,6 +79,13 @@ class ServiceRequestTypePolicy
 
     public function view(Authenticatable $authenticatable, ServiceRequestType $serviceRequestType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permissions to view this service request type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestType->getKey()}.view"],
             denyResponse: 'You do not have permissions to view this service request type.'
@@ -79,6 +94,12 @@ class ServiceRequestTypePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permissions to create service request types.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permissions to create service request types.'
@@ -87,6 +108,13 @@ class ServiceRequestTypePolicy
 
     public function update(Authenticatable $authenticatable, ServiceRequestType $serviceRequestType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permissions to update this service request type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestType->getKey()}.update"],
             denyResponse: 'You do not have permissions to update this service request type.'
@@ -95,6 +123,12 @@ class ServiceRequestTypePolicy
 
     public function delete(Authenticatable $authenticatable, ServiceRequestType $serviceRequestType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permissions to delete this service request type.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestType->getKey()}.delete"],
             denyResponse: 'You do not have permissions to delete this service request type.'
@@ -103,6 +137,12 @@ class ServiceRequestTypePolicy
 
     public function restore(Authenticatable $authenticatable, ServiceRequestType $serviceRequestType): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permissions to restore this service request type.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestType->getKey()}.restore"],
             denyResponse: 'You do not have permissions to restore this service request type.'
@@ -113,6 +153,13 @@ class ServiceRequestTypePolicy
     {
         if ($serviceRequestType->serviceRequests()->exists()) {
             return Response::deny('You cannot force delete this service request type because it has associated service requests.');
+        }
+
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permissions to force delete this service request type.'
+            );
         }
 
         return $authenticatable->canOrElse(

--- a/app-modules/service-management/src/Policies/ServiceRequestTypePolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestTypePolicy.php
@@ -64,7 +64,7 @@ class ServiceRequestTypePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permissions to view service request types.'
@@ -79,7 +79,7 @@ class ServiceRequestTypePolicy
 
     public function view(Authenticatable $authenticatable, ServiceRequestType $serviceRequestType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permissions to view this service request type.'
@@ -94,12 +94,13 @@ class ServiceRequestTypePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permissions to create service request types.'
             );
         }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permissions to create service request types.'
@@ -108,7 +109,7 @@ class ServiceRequestTypePolicy
 
     public function update(Authenticatable $authenticatable, ServiceRequestType $serviceRequestType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permissions to update this service request type.'
@@ -123,12 +124,13 @@ class ServiceRequestTypePolicy
 
     public function delete(Authenticatable $authenticatable, ServiceRequestType $serviceRequestType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permissions to delete this service request type.'
             );
         }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestType->getKey()}.delete"],
             denyResponse: 'You do not have permissions to delete this service request type.'
@@ -137,12 +139,13 @@ class ServiceRequestTypePolicy
 
     public function restore(Authenticatable $authenticatable, ServiceRequestType $serviceRequestType): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permissions to restore this service request type.'
             );
         }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$serviceRequestType->getKey()}.restore"],
             denyResponse: 'You do not have permissions to restore this service request type.'
@@ -155,7 +158,7 @@ class ServiceRequestTypePolicy
             return Response::deny('You cannot force delete this service request type because it has associated service requests.');
         }
 
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permissions to force delete this service request type.'

--- a/app-modules/service-management/src/Policies/SlaPolicy.php
+++ b/app-modules/service-management/src/Policies/SlaPolicy.php
@@ -64,7 +64,7 @@ class SlaPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view SLAs.'
@@ -79,7 +79,7 @@ class SlaPolicy
 
     public function view(Authenticatable $authenticatable, Sla $sla): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this SLA.'
@@ -94,7 +94,7 @@ class SlaPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create SLAs.'
@@ -109,7 +109,7 @@ class SlaPolicy
 
     public function update(Authenticatable $authenticatable, Sla $sla): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this SLA.'
@@ -124,7 +124,7 @@ class SlaPolicy
 
     public function delete(Authenticatable $authenticatable, Sla $sla): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this SLA.'
@@ -139,7 +139,7 @@ class SlaPolicy
 
     public function restore(Authenticatable $authenticatable, Sla $sla): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this SLA.'
@@ -154,13 +154,13 @@ class SlaPolicy
 
     public function forceDelete(Authenticatable $authenticatable, Sla $sla): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this SLA.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this SLA.'

--- a/app-modules/service-management/src/Policies/SlaPolicy.php
+++ b/app-modules/service-management/src/Policies/SlaPolicy.php
@@ -39,6 +39,7 @@ namespace AidingApp\ServiceManagement\Policies;
 use AidingApp\Contact\Models\Contact;
 use AidingApp\ServiceManagement\Models\Sla;
 use App\Enums\Feature;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Support\FeatureAccessResponse;
 use Illuminate\Auth\Access\Response;
@@ -63,6 +64,13 @@ class SlaPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view SLAs.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view SLAs.'
@@ -71,6 +79,13 @@ class SlaPolicy
 
     public function view(Authenticatable $authenticatable, Sla $sla): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this SLA.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.view"],
             denyResponse: 'You do not have permission to view this SLA.'
@@ -79,6 +94,13 @@ class SlaPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create SLAs.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create SLAs.'
@@ -87,6 +109,13 @@ class SlaPolicy
 
     public function update(Authenticatable $authenticatable, Sla $sla): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this SLA.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.update"],
             denyResponse: 'You do not have permission to update this SLA.'
@@ -95,6 +124,13 @@ class SlaPolicy
 
     public function delete(Authenticatable $authenticatable, Sla $sla): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this SLA.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this SLA.'
@@ -103,6 +139,13 @@ class SlaPolicy
 
     public function restore(Authenticatable $authenticatable, Sla $sla): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this SLA.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this SLA.'
@@ -111,6 +154,13 @@ class SlaPolicy
 
     public function forceDelete(Authenticatable $authenticatable, Sla $sla): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this SLA.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this SLA.'

--- a/app-modules/service-management/tests/Tenant/IncidentSeverity/CreateIncidentSeverityTest.php
+++ b/app-modules/service-management/tests/Tenant/IncidentSeverity/CreateIncidentSeverityTest.php
@@ -58,8 +58,8 @@ test('CreateIncidentSeverity is gated with proper access control', function () {
     livewire(CreateIncidentSeverity::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/service-management/tests/Tenant/IncidentSeverity/EditIncidentSeverityTest.php
+++ b/app-modules/service-management/tests/Tenant/IncidentSeverity/EditIncidentSeverityTest.php
@@ -62,8 +62,8 @@ test('EditIncidentSeverity is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -89,8 +89,8 @@ test('EditIncidentSeverity validates the inputs', function ($data, $errors) {
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $incidentSeverity = IncidentSeverity::factory()->create();
 
@@ -130,15 +130,15 @@ test('delete action visible with proper access control', function () {
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     livewire(EditIncidentSeverity::class, [
         'record' => $incidentSeverity->getRouteKey(),
     ])
         ->assertActionHidden(DeleteAction::class);
 
-    $user->givePermissionTo('product_admin.*.delete');
+    $user->givePermissionTo('settings.*.delete');
 
     livewire(EditIncidentSeverity::class, [
         'record' => $incidentSeverity->getRouteKey(),

--- a/app-modules/service-management/tests/Tenant/IncidentSeverity/ListIncidentSeveritiesTest.php
+++ b/app-modules/service-management/tests/Tenant/IncidentSeverity/ListIncidentSeveritiesTest.php
@@ -55,7 +55,7 @@ test('ListIncidentSeverities is gated with proper access control', function () {
             IncidentSeverityResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -71,7 +71,7 @@ test('can list records', function () {
             IncidentSeverityResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     $records = IncidentSeverity::factory()->count(5)->create();
 
@@ -86,8 +86,8 @@ test('bulk delete IncidentSeverities', function () {
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.delete');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.delete');
 
     $incidentSeverities = IncidentSeverity::factory()->count(10)->create();
 
@@ -104,8 +104,8 @@ test('prevent deletion of IncidentSeverity if it has associated Incidents', func
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.delete');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.delete');
 
     $incidentSeverities = IncidentSeverity::factory()
         ->has(Incident::factory(), 'incidents')

--- a/app-modules/service-management/tests/Tenant/IncidentSeverity/ViewIncidentSeverityTest.php
+++ b/app-modules/service-management/tests/Tenant/IncidentSeverity/ViewIncidentSeverityTest.php
@@ -47,8 +47,8 @@ test('The correct details are displayed on the ViewIncidentSeverity page', funct
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $incidentSeverity = IncidentSeverity::factory()->create();
 

--- a/app-modules/service-management/tests/Tenant/IncidentStatus/CreateIncidentStatusTest.php
+++ b/app-modules/service-management/tests/Tenant/IncidentStatus/CreateIncidentStatusTest.php
@@ -88,8 +88,8 @@ test('CreateIncidentStatus is gated with proper access control', function () {
     livewire(CreateIncidentStatus::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/service-management/tests/Tenant/IncidentStatus/EditIncidentStatusTest.php
+++ b/app-modules/service-management/tests/Tenant/IncidentStatus/EditIncidentStatusTest.php
@@ -63,8 +63,8 @@ test('EditIncidentStatus is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -127,15 +127,15 @@ test('delete action visible with proper access control', function () {
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     livewire(EditIncidentStatus::class, [
         'record' => $incidentStatus->getRouteKey(),
     ])
         ->assertActionHidden(DeleteAction::class);
 
-    $user->givePermissionTo('product_admin.*.delete');
+    $user->givePermissionTo('settings.*.delete');
 
     livewire(EditIncidentStatus::class, [
         'record' => $incidentStatus->getRouteKey(),

--- a/app-modules/service-management/tests/Tenant/IncidentStatus/ListIncidentStatusesTest.php
+++ b/app-modules/service-management/tests/Tenant/IncidentStatus/ListIncidentStatusesTest.php
@@ -55,7 +55,7 @@ test('ListIncidentStatuses is gated with proper access control', function () {
             IncidentStatusResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -71,7 +71,7 @@ test('can list records', function () {
             IncidentStatusResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     $records = IncidentStatus::factory()->count(5)->create();
 
@@ -86,8 +86,8 @@ test('bulk delete IncidentStatuses', function () {
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.delete');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.delete');
 
     $incidentStatuses = IncidentStatus::factory()->count(10)->create();
 
@@ -104,8 +104,8 @@ test('prevent deletion of IncidentStatus if it has associated Incidents', functi
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.delete');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.delete');
 
     $incidentStatuses = IncidentStatus::factory()
         ->has(Incident::factory(), 'incidents')

--- a/app-modules/service-management/tests/Tenant/IncidentStatus/ViewIncidentStatusTest.php
+++ b/app-modules/service-management/tests/Tenant/IncidentStatus/ViewIncidentStatusTest.php
@@ -47,8 +47,8 @@ test('The correct details are displayed on the ViewIncidentStatus page', functio
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $incidentStatus = IncidentStatus::factory()->create();
 

--- a/app-modules/service-management/tests/Tenant/ServiceRequestStatus/CreateServiceRequestStatusTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestStatus/CreateServiceRequestStatusTest.php
@@ -102,8 +102,8 @@ test('CreateServiceRequestStatus is gated with proper access control', function 
     livewire(CreateServiceRequestStatus::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -131,8 +131,8 @@ test('CreateServiceRequestStatus is gated with proper feature access control', f
 
     $user = User::factory()->licensed([Contact::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/service-management/tests/Tenant/ServiceRequestStatus/EditServiceRequestStatusTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestStatus/EditServiceRequestStatusTest.php
@@ -125,8 +125,8 @@ test('EditServiceRequestStatus is gated with proper access control', function ()
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -156,8 +156,8 @@ test('EditServiceRequestStatus is gated with proper feature access control', fun
 
     $user = User::factory()->licensed([Contact::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $serviceRequestStatus = ServiceRequestStatus::factory()->create();
 

--- a/app-modules/service-management/tests/Tenant/ServiceRequestStatus/ListServiceRequestStatusesTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestStatus/ListServiceRequestStatusesTest.php
@@ -101,7 +101,7 @@ test('ListServiceRequestStatuses is gated with proper access control', function 
             ServiceRequestStatusResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -118,7 +118,7 @@ test('ListServiceRequestStatuses is gated with proper feature access control', f
 
     $user = User::factory()->licensed([Contact::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/service-management/tests/Tenant/ServiceRequestStatus/ViewServiceRequestStatusTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestStatus/ViewServiceRequestStatusTest.php
@@ -79,8 +79,8 @@ test('ViewServiceRequestStatus is gated with proper access control', function ()
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(
@@ -99,8 +99,8 @@ test('ViewServiceRequestStatus is gated with proper feature access control', fun
 
     $user = User::factory()->licensed([Contact::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $serviceRequestStatus = ServiceRequestStatus::factory()->create();
 

--- a/app-modules/service-management/tests/Tenant/ServiceRequestType/CreateServiceRequestTypeTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestType/CreateServiceRequestTypeTest.php
@@ -97,8 +97,8 @@ test('CreateServiceRequestType is gated with proper access control', function ()
     livewire(CreateServiceRequestType::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -126,8 +126,8 @@ test('CreateServiceRequestType is gated with proper feature access control', fun
 
     $user = User::factory()->licensed([Contact::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/service-management/tests/Tenant/ServiceRequestType/EditServiceRequestTypeAssignmentsTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestType/EditServiceRequestTypeAssignmentsTest.php
@@ -151,8 +151,8 @@ test('EditServiceRequestTypeAssignments is gated with proper access control', fu
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -182,8 +182,8 @@ test('EditServiceRequestTypeAssignments is gated with proper feature access cont
 
     $user = User::factory()->licensed([Contact::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $serviceRequestType = ServiceRequestType::factory()->create();
 

--- a/app-modules/service-management/tests/Tenant/ServiceRequestType/EditServiceRequestTypeTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestType/EditServiceRequestTypeTest.php
@@ -116,8 +116,8 @@ test('EditServiceRequestType is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -147,8 +147,8 @@ test('EditServiceRequestType is gated with proper feature access control', funct
 
     $user = User::factory()->licensed([Contact::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $serviceRequestType = ServiceRequestType::factory()->create();
 

--- a/app-modules/service-management/tests/Tenant/ServiceRequestType/ListServiceRequestTypeTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestType/ListServiceRequestTypeTest.php
@@ -89,7 +89,7 @@ test('ListServiceRequestTypes is gated with proper access control', function () 
             ServiceRequestTypeResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -106,7 +106,7 @@ test('ListServiceRequestTypes is gated with proper feature access control', func
 
     $user = User::factory()->licensed([Contact::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/service-management/tests/Tenant/ServiceRequestType/ServiceRequestTypeAuditorsTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestType/ServiceRequestTypeAuditorsTest.php
@@ -59,7 +59,7 @@ it('can attach audit member to service request type', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
     $user->givePermissionTo('team.view-any');
 
     livewire(ManageServiceRequestTypeAuditors::class, [

--- a/app-modules/service-management/tests/Tenant/ServiceRequestType/ServiceRequestTypeManagersTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestType/ServiceRequestTypeManagersTest.php
@@ -59,7 +59,7 @@ it('can attach team member to service request type', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
     $user->givePermissionTo('team.view-any');
 
     livewire(ManageServiceRequestTypeManagers::class, [

--- a/app-modules/service-management/tests/Tenant/ServiceRequestType/ViewServiceRequestTypeTest.php
+++ b/app-modules/service-management/tests/Tenant/ServiceRequestType/ViewServiceRequestTypeTest.php
@@ -75,8 +75,8 @@ test('ViewServiceRequestType is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(
@@ -95,8 +95,8 @@ test('ViewServiceRequestType is gated with proper feature access control', funct
 
     $user = User::factory()->licensed([Contact::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $serviceRequestType = ServiceRequestType::factory()->create();
 

--- a/app/Features/SettingsPermissions.php
+++ b/app/Features/SettingsPermissions.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/app/Features/SettingsPermissions.php
+++ b/app/Features/SettingsPermissions.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class SettingsPermissions extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Filament/Clusters/AssetManagement.php
+++ b/app/Filament/Clusters/AssetManagement.php
@@ -42,7 +42,7 @@ class AssetManagement extends Cluster
 {
     protected static ?string $navigationIcon = 'heroicon-o-document-text';
 
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 10;
 }

--- a/app/Filament/Clusters/Communication.php
+++ b/app/Filament/Clusters/Communication.php
@@ -42,7 +42,7 @@ class Communication extends Cluster
 {
     protected static ?string $navigationIcon = 'heroicon-o-squares-2x2';
 
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?string $navigationLabel = 'Communication Settings';
 

--- a/app/Filament/Clusters/ContactManagement.php
+++ b/app/Filament/Clusters/ContactManagement.php
@@ -42,7 +42,7 @@ class ContactManagement extends Cluster
 {
     protected static ?string $navigationIcon = 'heroicon-o-document-text';
 
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 20;
 }

--- a/app/Filament/Clusters/ContractManagement.php
+++ b/app/Filament/Clusters/ContractManagement.php
@@ -42,7 +42,7 @@ class ContractManagement extends Cluster
 {
     protected static ?string $navigationIcon = 'heroicon-o-squares-2x2';
 
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 30;
 }

--- a/app/Filament/Clusters/IncidentManagement.php
+++ b/app/Filament/Clusters/IncidentManagement.php
@@ -40,7 +40,7 @@ use Filament\Clusters\Cluster;
 
 class IncidentManagement extends Cluster
 {
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 50;
 

--- a/app/Filament/Clusters/KnowledgeManagement.php
+++ b/app/Filament/Clusters/KnowledgeManagement.php
@@ -42,7 +42,7 @@ class KnowledgeManagement extends Cluster
 {
     protected static ?string $navigationIcon = 'heroicon-o-document-text';
 
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?string $navigationLabel = 'Knowledge Base';
 

--- a/app/Filament/Clusters/ProfileManagement.php
+++ b/app/Filament/Clusters/ProfileManagement.php
@@ -42,7 +42,7 @@ class ProfileManagement extends Cluster
 {
     protected static ?string $navigationIcon = 'heroicon-o-document-text';
 
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 70;
 }

--- a/app/Filament/Clusters/ServiceManagementAdministration.php
+++ b/app/Filament/Clusters/ServiceManagementAdministration.php
@@ -42,7 +42,7 @@ class ServiceManagementAdministration extends Cluster
 {
     protected static ?string $navigationIcon = 'heroicon-o-document-text';
 
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 40;
 

--- a/app/Policies/NotificationSettingPolicy.php
+++ b/app/Policies/NotificationSettingPolicy.php
@@ -36,6 +36,7 @@
 
 namespace App\Policies;
 
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Models\NotificationSetting;
 use Illuminate\Auth\Access\Response;
@@ -44,6 +45,13 @@ class NotificationSettingPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view notification settings.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view notification settings.'
@@ -52,6 +60,13 @@ class NotificationSettingPolicy
 
     public function view(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.view",
+                denyResponse: 'You do not have permission to view this notification setting.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getkey()}.view"],
             denyResponse: 'You do not have permission to view this notification setting.'
@@ -60,6 +75,13 @@ class NotificationSettingPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create notification settings.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create notification settings.'
@@ -68,6 +90,13 @@ class NotificationSettingPolicy
 
     public function update(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.update",
+                denyResponse: 'You do not have permission to update this notification setting.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.update"],
             denyResponse: 'You do not have permission to update this notification setting.'
@@ -76,6 +105,13 @@ class NotificationSettingPolicy
 
     public function delete(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.delete",
+                denyResponse: 'You do not have permission to delete this notification setting.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this notification setting.'
@@ -84,6 +120,13 @@ class NotificationSettingPolicy
 
     public function restore(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.restore",
+                denyResponse: 'You do not have permission to restore this notification setting.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this notification setting.'
@@ -92,6 +135,13 @@ class NotificationSettingPolicy
 
     public function forceDelete(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.force-delete",
+                denyResponse: 'You do not have permission to permanently delete this notification setting.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this notification setting.'

--- a/app/Policies/NotificationSettingPolicy.php
+++ b/app/Policies/NotificationSettingPolicy.php
@@ -45,7 +45,7 @@ class NotificationSettingPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view notification settings.'
@@ -60,9 +60,9 @@ class NotificationSettingPolicy
 
     public function view(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.view",
+                abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this notification setting.'
             );
         }
@@ -75,7 +75,7 @@ class NotificationSettingPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create notification settings.'
@@ -90,9 +90,9 @@ class NotificationSettingPolicy
 
     public function update(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.update",
+                abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this notification setting.'
             );
         }
@@ -105,9 +105,9 @@ class NotificationSettingPolicy
 
     public function delete(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.delete",
+                abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this notification setting.'
             );
         }
@@ -120,9 +120,9 @@ class NotificationSettingPolicy
 
     public function restore(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.restore",
+                abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this notification setting.'
             );
         }
@@ -135,13 +135,13 @@ class NotificationSettingPolicy
 
     public function forceDelete(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.force-delete",
+                abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this notification setting.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this notification setting.'

--- a/app/Policies/NotificationSettingPolicy.php
+++ b/app/Policies/NotificationSettingPolicy.php
@@ -47,7 +47,7 @@ class NotificationSettingPolicy
     {
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
-                abilities: 'settings.*.view',
+                abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view notification settings.'
             );
         }

--- a/app/Policies/PronounsPolicy.php
+++ b/app/Policies/PronounsPolicy.php
@@ -36,6 +36,7 @@
 
 namespace App\Policies;
 
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Models\Pronouns;
 use Illuminate\Auth\Access\Response;
@@ -44,6 +45,13 @@ class PronounsPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view pronouns.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ['product_admin.view-any'],
             denyResponse: 'You do not have permission to view pronouns.'
@@ -52,6 +60,13 @@ class PronounsPolicy
 
     public function view(Authenticatable $authenticatable, Pronouns $model): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.view",
+                denyResponse: 'You do not have permission to view these pronouns.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.view"],
             denyResponse: 'You do not have permission to view these pronouns.'
@@ -60,6 +75,13 @@ class PronounsPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create pronouns.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create pronouns.'
@@ -68,6 +90,13 @@ class PronounsPolicy
 
     public function update(Authenticatable $authenticatable, Pronouns $model): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update these pronouns.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.update"],
             denyResponse: 'You do not have permission to update these pronouns.'
@@ -76,6 +105,13 @@ class PronounsPolicy
 
     public function delete(Authenticatable $authenticatable, Pronouns $model): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete these pronouns.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete these pronouns.'
@@ -84,6 +120,13 @@ class PronounsPolicy
 
     public function restore(Authenticatable $authenticatable, Pronouns $model): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.restore",
+                denyResponse: 'You do not have permission to restore these pronouns.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore these pronouns.'
@@ -92,6 +135,13 @@ class PronounsPolicy
 
     public function forceDelete(Authenticatable $authenticatable, Pronouns $model): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.force-delete",
+                denyResponse: 'You do not have permission to permanently delete these pronouns.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getkey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete these pronouns.'

--- a/app/Policies/PronounsPolicy.php
+++ b/app/Policies/PronounsPolicy.php
@@ -45,13 +45,13 @@ class PronounsPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view pronouns.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.view-any'],
             denyResponse: 'You do not have permission to view pronouns.'
@@ -60,22 +60,22 @@ class PronounsPolicy
 
     public function view(Authenticatable $authenticatable, Pronouns $model): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.view",
-                denyResponse: 'You do not have permission to view these pronoun.'
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view these pronouns.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.view"],
-            denyResponse: 'You do not have permission to view these pronoun.'
+            denyResponse: 'You do not have permission to view these pronouns.'
         );
     }
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create pronouns.'
@@ -90,61 +90,61 @@ class PronounsPolicy
 
     public function update(Authenticatable $authenticatable, Pronouns $model): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
-                denyResponse: 'You do not have permission to update these pronoun.'
+                denyResponse: 'You do not have permission to update these pronouns.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.update"],
-            denyResponse: 'You do not have permission to update these pronoun.'
+            denyResponse: 'You do not have permission to update these pronouns.'
         );
     }
 
     public function delete(Authenticatable $authenticatable, Pronouns $model): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
-                denyResponse: 'You do not have permission to delete these pronoun.'
+                denyResponse: 'You do not have permission to delete these pronouns.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.delete"],
-            denyResponse: 'You do not have permission to delete these pronoun.'
+            denyResponse: 'You do not have permission to delete these pronouns.'
         );
     }
 
     public function restore(Authenticatable $authenticatable, Pronouns $model): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.restore",
-                denyResponse: 'You do not have permission to restore these pronoun.'
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore these pronouns.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.restore"],
-            denyResponse: 'You do not have permission to restore these pronoun.'
+            denyResponse: 'You do not have permission to restore these pronouns.'
         );
     }
 
     public function forceDelete(Authenticatable $authenticatable, Pronouns $model): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.force-delete",
-                denyResponse: 'You do not have permission to permanently delete these pronoun.'
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete these pronouns.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getkey()}.force-delete"],
-            denyResponse: 'You do not have permission to permanently delete these pronoun.'
+            denyResponse: 'You do not have permission to permanently delete these pronouns.'
         );
     }
 }

--- a/app/Policies/PronounsPolicy.php
+++ b/app/Policies/PronounsPolicy.php
@@ -63,13 +63,13 @@ class PronounsPolicy
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: "settings.*.view",
-                denyResponse: 'You do not have permission to view these pronouns.'
+                denyResponse: 'You do not have permission to view these pronoun.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.view"],
-            denyResponse: 'You do not have permission to view these pronouns.'
+            denyResponse: 'You do not have permission to view these pronoun.'
         );
     }
 
@@ -93,13 +93,13 @@ class PronounsPolicy
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
-                denyResponse: 'You do not have permission to update these pronouns.'
+                denyResponse: 'You do not have permission to update these pronoun.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.update"],
-            denyResponse: 'You do not have permission to update these pronouns.'
+            denyResponse: 'You do not have permission to update these pronoun.'
         );
     }
 
@@ -108,13 +108,13 @@ class PronounsPolicy
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
-                denyResponse: 'You do not have permission to delete these pronouns.'
+                denyResponse: 'You do not have permission to delete these pronoun.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.delete"],
-            denyResponse: 'You do not have permission to delete these pronouns.'
+            denyResponse: 'You do not have permission to delete these pronoun.'
         );
     }
 
@@ -123,13 +123,13 @@ class PronounsPolicy
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: "settings.*.restore",
-                denyResponse: 'You do not have permission to restore these pronouns.'
+                denyResponse: 'You do not have permission to restore these pronoun.'
             );
         }
 
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.restore"],
-            denyResponse: 'You do not have permission to restore these pronouns.'
+            denyResponse: 'You do not have permission to restore these pronoun.'
         );
     }
 
@@ -138,13 +138,13 @@ class PronounsPolicy
         if(SettingsPermissions::active()){
             return $authenticatable->canOrElse(
                 abilities: "settings.*.force-delete",
-                denyResponse: 'You do not have permission to permanently delete these pronouns.'
+                denyResponse: 'You do not have permission to permanently delete these pronoun.'
             );
         }
         
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getkey()}.force-delete"],
-            denyResponse: 'You do not have permission to permanently delete these pronouns.'
+            denyResponse: 'You do not have permission to permanently delete these pronoun.'
         );
     }
 }

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -45,13 +45,13 @@ class TagPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view tags.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.view-any'],
             denyResponse: 'You do not have permission to view tags.'
@@ -60,9 +60,9 @@ class TagPolicy
 
     public function view(Authenticatable $authenticatable, Tag $tag): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.view",
+                abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this tag.'
             );
         }
@@ -75,7 +75,7 @@ class TagPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create tags.'
@@ -90,7 +90,7 @@ class TagPolicy
 
     public function update(Authenticatable $authenticatable, Tag $tag): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this tag.'
@@ -105,7 +105,7 @@ class TagPolicy
 
     public function delete(Authenticatable $authenticatable, Tag $tag): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this tag.'
@@ -120,9 +120,9 @@ class TagPolicy
 
     public function restore(Authenticatable $authenticatable, Tag $tag): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.restore",
+                abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this tag.'
             );
         }
@@ -135,13 +135,13 @@ class TagPolicy
 
     public function forceDelete(Authenticatable $authenticatable, Tag $tag): Response
     {
-        if(SettingsPermissions::active()){
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: "settings.*.force-delete",
+                abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this tag.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$tag->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this tag.'

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -36,6 +36,7 @@
 
 namespace App\Policies;
 
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Models\Tag;
 use Illuminate\Auth\Access\Response;
@@ -44,6 +45,13 @@ class TagPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view tags.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ['product_admin.view-any'],
             denyResponse: 'You do not have permission to view tags.'
@@ -52,6 +60,13 @@ class TagPolicy
 
     public function view(Authenticatable $authenticatable, Tag $tag): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.view",
+                denyResponse: 'You do not have permission to view this tag.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$tag->getKey()}.view"],
             denyResponse: 'You do not have permission to view this tag.'
@@ -60,6 +75,13 @@ class TagPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create tags.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create tags.'
@@ -68,6 +90,13 @@ class TagPolicy
 
     public function update(Authenticatable $authenticatable, Tag $tag): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this tag.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$tag->getKey()}.update"],
             denyResponse: 'You do not have permission to update this tag.'
@@ -76,6 +105,13 @@ class TagPolicy
 
     public function delete(Authenticatable $authenticatable, Tag $tag): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this tag.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$tag->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this tag.'
@@ -84,6 +120,13 @@ class TagPolicy
 
     public function restore(Authenticatable $authenticatable, Tag $tag): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.restore",
+                denyResponse: 'You do not have permission to restore this tag.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$tag->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this tag.'
@@ -92,6 +135,13 @@ class TagPolicy
 
     public function forceDelete(Authenticatable $authenticatable, Tag $tag): Response
     {
+        if(SettingsPermissions::active()){
+            return $authenticatable->canOrElse(
+                abilities: "settings.*.force-delete",
+                denyResponse: 'You do not have permission to permanently delete this tag.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$tag->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this tag.'

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -170,7 +170,7 @@ class AdminPanelProvider extends PanelProvider
                     ->icon('heroicon-o-users')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('Product Administration')
+                    ->label('Settings')
                     ->icon('heroicon-o-wrench-screwdriver')
                     ->collapsed(),
                 NavigationGroup::make()

--- a/database/migrations/2025_07_11_112621_data_rename_product_admin_to_settings.php
+++ b/database/migrations/2025_07_11_112621_data_rename_product_admin_to_settings.php
@@ -1,0 +1,79 @@
+<?php
+
+use CanyonGBS\Common\Database\Migrations\Concerns\CanModifyPermissions;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    use CanModifyPermissions;
+
+    /**
+     * @var array<string, string> $productAdminToSettingsPermissions
+     */
+    private array $productAdminToSettingsPermissions = [
+        'product_admin.*.delete' => 'settings.*.delete',
+        'product_admin.*.force-delete' => 'settings.*.force-delete',
+        'product_admin.*.restore' => 'settings.*.restore',
+        'product_admin.*.update' => 'settings.*.update',
+        'product_admin.*.view' => 'settings.*.view',
+        'product_admin.create' => 'settings.create',
+        'product_admin.view-any' => 'settings.view-any',
+    ];
+
+    /**
+     * @var array<string, string> $maintenanceProviderPermissions
+     */
+    private array $maintenanceProviderPermissions = [
+        'maintenance_provider.view-any' => 'Maintenance Provider',
+        'maintenance_provider.create' => 'Maintenance Provider',
+        'maintenance_provider.*.view' => 'Maintenance Provider',
+        'maintenance_provider.*.update' => 'Maintenance Provider',
+        'maintenance_provider.*.delete' => 'Maintenance Provider',
+        'maintenance_provider.*.restore' => 'Maintenance Provider',
+        'maintenance_provider.*.force-delete' => 'Maintenance Provider',
+    ];
+
+    /**
+     * @var array<string> $guards
+     */
+    private array $guards = [
+        'web',
+        'api',
+    ];
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+
+            collect($this->guards)
+            ->each(fn (string $guard) => $this->deletePermissions(array_keys($this->maintenanceProviderPermissions), $guard));
+
+            collect($this->guards)->each(function (string $guard) {
+                $this->renamePermissions($this->productAdminToSettingsPermissions, $guard);
+            });
+
+            $this->renamePermissionGroups([
+                'Product Admin' => 'Settings',
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            
+            collect($this->guards)
+            ->each(function (string $guard) {
+                $this->createPermissions($this->maintenanceProviderPermissions, $guard);
+            });
+
+            collect($this->guards)->each(function (string $guard) {
+                $this->renamePermissions(array_flip($this->productAdminToSettingsPermissions), $guard);
+            });
+
+            $this->renamePermissionGroups([
+                'Settings' => 'Product Admin',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2025_07_11_112621_data_rename_product_admin_to_settings_permissions.php
+++ b/database/migrations/2025_07_11_112621_data_rename_product_admin_to_settings_permissions.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use CanyonGBS\Common\Database\Migrations\Concerns\CanModifyPermissions;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;

--- a/database/migrations/2025_07_11_112621_data_rename_product_admin_to_settings_permissions.php
+++ b/database/migrations/2025_07_11_112621_data_rename_product_admin_to_settings_permissions.php
@@ -21,19 +21,6 @@ return new class () extends Migration {
     ];
 
     /**
-     * @var array<string, string> $maintenanceProviderPermissions
-     */
-    private array $maintenanceProviderPermissions = [
-        'maintenance_provider.view-any' => 'Maintenance Provider',
-        'maintenance_provider.create' => 'Maintenance Provider',
-        'maintenance_provider.*.view' => 'Maintenance Provider',
-        'maintenance_provider.*.update' => 'Maintenance Provider',
-        'maintenance_provider.*.delete' => 'Maintenance Provider',
-        'maintenance_provider.*.restore' => 'Maintenance Provider',
-        'maintenance_provider.*.force-delete' => 'Maintenance Provider',
-    ];
-
-    /**
      * @var array<string> $guards
      */
     private array $guards = [
@@ -44,10 +31,6 @@ return new class () extends Migration {
     public function up(): void
     {
         DB::transaction(function () {
-
-            collect($this->guards)
-            ->each(fn (string $guard) => $this->deletePermissions(array_keys($this->maintenanceProviderPermissions), $guard));
-
             collect($this->guards)->each(function (string $guard) {
                 $this->renamePermissions($this->productAdminToSettingsPermissions, $guard);
             });
@@ -61,12 +44,6 @@ return new class () extends Migration {
     public function down(): void
     {
         DB::transaction(function () {
-            
-            collect($this->guards)
-            ->each(function (string $guard) {
-                $this->createPermissions($this->maintenanceProviderPermissions, $guard);
-            });
-
             collect($this->guards)->each(function (string $guard) {
                 $this->renamePermissions(array_flip($this->productAdminToSettingsPermissions), $guard);
             });

--- a/database/migrations/2025_07_11_115516_data_activate_settings_permissions_feature_flag.php
+++ b/database/migrations/2025_07_11_115516_data_activate_settings_permissions_feature_flag.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Features\SettingsPermissions;
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        SettingsPermissions::activate();
+    }
+
+    public function down(): void
+    {
+        SettingsPermissions::deactivate();
+    }
+};

--- a/database/migrations/2025_07_11_115516_data_activate_settings_permissions_feature_flag.php
+++ b/database/migrations/2025_07_11_115516_data_activate_settings_permissions_feature_flag.php
@@ -36,11 +36,8 @@
 
 use App\Features\SettingsPermissions;
 use Illuminate\Database\Migrations\Migration;
-use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
-use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         SettingsPermissions::activate();

--- a/database/migrations/2025_07_11_115516_data_activate_settings_permissions_feature_flag.php
+++ b/database/migrations/2025_07_11_115516_data_activate_settings_permissions_feature_flag.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\SettingsPermissions;
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-653

### Technical Description

> Rename product administration to settings in the main navigation.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> Yes.
> SettingsPermissions.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
