### PR TITLE
[AIDAPP-651]: SelectFilters should use non-native version

### DIFF
--- a/app/Providers/FilamentServiceProvider.php
+++ b/app/Providers/FilamentServiceProvider.php
@@ -36,24 +36,25 @@
 
 namespace App\Providers;
 
-use App\Models\Export;
-use App\Models\FailedImportRow;
-use App\Models\Import;
 use App\Models\User;
-use Filament\Actions\Exports\Models\Export as BaseExport;
-use Filament\Actions\Imports\Models\FailedImportRow as BaseFailedImportRow;
-use Filament\Actions\Imports\Models\Import as BaseImport;
-use Filament\Forms\Components\Checkbox;
+use App\Models\Export;
+use App\Models\Import;
+use Illuminate\View\View;
+use App\Models\FailedImportRow;
+use Filament\Support\Colors\Color;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Toggle;
-use Filament\Support\Colors\Color;
-use Filament\Support\Facades\FilamentColor;
-use Filament\Support\Facades\FilamentView;
+use Filament\Forms\Components\Checkbox;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\View\View;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Support\Facades\FilamentView;
+use Filament\Support\Facades\FilamentColor;
 use Ysfkaya\FilamentPhoneInput\Forms\PhoneInput;
 use Ysfkaya\FilamentPhoneInput\Infolists\PhoneEntry;
 use Ysfkaya\FilamentPhoneInput\PhoneInputNumberType;
+use Filament\Actions\Exports\Models\Export as BaseExport;
+use Filament\Actions\Imports\Models\Import as BaseImport;
+use Filament\Actions\Imports\Models\FailedImportRow as BaseFailedImportRow;
 
 class FilamentServiceProvider extends ServiceProvider
 {
@@ -187,6 +188,10 @@ class FilamentServiceProvider extends ServiceProvider
 
         Select::configureUsing(function (Select $select): void {
             $select->native(false);
+        });
+
+        SelectFilter::configureUsing(function (SelectFilter $selectFilter): void {
+            $selectFilter->native(false);
         });
 
         Toggle::macro('lockedWithoutAnyLicenses', function (User $user, array $licenses) {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue
- https://canyongbs.atlassian.net/browse/AIDAPP-651

### Technical Description
- Update the FilamentServiceProvider to SelectFilters are non-native by default.

### Any deployment steps required?
- No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?
- No
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
