### PR TITLE
[AIDAPP-657]: Update Olympus API tenant creation to work without a name passed

### DIFF
--- a/app/Http/Controllers/Tenants/CreateTenantController.php
+++ b/app/Http/Controllers/Tenants/CreateTenantController.php
@@ -51,13 +51,17 @@ use App\Multitenancy\DataTransferObjects\TenantS3FilesystemConfig;
 use App\Multitenancy\DataTransferObjects\TenantSmtpMailerConfig;
 use App\Multitenancy\DataTransferObjects\TenantUser;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Str;
+use Sqids\Sqids;
 
 class CreateTenantController extends Controller
 {
     public function __invoke(CreateTenantRequest $request): JsonResponse
     {
+        $rootName = Str::snake($request->validated('domain')) . '_' . (new Sqids())->encode([time()]);
+
         $tenant = app(CreateTenant::class)(
-            $request->validated('name'),
+            $request->validated('domain'),
             $request->validated('domain'),
             new TenantConfig(
                 database: new TenantDatabaseConfig(
@@ -76,7 +80,7 @@ class CreateTenantController extends Controller
                     endpoint: config('filesystems.disks.s3.endpoint'),
                     usePathStyleEndpoint: config('filesystems.disks.s3.use_path_style_endpoint'),
                     throw: config('filesystems.disks.s3.throw'),
-                    root: config('filesystems.disks.s3.root'),
+                    root: $rootName,
                 ),
                 s3PublicFilesystem: new TenantS3FilesystemConfig(
                     key: config('filesystems.disks.s3-public.key'),
@@ -87,7 +91,7 @@ class CreateTenantController extends Controller
                     endpoint: config('filesystems.disks.s3-public.endpoint'),
                     usePathStyleEndpoint: config('filesystems.disks.s3-public.use_path_style_endpoint'),
                     throw: config('filesystems.disks.s3-public.throw'),
-                    root: config('filesystems.disks.s3-public.root'),
+                    root: $rootName . '/PUBLIC',
                 ),
                 mail: new TenantMailConfig(
                     mailers: new TenantMailersConfig(

--- a/app/Http/Requests/Tenants/CreateTenantRequest.php
+++ b/app/Http/Requests/Tenants/CreateTenantRequest.php
@@ -46,7 +46,6 @@ class CreateTenantRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
             'domain' => ['required', 'string', 'max:255', 'unique:landlord.tenants,domain', 'regex:/^((?:[a-zA-Z0-9-]*?\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,})$/i'],
             'database' => ['required', 'string', 'max:255'],
             'user.name' => ['required', 'string', 'max:255'],


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-657

### Technical Description

Update the Olympus API Tenant creation process to no longer require the name of the Tenant be passed and now instead use the domain provided as the name of the Tenant and the key for the folder names in storage.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
