### PR TITLE
[AIDAPP-696]: Introduce a button at the top of the page for service monitoring to reset monitoring

### DIFF
--- a/app-modules/service-management/src/Actions/ResetMonitoringAction.php
+++ b/app-modules/service-management/src/Actions/ResetMonitoringAction.php
@@ -34,27 +34,14 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Filament\Actions;
+namespace AidingApp\ServiceManagement\Actions;
 
-use AidingApp\ServiceManagement\Actions\ResetMonitoringAction;
 use AidingApp\ServiceManagement\Models\ServiceMonitoringTarget;
-use Filament\Actions\Action;
 
-class ResetAction extends Action
+class ResetMonitoringAction
 {
-    protected function setup(): void
+    public static function execute(ServiceMonitoringTarget $serviceMonitor): void
     {
-        parent::setup();
-
-        $this->form([])
-            ->label('Reset Monitoring')
-            ->action(fn (ServiceMonitoringTarget $record) => ResetMonitoringAction::execute($record))
-            ->requiresConfirmation()
-            ->modalDescription('Are you sure you wish to reset monitoring, the data loss is irreversible.');
-    }
-
-    public static function getDefaultName(): string
-    {
-        return 'reset';
+        $serviceMonitor->histories()->delete();
     }
 }

--- a/app-modules/service-management/src/Filament/Actions/ResetAction.php
+++ b/app-modules/service-management/src/Filament/Actions/ResetAction.php
@@ -48,7 +48,7 @@ class ResetAction extends Action
 
         $this->form([])
             ->label('Reset Monitoring')
-            ->action(fn (ServiceMonitoringTarget $record) => ResetMonitoringAction::execute($record))
+            ->action(fn (ServiceMonitoringTarget $record, ResetMonitoringAction $resetMonitoringAction) => $resetMonitoringAction::execute($record))
             ->requiresConfirmation()
             ->modalDescription('Are you sure you wish to reset monitoring, the data loss is irreversible.');
     }

--- a/app-modules/service-management/src/Filament/Actions/ResetAction.php
+++ b/app-modules/service-management/src/Filament/Actions/ResetAction.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Aiding App™ is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Aiding App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AidingApp\ServiceManagement\Filament\Actions;
 
 use AidingApp\ServiceManagement\Models\ServiceMonitoringTarget;

--- a/app-modules/service-management/src/Filament/Actions/ResetAction.php
+++ b/app-modules/service-management/src/Filament/Actions/ResetAction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AidingApp\ServiceManagement\Filament\Actions;
+
+use AidingApp\ServiceManagement\Models\ServiceMonitoringTarget;
+use Filament\Actions\Action;
+
+class ResetAction extends Action
+{
+    protected function setup(): void
+    {
+        parent::setup();
+
+        $this->form([])
+            ->label('Reset Monitoring')
+            ->action(function (array $data, ServiceMonitoringTarget $record): void {
+                $record->histories()->delete();
+            })
+            ->requiresConfirmation()
+            ->modalDescription('Are you sure you wish to reset monitoring, the data loss is irreversible.');
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'reset';
+    }
+}

--- a/app-modules/service-management/src/Filament/Resources/ServiceMonitoringResource/Pages/EditServiceMonitoring.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceMonitoringResource/Pages/EditServiceMonitoring.php
@@ -37,6 +37,7 @@
 namespace AidingApp\ServiceManagement\Filament\Resources\ServiceMonitoringResource\Pages;
 
 use AidingApp\ServiceManagement\Enums\ServiceMonitoringFrequency;
+use AidingApp\ServiceManagement\Filament\Actions\ResetAction;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceMonitoringResource;
 use AidingApp\ServiceManagement\Models\ServiceMonitoringTarget;
 use App\Concerns\EditPageRedirection;
@@ -127,6 +128,7 @@ class EditServiceMonitoring extends EditRecord
     {
         return [
             ViewAction::make(),
+            ResetAction::make(),
             DeleteAction::make(),
         ];
     }

--- a/app-modules/service-management/src/Filament/Resources/ServiceMonitoringResource/Pages/ViewServiceMonitoring.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceMonitoringResource/Pages/ViewServiceMonitoring.php
@@ -36,6 +36,7 @@
 
 namespace AidingApp\ServiceManagement\Filament\Resources\ServiceMonitoringResource\Pages;
 
+use AidingApp\ServiceManagement\Filament\Actions\ResetAction;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceMonitoringResource;
 use AidingApp\ServiceManagement\Models\ServiceMonitoringTarget;
 use Filament\Actions\EditAction;
@@ -113,6 +114,7 @@ class ViewServiceMonitoring extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            ResetAction::make(),
             EditAction::make(),
         ];
     }

--- a/app-modules/service-management/tests/Tenant/Filament/ServiceMonitoring/Pages/ViewServiceMonitoringTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/ServiceMonitoring/Pages/ViewServiceMonitoringTest.php
@@ -119,4 +119,4 @@ test('Reset Monitoring button resets monitoring', function () {
 
     expect($serviceMonitoringTarget->histories()->count())
         ->toBe(0);
-})->only();
+});

--- a/app-modules/service-management/tests/Tenant/Filament/ServiceMonitoring/Pages/ViewServiceMonitoringTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/ServiceMonitoring/Pages/ViewServiceMonitoringTest.php
@@ -36,10 +36,12 @@
 
 use AidingApp\Authorization\Enums\LicenseType;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceMonitoringResource;
+use AidingApp\ServiceManagement\Filament\Resources\ServiceMonitoringResource\Pages\ViewServiceMonitoring;
 use AidingApp\ServiceManagement\Models\ServiceMonitoringTarget;
 use App\Models\User;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
 test('The correct details are displayed on the ViewServiceMonitoring page', function () {
@@ -91,3 +93,30 @@ test('ViewServiceMonitoring is gated with proper access control', function () {
             ])
         )->assertSuccessful();
 });
+
+test('Reset Monitoring button resets monitoring', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    asSuperAdmin($user);
+
+    $serviceMonitoringTarget = ServiceMonitoringTarget::factory()->create();
+
+    $serviceMonitoringTarget->histories()->create([
+        'response' => 200,
+        'response_time' => 0.138348,
+        'succeeded' => 1,
+    ]);
+
+    expect($serviceMonitoringTarget->histories()->count())
+        ->toBe(1);
+
+    livewire(ViewServiceMonitoring::class, [
+        'record' => $serviceMonitoringTarget->getRouteKey(),
+    ])
+        ->assertSuccessful()
+        ->assertSee('Reset Monitoring')
+        ->callAction('reset');
+
+    expect($serviceMonitoringTarget->histories()->count())
+        ->toBe(0);
+})->only();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-696

### Technical Description
- Create a custom action for Reseting Monitoring (soft deleting the history)
- Add the button to header actions on View / Edit pages.

### Any deployment steps required?
- No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?
- No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
