### PR TITLE
[AIDAPP-698]: Change embed authorized domain checks to check origin header, NOT referer

### DIFF
--- a/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
+++ b/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
@@ -39,7 +39,6 @@ namespace AidingApp\Form\Actions;
 use AidingApp\Form\Models\Submissible;
 use AidingApp\ServiceManagement\Models\ServiceRequestForm;
 use Exception;
-use Illuminate\Support\Facades\URL;
 
 class GenerateSubmissibleEmbedCode
 {
@@ -49,12 +48,9 @@ class GenerateSubmissibleEmbedCode
             ServiceRequestForm::class => (function () use ($submissible) {
                 /** @var ServiceRequestForm $submissible */
                 $scriptUrl = url('js/widgets/service-request-form/aiding-app-service-request-form-widget.js?v=' . app('current-commit'));
-                $formDefinitionUrl = URL::to(
-                    URL::signedRoute(
-                        name: 'service-request-forms.define',
-                        parameters: ['serviceRequestForm' => $submissible],
-                        absolute: false,
-                    )
+                $formDefinitionUrl = route(
+                    name: 'service-request-forms.define',
+                    parameters: ['serviceRequestForm' => $submissible],
                 );
 
                 return <<<EOD

--- a/app-modules/form/src/Http/Middleware/EnsureSubmissibleIsEmbeddableAndAuthorized.php
+++ b/app-modules/form/src/Http/Middleware/EnsureSubmissibleIsEmbeddableAndAuthorized.php
@@ -48,23 +48,23 @@ class EnsureSubmissibleIsEmbeddableAndAuthorized
         /** @var Submissible $submissible */
         $submissible = $request->route($binding);
 
-        $referer = $request->headers->get('referer');
+        $origin = $request->headers->get('origin');
 
-        if (! $referer) {
-            return response()->json(['error' => 'Missing referer header.'], 400);
+        if (! $origin) {
+            return response()->json(['error' => 'Missing origin header.'], 400);
         }
 
-        $referer = parse_url($referer)['host'];
+        $origin = parse_url($origin)['host'];
 
-        if ($referer != parse_url(config('app.url'))['host']) {
+        if ($origin != parse_url(config('app.url'))['host']) {
             if (! $submissible->embed_enabled) {
                 return response()->json(['error' => 'Embedding is not enabled for this form.'], 403);
             }
 
             $allowedDomains = collect($submissible->allowed_domains ?? []);
 
-            if (! $allowedDomains->contains($referer)) {
-                return response()->json(['error' => 'Referer not allowed. Domain must be added to allowed domains list'], 403);
+            if (! $allowedDomains->contains($origin)) {
+                return response()->json(['error' => 'Origin not allowed. Domain must be added to allowed domains list'], 403);
             }
         }
 

--- a/app-modules/portal/src/Http/Middleware/EnsureKnowledgeManagementPortalIsEmbeddableAndAuthorized.php
+++ b/app-modules/portal/src/Http/Middleware/EnsureKnowledgeManagementPortalIsEmbeddableAndAuthorized.php
@@ -44,21 +44,21 @@ class EnsureKnowledgeManagementPortalIsEmbeddableAndAuthorized
 {
     public function handle(Request $request, Closure $next): Response
     {
-        $referer = $request->headers->get('referer');
+        $origin = $request->headers->get('origin');
 
         // If we are on the root domain
         if (parse_url($request->url())['host'] === parse_url(config('app.url'))['host']) {
             return $next($request);
         }
 
-        if (! $referer) {
-            return response()->json(['error' => 'Missing referer header.'], 400);
+        if (! $origin) {
+            return response()->json(['error' => 'Missing origin header.'], 400);
         }
 
-        $referer = parse_url($referer)['host'];
+        $origin = parse_url($origin)['host'];
 
-        if ($referer != parse_url(config('app.url'))['host']) {
-            return response()->json(['error' => 'Referer not allowed'], 403);
+        if ($origin != parse_url(config('app.url'))['host']) {
+            return response()->json(['error' => 'Origin not allowed'], 403);
         }
 
         return $next($request);

--- a/app-modules/service-management/routes/api.php
+++ b/app-modules/service-management/routes/api.php
@@ -55,7 +55,6 @@ Route::prefix('api')
             ])
             ->group(function () {
                 Route::get('/{serviceRequestForm}', [ServiceRequestFormWidgetController::class, 'view'])
-                    ->middleware(['signed:relative'])
                     ->name('define');
                 Route::post('/{serviceRequestForm}/authenticate/request', [ServiceRequestFormWidgetController::class, 'requestAuthentication'])
                     ->middleware(['signed:relative'])


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-698

### Technical Description

Changes the authorized domains check to check the `origin` header instead of the insecure `referer` header.

Also updates `devops` submodule.

Also sets the form embed main URL to not be signed to prevent issues in the future if our key is rotated.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
