### PR TITLE
[Bugfix]: Service Request Update CreateBy backfill bugfix

### DIFF
--- a/app-modules/service-management/database/migrations/2025_09_26_165527_add_created_by_columns_and_remove_direction_in_service_request_updates_table.php
+++ b/app-modules/service-management/database/migrations/2025_09_26_165527_add_created_by_columns_and_remove_direction_in_service_request_updates_table.php
@@ -55,7 +55,6 @@ return new class () extends Migration {
 
             // Backfill existing records SHOULD BE REMOVED DURING CLEANUP OF ServiceRequestUpdateCreatedByFeature
             ServiceRequestUpdate::query()
-                ->whereHas('serviceRequest')
                 ->eachById(function (ServiceRequestUpdate $serviceRequestUpdate) {
                     match ($serviceRequestUpdate->direction) {
                         ServiceRequestUpdateDirection::Inbound => (function () use ($serviceRequestUpdate) {

--- a/app-modules/service-management/database/migrations/2025_09_26_165527_add_created_by_columns_and_remove_direction_in_service_request_updates_table.php
+++ b/app-modules/service-management/database/migrations/2025_09_26_165527_add_created_by_columns_and_remove_direction_in_service_request_updates_table.php
@@ -66,7 +66,7 @@ return new class () extends Migration {
                         ServiceRequestUpdateDirection::Outbound => (function () use ($serviceRequestUpdate) {
                             $user = $serviceRequestUpdate->serviceRequest->assignedTo->user
                                 // @phpstan-ignore method.notFound
-                                ?? $serviceRequestUpdate->serviceRequest->priority->type->managers()->first()?->users()->first()
+                                ?? $serviceRequestUpdate->serviceRequest?->priority->type->managers()->first()?->users()->first()
                                 ?? User::role(Authenticatable::SUPER_ADMIN_ROLE)->first();
                             $serviceRequestUpdate->createdBy()->associate($user);
                             $serviceRequestUpdate->save();
@@ -94,7 +94,6 @@ return new class () extends Migration {
 
             // Revert backfill existing records SHOULD BE REMOVED DURING CLEANUP OF ServiceRequestUpdateCreatedByFeature
             ServiceRequestUpdate::query()
-                ->whereHas('serviceRequest')
                 ->eachById(function (ServiceRequestUpdate $serviceRequestUpdate) {
                     match ($serviceRequestUpdate->createdBy::class) {
                         Contact::class => (function () use ($serviceRequestUpdate) {

--- a/app-modules/service-management/database/migrations/2025_09_26_165527_add_created_by_columns_and_remove_direction_in_service_request_updates_table.php
+++ b/app-modules/service-management/database/migrations/2025_09_26_165527_add_created_by_columns_and_remove_direction_in_service_request_updates_table.php
@@ -55,6 +55,7 @@ return new class () extends Migration {
 
             // Backfill existing records SHOULD BE REMOVED DURING CLEANUP OF ServiceRequestUpdateCreatedByFeature
             ServiceRequestUpdate::query()
+                ->whereHas('serviceRequest')
                 ->eachById(function (ServiceRequestUpdate $serviceRequestUpdate) {
                     match ($serviceRequestUpdate->direction) {
                         ServiceRequestUpdateDirection::Inbound => (function () use ($serviceRequestUpdate) {
@@ -93,6 +94,7 @@ return new class () extends Migration {
 
             // Revert backfill existing records SHOULD BE REMOVED DURING CLEANUP OF ServiceRequestUpdateCreatedByFeature
             ServiceRequestUpdate::query()
+                ->whereHas('serviceRequest')
                 ->eachById(function (ServiceRequestUpdate $serviceRequestUpdate) {
                     match ($serviceRequestUpdate->createdBy::class) {
                         Contact::class => (function () use ($serviceRequestUpdate) {

--- a/app-modules/service-management/database/migrations/2025_09_26_165527_add_created_by_columns_and_remove_direction_in_service_request_updates_table.php
+++ b/app-modules/service-management/database/migrations/2025_09_26_165527_add_created_by_columns_and_remove_direction_in_service_request_updates_table.php
@@ -66,7 +66,7 @@ return new class () extends Migration {
                         ServiceRequestUpdateDirection::Outbound => (function () use ($serviceRequestUpdate) {
                             $user = $serviceRequestUpdate->serviceRequest->assignedTo->user
                                 // @phpstan-ignore method.notFound
-                                ?? $serviceRequestUpdate->serviceRequest?->priority->type->managers()->first()?->users()->first()
+                                ?? $serviceRequestUpdate->serviceRequest?->priority?->type?->managers()->first()?->users()->first()
                                 ?? User::role(Authenticatable::SUPER_ADMIN_ROLE)->first();
                             $serviceRequestUpdate->createdBy()->associate($user);
                             $serviceRequestUpdate->save();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Fix issues in the `createdBy` backfill migration when a ServiceRequestUpdate ServiceRequest is deleted.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
