### PR TITLE
[Chore]: Cleanup archive ignores

### DIFF
--- a/app-modules/contact/src/Filament/Resources/ContactResource/RelationManagers/ServiceRequestsRelationManager.php
+++ b/app-modules/contact/src/Filament/Resources/ContactResource/RelationManagers/ServiceRequestsRelationManager.php
@@ -110,9 +110,9 @@ class ServiceRequestsRelationManager extends RelationManager
                     ->schema([
                         Select::make('type_id')
                             ->options(
-                                fn (?ServiceRequest $record) => ServiceRequestType::query() // @phpstan-ignore method.notFound
+                                fn (?ServiceRequest $record) => ServiceRequestType::query()
                                     ->where(
-                                        fn (Builder $query) => $query // @phpstan-ignore method.notFound
+                                        fn (Builder $query) => $query
                                             ->withoutArchived()
                                             ->when(! auth()->user()->isSuperAdmin(), function (Builder $query) {
                                                 $query->where(function (Builder $query) {

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/ServiceRequestTypesController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/ServiceRequestTypesController.php
@@ -49,7 +49,7 @@ class ServiceRequestTypesController extends Controller
         // render top-level categories/types and navigate into subcategories without
         // additional requests.
         $categories = ServiceRequestTypeCategory::query()->orderBy('sort')->get();
-        $types = ServiceRequestType::query()->withoutArchived()->orderBy('sort')->get(); /* @phpstan-ignore method.notFound */
+        $types = ServiceRequestType::query()->withoutArchived()->orderBy('sort')->get();
 
         $catsById = [];
 

--- a/app-modules/report/src/Filament/Pages/ServiceRequestFeedback.php
+++ b/app-modules/report/src/Filament/Pages/ServiceRequestFeedback.php
@@ -124,7 +124,7 @@ class ServiceRequestFeedback extends Dashboard
                 ->schema([
                     Select::make('serviceRequestTypes')
                         ->label('Service Request Type Filter')
-                        ->options(ServiceRequestType::query() /* @phpstan-ignore method.notFound */
+                        ->options(ServiceRequestType::query()
                             ->withoutArchived()
                             ->orderBy('name')
                             ->pluck('name', 'id'))

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestForms/Pages/ListServiceRequestForms.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestForms/Pages/ListServiceRequestForms.php
@@ -38,6 +38,7 @@ namespace AidingApp\ServiceManagement\Filament\Resources\ServiceRequestForms\Pag
 
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestForms\ServiceRequestFormResource;
 use AidingApp\ServiceManagement\Models\ServiceRequestForm;
+use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
@@ -54,7 +55,13 @@ class ListServiceRequestForms extends ListRecords
     public function table(Table $table): Table
     {
         return $table
-            ->modifyQueryUsing(fn (Builder $query) => $query->withoutArchived()->whereHas('type', fn (Builder $query) => $query->withoutArchived())) /** @phpstan-ignore method.notFound, method.notFound */
+            ->modifyQueryUsing(function (Builder $query) {
+                /** @var Builder<ServiceRequestForm> $query */
+                return $query->withoutArchived()->whereHas('type', function (Builder $query) {
+                    /** @var Builder<ServiceRequestType> $query */ // @phpstan-ignore varTag.nativeType
+                    $query->withoutArchived();
+                });
+            })
             ->columns([
                 IdColumn::make(),
                 TextColumn::make('name'),

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestForms/Pages/ListServiceRequestForms.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestForms/Pages/ListServiceRequestForms.php
@@ -38,7 +38,6 @@ namespace AidingApp\ServiceManagement\Filament\Resources\ServiceRequestForms\Pag
 
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestForms\ServiceRequestFormResource;
 use AidingApp\ServiceManagement\Models\ServiceRequestForm;
-use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
@@ -57,10 +56,7 @@ class ListServiceRequestForms extends ListRecords
         return $table
             ->modifyQueryUsing(function (Builder $query) {
                 /** @var Builder<ServiceRequestForm> $query */
-                return $query->withoutArchived()->whereHas('type', function (Builder $query) {
-                    /** @var Builder<ServiceRequestType> $query */ // @phpstan-ignore varTag.nativeType
-                    $query->withoutArchived();
-                });
+                return $query->withoutArchived()->whereHas('type', fn (Builder $query) => $query->withoutArchived());
             })
             ->columns([
                 IdColumn::make(),

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestTypes/Pages/ListServiceRequestTypes.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestTypes/Pages/ListServiceRequestTypes.php
@@ -87,11 +87,11 @@ class ListServiceRequestTypes extends ListRecords
                 'children' => function (HasMany $query) {
                     $query->orderBy('sort')
                         ->with([/** @phpstan-ignore argument.type */
-                            'types' => fn (HasMany $typeQuery) => $typeQuery->withoutArchived()->orderBy('sort')->withCount('serviceRequests'), /** @phpstan-ignore method.notFound */
+                            'types' => fn ($typeQuery) => $typeQuery->withoutArchived()->orderBy('sort')->withCount('serviceRequests'),
                             'children' => function (HasMany $childQuery) {
                                 $childQuery->orderBy('sort')
                                     ->with([/** @phpstan-ignore argument.type */
-                                        'types' => fn (HasMany $typeQuery) => $typeQuery->withoutArchived()->orderBy('sort')->withCount('serviceRequests'), /** @phpstan-ignore method.notFound */
+                                        'types' => fn ($typeQuery) => $typeQuery->withoutArchived()->orderBy('sort')->withCount('serviceRequests'),
                                     ])
                                     ->withCount('descendantServiceRequests');
                             },
@@ -105,7 +105,7 @@ class ListServiceRequestTypes extends ListRecords
             ->orderBy('sort')
             ->get();
 
-        $uncategorizedTypes = ServiceRequestType::query() /** @phpstan-ignore method.notFound */
+        $uncategorizedTypes = ServiceRequestType::query()
             ->withoutArchived()
             ->whereNull('category_id')
             ->orderBy('sort')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/CreateServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/CreateServiceRequest.php
@@ -107,7 +107,7 @@ class CreateServiceRequest extends CreateRecord
                                     ->exists((new ServiceRequestStatus())->getTable(), 'id')
                                     ->columnSpan(fn (Get $get): int => filled($get('type_id')) ? 2 : 3),
                                 Select::make('type_id')
-                                    ->options(ServiceRequestType::query()->withoutArchived()->when(! auth()->user()->isSuperAdmin(), function (Builder $query) { /** @phpstan-ignore method.notFound */
+                                    ->options(ServiceRequestType::query()->withoutArchived()->when(! auth()->user()->isSuperAdmin(), function (Builder $query) {
                                         $query->whereHas('managerUsers', function (Builder $query): void {
                                             $query->where('users.id', auth()->user()->getKey());
                                         })->orWhereHas('managerTeams', function (Builder $query): void {

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/EditServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/EditServiceRequest.php
@@ -112,9 +112,9 @@ class EditServiceRequest extends EditRecord
                                     ->disableOptionWhen(fn (string $value) => $disabledStatuses->contains($value)),
                                 Select::make('type_id')
                                     ->options(
-                                        fn (ServiceRequest $record) => ServiceRequestType::query() // @phpstan-ignore method.notFound
+                                        fn (ServiceRequest $record) => ServiceRequestType::query()
                                             ->where(
-                                                fn (Builder $query) => $query // @phpstan-ignore method.notFound
+                                                fn (Builder $query) => $query
                                                     ->withoutArchived()
                                                     ->when(! auth()->user()->isSuperAdmin(), function (Builder $query) {
                                                         $query->where(function (Builder $query) {

--- a/app-modules/service-management/src/Models/ServiceRequestType.php
+++ b/app-modules/service-management/src/Models/ServiceRequestType.php
@@ -144,7 +144,7 @@ class ServiceRequestType extends BaseModel implements Auditable
      */
     public function form(): HasOne
     {
-        return $this->hasOne(ServiceRequestForm::class, 'service_request_type_id') /** @phpstan-ignore method.notFound */
+        return $this->hasOne(ServiceRequestForm::class, 'service_request_type_id')
             ->withoutArchived();
     }
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "canyon-gbs/project": "*",
         "canyon-gbs/purchasing": "*",
         "canyon-gbs/report": "*",
-        "canyongbs/common": "^2.11.0",
+        "canyongbs/common": "^2.12.0",
         "canyongbs/filament-tiptap-editor": "^2.3.6",
         "canyongbs/model-state-machine": "^2.0.5",
         "cknow/laravel-money": "^8.1",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "canyon-gbs/project": "*",
         "canyon-gbs/purchasing": "*",
         "canyon-gbs/report": "*",
-        "canyongbs/common": "^2.10.0",
+        "canyongbs/common": "^2.11.0",
         "canyongbs/filament-tiptap-editor": "^2.3.6",
         "canyongbs/model-state-machine": "^2.0.5",
         "cknow/laravel-money": "^8.1",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "canyon-gbs/project": "*",
         "canyon-gbs/purchasing": "*",
         "canyon-gbs/report": "*",
-        "canyongbs/common": "^2.12.0",
+        "canyongbs/common": "^2.12.1",
         "canyongbs/filament-tiptap-editor": "^2.3.6",
         "canyongbs/model-state-machine": "^2.0.5",
         "cknow/laravel-money": "^8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d7aee98711fff47177516cbbfe2a89d",
+    "content-hash": "677aac2591124ce9a42e955fd4f3985e",
     "packages": [
         {
             "name": "ably/ably-php",
@@ -1589,16 +1589,16 @@
         },
         {
             "name": "canyongbs/common",
-            "version": "2.10.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/canyongbs/common.git",
-                "reference": "e11e31a52b946078043fd2ee7a2fdf4f43993d25"
+                "reference": "a41556275d5edf796959f053c66d0c911e23492e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/canyongbs/common/zipball/e11e31a52b946078043fd2ee7a2fdf4f43993d25",
-                "reference": "e11e31a52b946078043fd2ee7a2fdf4f43993d25",
+                "url": "https://api.github.com/repos/canyongbs/common/zipball/a41556275d5edf796959f053c66d0c911e23492e",
+                "reference": "a41556275d5edf796959f053c66d0c911e23492e",
                 "shasum": ""
             },
             "require": {
@@ -1609,6 +1609,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.75",
+                "larastan/larastan": "^3.0",
                 "orchestra/testbench": "^10.4",
                 "orrison/meliorstan": "^0.3.2",
                 "pestphp/pest": "^3.8.5",
@@ -1643,9 +1644,9 @@
             ],
             "support": {
                 "issues": "https://github.com/canyongbs/common/issues",
-                "source": "https://github.com/canyongbs/common/tree/2.10.0"
+                "source": "https://github.com/canyongbs/common/tree/2.11.0"
             },
-            "time": "2026-04-08T16:56:33+00:00"
+            "time": "2026-04-10T09:08:07+00:00"
         },
         {
             "name": "canyongbs/filament-tiptap-editor",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "677aac2591124ce9a42e955fd4f3985e",
+    "content-hash": "4c4491b62139cff5563cc8a08f0fe6c8",
     "packages": [
         {
             "name": "ably/ably-php",
@@ -1589,16 +1589,16 @@
         },
         {
             "name": "canyongbs/common",
-            "version": "2.11.0",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/canyongbs/common.git",
-                "reference": "a41556275d5edf796959f053c66d0c911e23492e"
+                "reference": "a5ad946e1befe6e1849425171d4f954d3a76bc99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/canyongbs/common/zipball/a41556275d5edf796959f053c66d0c911e23492e",
-                "reference": "a41556275d5edf796959f053c66d0c911e23492e",
+                "url": "https://api.github.com/repos/canyongbs/common/zipball/a5ad946e1befe6e1849425171d4f954d3a76bc99",
+                "reference": "a5ad946e1befe6e1849425171d4f954d3a76bc99",
                 "shasum": ""
             },
             "require": {
@@ -1644,9 +1644,9 @@
             ],
             "support": {
                 "issues": "https://github.com/canyongbs/common/issues",
-                "source": "https://github.com/canyongbs/common/tree/2.11.0"
+                "source": "https://github.com/canyongbs/common/tree/2.12.0"
             },
-            "time": "2026-04-10T09:08:07+00:00"
+            "time": "2026-04-13T09:46:32+00:00"
         },
         {
             "name": "canyongbs/filament-tiptap-editor",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4c4491b62139cff5563cc8a08f0fe6c8",
+    "content-hash": "ddf5d70314c5b9721d12a4e726eef8ea",
     "packages": [
         {
             "name": "ably/ably-php",
@@ -1589,16 +1589,16 @@
         },
         {
             "name": "canyongbs/common",
-            "version": "2.12.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/canyongbs/common.git",
-                "reference": "a5ad946e1befe6e1849425171d4f954d3a76bc99"
+                "reference": "61445c39aa590cf5c2c64a570d9e8c5b141a9d59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/canyongbs/common/zipball/a5ad946e1befe6e1849425171d4f954d3a76bc99",
-                "reference": "a5ad946e1befe6e1849425171d4f954d3a76bc99",
+                "url": "https://api.github.com/repos/canyongbs/common/zipball/61445c39aa590cf5c2c64a570d9e8c5b141a9d59",
+                "reference": "61445c39aa590cf5c2c64a570d9e8c5b141a9d59",
                 "shasum": ""
             },
             "require": {
@@ -1644,9 +1644,9 @@
             ],
             "support": {
                 "issues": "https://github.com/canyongbs/common/issues",
-                "source": "https://github.com/canyongbs/common/tree/2.12.0"
+                "source": "https://github.com/canyongbs/common/tree/2.12.1"
             },
-            "time": "2026-04-13T09:46:32+00:00"
+            "time": "2026-04-13T14:27:06+00:00"
         },
         {
             "name": "canyongbs/filament-tiptap-editor",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -73,6 +73,9 @@ parameters:
             message: '#Call to an undefined method Pest\\PendingCalls\\TestCall::expect\(\)#'
             identifier: method.notFound
             path: tests/Tenant/Unit/ArchTest.php
+        -
+            message: '#Anonymous function should return Illuminate\\Database\\Eloquent\\Builder<Illuminate\\Database\\Eloquent\\Model> but returns Illuminate\\Database\\Eloquent\\Builder<.+>#'
+            identifier: return.type
 
     typeAliases:
         ValidationRules: 'array<string, array<\Illuminate\Contracts\Validation\Rule|\Illuminate\Contracts\Validation\ValidationRule|string>|string>'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,7 @@ includes:
     - ./phpstan-baseline.php
     - ./vendor/pestphp/pest/extension.neon
     - ./vendor/orrison/meliorstan/config/extension.neon
+    - ./vendor/canyongbs/common/phpstan-extension.neon
 
 rules:
     - Orrison\MeliorStan\Rules\BooleanGetMethodName\BooleanGetMethodNameRule


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Updates `common` to includes the new extension to add support to PHPStan for our archive methods.

We may want to wait on merging and releasing https://github.com/canyongbs/common/pull/74 so I can remove the final ignores though.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
