### PR TITLE
[AIDAPP-1068]: Some users have reported that existing images in knowledge base articles are no longer rendering

### DIFF
--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/ListKnowledgeBaseItems.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/ListKnowledgeBaseItems.php
@@ -242,7 +242,7 @@ class ListKnowledgeBaseItems extends ListRecords
                         $uuidMap = [];
 
                         foreach ($media as $mediaItem) {
-                            $newMedia = $mediaItem->copy($replica, 'article_details', 's3-public');
+                            $newMedia = $mediaItem->copy($replica, 'article_details');
                             $uuidMap[$mediaItem->uuid] = $newMedia->uuid;
                         }
 

--- a/app-modules/knowledge-base/src/Models/KnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Models/KnowledgeBaseItem.php
@@ -140,8 +140,6 @@ class KnowledgeBaseItem extends BaseModel implements AiFile, Auditable, HasMedia
     public function setUpRichContent(): void
     {
         $this->registerRichContent('article_details')
-            ->fileAttachmentsDisk('s3-public')
-            ->fileAttachmentsVisibility('public')
             ->fileAttachmentProvider(
                 SpatieMediaLibraryFileAttachmentProvider::make()
                     ->collection('article_details')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1068

### Technical Description

It looks like some images in the production database are being stored on the private disk instead of the public disk, and we weren't generating temporary URLs for these, so they failed to render.

#988 set the visibility and disk for knowledgebase articles to be `public`, since I saw that there were places where we were storing images in the public disk previously. However, it seems like many of the existing images were actually uploaded to the private disk, and I don't see any reason for this feature to use the public disk (we don't send article content in emails etc like we do in Advising App). As such, I have adjusted the settings so that temporary URLs are generated for all images, and new images are uploaded to the private instead of the public disk.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
