### PR TITLE
[AIDAPP-1078] : Enhance enterprise AI by extending configuration support for GPT 5.4 nano

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,3 +131,7 @@ AZURE_OPEN_AI_ENABLE_TEST_MODE=true
 OPEN_AI_GPT_54_MINI_BASE_URI=https://cgbs-partner-canyon-dev-east-2.openai.azure.com/openai/v1
 OPEN_AI_GPT_54_MINI_API_KEY=
 OPEN_AI_GPT_54_MINI_MODEL=
+
+OPEN_AI_GPT_54_NANO_BASE_URI=https://cgbs-partner-canyon-dev-east-2.openai.azure.com/openai/v1
+OPEN_AI_GPT_54_NANO_API_KEY=
+OPEN_AI_GPT_54_NANO_MODEL=

--- a/app-modules/ai/database/migrations/2026_04_22_145455_add_gpt_54_nano_settings.php
+++ b/app-modules/ai/database/migrations/2026_04_22_145455_add_gpt_54_nano_settings.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app-modules/ai/database/migrations/2026_04_22_145455_add_gpt_54_nano_settings.php
+++ b/app-modules/ai/database/migrations/2026_04_22_145455_add_gpt_54_nano_settings.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use App\Features\Gpt54NanoFeature;
+use Illuminate\Support\Facades\DB;
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        DB::transaction(function () {
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_nano_model_name');
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_nano_base_uri', config('integration-open-ai.gpt_54_nano_base_uri'), encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_nano_api_key', config('integration-open-ai.gpt_54_nano_api_key'), encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_nano_model', config('integration-open-ai.gpt_54_nano_model'), encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_nano_applicable_features', []);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_nano_image_generation_deployment', encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            Gpt54NanoFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Gpt54NanoFeature::deactivate();
+
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_nano_base_uri');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_nano_api_key');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_nano_model');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_nano_applicable_features');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_nano_model_name');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_nano_image_generation_deployment');
+        });
+    }
+};

--- a/app-modules/ai/src/Enums/AiModel.php
+++ b/app-modules/ai/src/Enums/AiModel.php
@@ -40,6 +40,7 @@ use AidingApp\Ai\Services\Contracts\AiService;
 use AidingApp\Ai\Services\TestAiService;
 use AidingApp\Ai\Settings\AiIntegrationsSettings;
 use AidingApp\IntegrationOpenAi\Services\OpenAiGpt54MiniService;
+use AidingApp\IntegrationOpenAi\Services\OpenAiGpt54NanoService;
 use AidingApp\IntegrationOpenAi\Services\OpenAiGpt5MiniService;
 use AidingApp\IntegrationOpenAi\Services\OpenAiGpt5NanoService;
 use AidingApp\IntegrationOpenAi\Services\OpenAiGpt5Service;
@@ -57,6 +58,8 @@ enum AiModel: string implements HasLabel
 
     case OpenAiGpt5Nano = 'openai_gpt_5_nano';
 
+    case OpenAiGpt54Nano = 'openai_gpt_54_nano';
+
     case OpenAiGptTest = 'openai_gpt_test';
 
     case LlamaParse = 'llamaparse';
@@ -72,6 +75,7 @@ enum AiModel: string implements HasLabel
             self::OpenAiGpt5Mini => $aiIntegrationSettings->open_ai_gpt_5_mini_model_name ?? 'Canyon 5 mini',
             self::OpenAiGpt54Mini => $aiIntegrationSettings->open_ai_gpt_54_mini_model_name ?? 'Canyon 5.4 mini',
             self::OpenAiGpt5Nano => $aiIntegrationSettings->open_ai_gpt_5_nano_model_name ?? 'Canyon 5 nano',
+            self::OpenAiGpt54Nano => $aiIntegrationSettings->open_ai_gpt_54_nano_model_name ?? 'Canyon 5.4 nano',
             self::LlamaParse => $aiIntegrationSettings->llamaparse_model_name ?? 'Canyon Parsing Service',
             self::OpenAiGptTest => 'Canyon Test',
             self::Test => 'Test',
@@ -90,6 +94,7 @@ enum AiModel: string implements HasLabel
             self::OpenAiGpt5Mini => $aiIntegrationSettings->open_ai_gpt_5_mini_applicable_features,
             self::OpenAiGpt54Mini => $aiIntegrationSettings->open_ai_gpt_54_mini_applicable_features,
             self::OpenAiGpt5Nano => $aiIntegrationSettings->open_ai_gpt_5_nano_applicable_features,
+            self::OpenAiGpt54Nano => $aiIntegrationSettings->open_ai_gpt_54_nano_applicable_features,
             self::LlamaParse => [],
             self::OpenAiGptTest => app()->hasDebugModeEnabled() ? AiModelApplicabilityFeature::cases() : [],
             self::Test => app()->hasDebugModeEnabled() ? AiModelApplicabilityFeature::cases() : [],
@@ -116,6 +121,7 @@ enum AiModel: string implements HasLabel
             self::OpenAiGpt5Mini => OpenAiGpt5MiniService::class,
             self::OpenAiGpt5Nano => OpenAiGpt5NanoService::class,
             self::OpenAiGpt54Mini => OpenAiGpt54MiniService::class,
+            self::OpenAiGpt54Nano => OpenAiGpt54NanoService::class,
             self::OpenAiGptTest => OpenAiGptTestService::class,
             self::Test => TestAiService::class,
             default => throw new Exception('No Service class found for this model.'),

--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
@@ -39,6 +39,7 @@ namespace AidingApp\Ai\Filament\Pages;
 use AidingApp\Ai\Enums\AiModelApplicabilityFeature;
 use AidingApp\Ai\Settings\AiIntegrationsSettings;
 use App\Features\Gpt54MiniFeature;
+use App\Features\Gpt54NanoFeature;
 use App\Filament\Clusters\GlobalArtificialIntelligence;
 use App\Models\User;
 use Filament\Forms\Components\Select;
@@ -179,11 +180,35 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_54_mini_image_generation_deployment')
                                     ->label('Image generation model'),
                                 Select::make('open_ai_gpt_54_mini_applicable_features')
+                            ])->visible(fn () => Gpt54MiniFeature::active()),
+                        Section::make('GPT 5.4 nano')
+                            ->collapsible()
+                            ->schema([
+                                TextInput::make('open_ai_gpt_54_nano_model_name')
+                                    ->label('Model Name')
+                                    ->placeholder('Canyon 5.4 nano')
+                                    ->string()
+                                    ->maxLength(255)
+                                    ->nullable(),
+                                TextInput::make('open_ai_gpt_54_nano_base_uri')
+                                    ->label('Base URI')
+                                    ->placeholder('https://example.openai.azure.com/openai')
+                                    ->url(),
+                                TextInput::make('open_ai_gpt_54_nano_api_key')
+                                    ->label('API Key')
+                                    ->password()
+                                    ->autocomplete(false),
+                                TextInput::make('open_ai_gpt_54_nano_model')
+                                    ->label('Model'),
+                                TextInput::make('open_ai_gpt_54_nano_image_generation_deployment')
+                                    ->label('Image generation model'),
+                                Select::make('open_ai_gpt_54_nano_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
                                     ->multiple()
                                     ->nestedRecursiveRules([Rule::enum(AiModelApplicabilityFeature::class)]),
-                            ])->visible(fn () => Gpt54MiniFeature::active()),
+                            
+                            ])->visible(fn () => Gpt54NanoFeature::active()),
                     ]),
                 Section::make('LlamaCloud')
                     ->collapsible()

--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
@@ -180,6 +180,10 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_54_mini_image_generation_deployment')
                                     ->label('Image generation model'),
                                 Select::make('open_ai_gpt_54_mini_applicable_features')
+                                    ->label('Applicability')
+                                    ->options(AiModelApplicabilityFeature::class)
+                                    ->multiple()
+                                    ->nestedRecursiveRules([Rule::enum(AiModelApplicabilityFeature::class)]),
                             ])->visible(fn () => Gpt54MiniFeature::active()),
                         Section::make('GPT 5.4 nano')
                             ->collapsible()
@@ -207,7 +211,6 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->options(AiModelApplicabilityFeature::class)
                                     ->multiple()
                                     ->nestedRecursiveRules([Rule::enum(AiModelApplicabilityFeature::class)]),
-                            
                             ])->visible(fn () => Gpt54NanoFeature::active()),
                     ]),
                 Section::make('LlamaCloud')

--- a/app-modules/ai/src/Settings/AiIntegrationsSettings.php
+++ b/app-modules/ai/src/Settings/AiIntegrationsSettings.php
@@ -95,10 +95,22 @@ class AiIntegrationsSettings extends Settings
 
     public ?string $open_ai_gpt_54_mini_image_generation_deployment = null;
 
+    public ?string $open_ai_gpt_54_nano_model_name = null;
+
+    public ?string $open_ai_gpt_54_nano_base_uri = null;
+
+    public ?string $open_ai_gpt_54_nano_api_key = null;
+
+    public ?string $open_ai_gpt_54_nano_model = null;
+
+    public ?string $open_ai_gpt_54_nano_image_generation_deployment = null;
+
     /**
      * @var array<string>
      */
     public array $open_ai_gpt_54_mini_applicable_features = [];
+
+    public array $open_ai_gpt_54_nano_applicable_features = [];
 
     public ?string $llamaparse_model_name = null;
 
@@ -129,6 +141,10 @@ class AiIntegrationsSettings extends Settings
             'open_ai_gpt_54_mini_api_key',
             'open_ai_gpt_54_mini_model',
             'open_ai_gpt_54_mini_image_generation_deployment',
+            'open_ai_gpt_54_nano_base_uri',
+            'open_ai_gpt_54_nano_api_key',
+            'open_ai_gpt_54_nano_model',
+            'open_ai_gpt_54_nano_image_generation_deployment',
             'llamaparse_api_key',
         ];
     }

--- a/app-modules/ai/src/Settings/AiIntegrationsSettings.php
+++ b/app-modules/ai/src/Settings/AiIntegrationsSettings.php
@@ -110,6 +110,9 @@ class AiIntegrationsSettings extends Settings
      */
     public array $open_ai_gpt_54_mini_applicable_features = [];
 
+    /**
+     * @var array<string>
+     */
     public array $open_ai_gpt_54_nano_applicable_features = [];
 
     public ?string $llamaparse_model_name = null;

--- a/app-modules/integration-open-ai/config/integration-open-ai.php
+++ b/app-modules/integration-open-ai/config/integration-open-ai.php
@@ -58,7 +58,7 @@ return [
     'gpt_54_mini_api_key' => env('OPEN_AI_GPT_54_MINI_API_KEY'),
 
     'gpt_54_mini_model' => env('OPEN_AI_GPT_54_MINI_MODEL'),
-    
+
     'gpt_54_nano_base_uri' => env('OPEN_AI_GPT_54_NANO_BASE_URI'),
 
     'gpt_54_nano_api_key' => env('OPEN_AI_GPT_54_NANO_API_KEY'),

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt54NanoService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt54NanoService.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -34,34 +34,37 @@
 </COPYRIGHT>
 */
 
-return [
-    'gpt_5_base_uri' => env('OPEN_AI_GPT_5_BASE_URI'),
+namespace AidingApp\IntegrationOpenAi\Services;
 
-    'gpt_5_api_key' => env('OPEN_AI_GPT_5_API_KEY'),
+class OpenAiGpt54NanoService extends BaseOpenAiService
+{
+    public function getApiKey(): string
+    {
+        return $this->settings->open_ai_gpt_54_nano_api_key ?? config('integration-open-ai.gpt_54_nano_api_key');
+    }
 
-    'gpt_5_model' => env('OPEN_AI_GPT_5_MODEL'),
+    public function getModel(): string
+    {
+        return $this->settings->open_ai_gpt_54_nano_model ?? config('integration-open-ai.gpt_54_nano_model');
+    }
 
-    'gpt_5_mini_base_uri' => env('OPEN_AI_GPT_5_MINI_BASE_URI'),
+    public function getDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_54_nano_base_uri ?? config('integration-open-ai.gpt_54_nano_base_uri');
+    }
 
-    'gpt_5_mini_api_key' => env('OPEN_AI_GPT_5_MINI_API_KEY'),
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_54_nano_image_generation_deployment;
+    }
 
-    'gpt_5_mini_model' => env('OPEN_AI_GPT_5_MINI_MODEL'),
+    public function hasTemperature(): bool
+    {
+        return false;
+    }
 
-    'gpt_5_nano_base_uri' => env('OPEN_AI_GPT_5_NANO_BASE_URI'),
-
-    'gpt_5_nano_api_key' => env('OPEN_AI_GPT_5_NANO_API_KEY'),
-
-    'gpt_5_nano_model' => env('OPEN_AI_GPT_5_NANO_MODEL'),
-
-    'gpt_54_mini_base_uri' => env('OPEN_AI_GPT_54_MINI_BASE_URI'),
-
-    'gpt_54_mini_api_key' => env('OPEN_AI_GPT_54_MINI_API_KEY'),
-
-    'gpt_54_mini_model' => env('OPEN_AI_GPT_54_MINI_MODEL'),
-    
-    'gpt_54_nano_base_uri' => env('OPEN_AI_GPT_54_NANO_BASE_URI'),
-
-    'gpt_54_nano_api_key' => env('OPEN_AI_GPT_54_NANO_API_KEY'),
-
-    'gpt_54_nano_model' => env('OPEN_AI_GPT_54_NANO_MODEL'),
-];
+    public function hasReasoning(): bool
+    {
+        return true;
+    }
+}

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt54NanoService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt54NanoService.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app/Features/Gpt54NanoFeature.php
+++ b/app/Features/Gpt54NanoFeature.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app/Features/Gpt54NanoFeature.php
+++ b/app/Features/Gpt54NanoFeature.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -34,34 +34,14 @@
 </COPYRIGHT>
 */
 
-return [
-    'gpt_5_base_uri' => env('OPEN_AI_GPT_5_BASE_URI'),
+namespace App\Features;
 
-    'gpt_5_api_key' => env('OPEN_AI_GPT_5_API_KEY'),
+use App\Support\AbstractFeatureFlag;
 
-    'gpt_5_model' => env('OPEN_AI_GPT_5_MODEL'),
-
-    'gpt_5_mini_base_uri' => env('OPEN_AI_GPT_5_MINI_BASE_URI'),
-
-    'gpt_5_mini_api_key' => env('OPEN_AI_GPT_5_MINI_API_KEY'),
-
-    'gpt_5_mini_model' => env('OPEN_AI_GPT_5_MINI_MODEL'),
-
-    'gpt_5_nano_base_uri' => env('OPEN_AI_GPT_5_NANO_BASE_URI'),
-
-    'gpt_5_nano_api_key' => env('OPEN_AI_GPT_5_NANO_API_KEY'),
-
-    'gpt_5_nano_model' => env('OPEN_AI_GPT_5_NANO_MODEL'),
-
-    'gpt_54_mini_base_uri' => env('OPEN_AI_GPT_54_MINI_BASE_URI'),
-
-    'gpt_54_mini_api_key' => env('OPEN_AI_GPT_54_MINI_API_KEY'),
-
-    'gpt_54_mini_model' => env('OPEN_AI_GPT_54_MINI_MODEL'),
-    
-    'gpt_54_nano_base_uri' => env('OPEN_AI_GPT_54_NANO_BASE_URI'),
-
-    'gpt_54_nano_api_key' => env('OPEN_AI_GPT_54_NANO_API_KEY'),
-
-    'gpt_54_nano_model' => env('OPEN_AI_GPT_54_NANO_MODEL'),
-];
+class Gpt54NanoFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1078

### Technical Description

- Enhance enterprise AI by extending configuration support for GPT 5.4 nano

### Any deployment steps required?

Add the following keys to the .env.example file:

```
OPEN_AI_GPT_54_NANO_BASE_URI=https://cgbs-partner-canyon-dev-east-2.openai.azure.com/openai/v1
OPEN_AI_GPT_54_NANO_API_KEY=
OPEN_AI_GPT_54_NANO_MODEL=
```

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> Feature Flag Added: `Gpt54NanoFeature`
---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
