### PR TITLE
[AIDAPP-1119]: Prevent the display of division in article metadata if only one division exists

### DIFF
--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItem.php
@@ -36,6 +36,7 @@
 
 namespace AidingApp\KnowledgeBase\Filament\Resources\KnowledgeBaseItems\Pages;
 
+use AidingApp\Division\Models\Division;
 use AidingApp\KnowledgeBase\Filament\Actions\CreateConcernAction;
 use AidingApp\KnowledgeBase\Filament\Resources\KnowledgeBaseItems\KnowledgeBaseItemResource;
 use AidingApp\KnowledgeBase\Filament\Widgets\KnowledgeBaseItemConcernsTable;
@@ -107,6 +108,7 @@ class ViewKnowledgeBaseItem extends ViewRecord
                                 TextEntry::make('category.name')
                                     ->label('Category'),
                                 TextEntry::make('division.name')
+                                    ->visible(fn (): bool => Division::count() > 1)
                                     ->label('Division'),
                                 TextEntry::make('managers')
                                     ->label('Managers')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1119

### Technical Description

> Prevent the display of division in article metadata if only one division exists

### Any deployment steps required?

> NO

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> NO

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
