### PR TITLE
[AIDAPP-1131]: Enhance the concern management features associated with knowledge management so they use permissions

### DIFF
--- a/app-modules/knowledge-base/src/Filament/Actions/AssignManagerBulkAction.php
+++ b/app-modules/knowledge-base/src/Filament/Actions/AssignManagerBulkAction.php
@@ -55,6 +55,7 @@ class AssignManagerBulkAction
             ->label('Assign Managers')
             ->icon('heroicon-s-user-group')
             ->modalHeading('Bulk Assign Managers')
+            ->authorize(fn () => auth()->user()->can('knowledge_base_item.view-any') && auth()->user()->can('knowledge_base_item.*.update'))
             ->modalDescription(fn (Collection $records) => "You have selected {$records->count()} " . Str::plural('item', $records->count()) . ' to assign manager(s).')
             ->schema([
                 Select::make('manager_ids')

--- a/app-modules/knowledge-base/src/Filament/Actions/ChangeConcernStatusAction.php
+++ b/app-modules/knowledge-base/src/Filament/Actions/ChangeConcernStatusAction.php
@@ -51,6 +51,7 @@ class ChangeConcernStatusAction extends Action
             ->label('Change Status')
             ->button()
             ->outlined()
+            ->authorize(fn () => auth()->user()->can('knowledge_base_item.view-any') && auth()->user()->can('knowledge_base_item.*.update'))
             ->modalDescription('Select what status this concern should have.')
             ->schema([
                 Select::make('status')

--- a/app-modules/knowledge-base/src/Filament/Actions/CreateConcernAction.php
+++ b/app-modules/knowledge-base/src/Filament/Actions/CreateConcernAction.php
@@ -51,6 +51,7 @@ class CreateConcernAction extends Action
         $this
             ->label('Raise Concern')
             ->button()
+            ->authorize(fn () => auth()->user()->can('knowledge_base_item.view-any'))
             ->modalDescription('Please articulate the concern you have with this knowledge base item. You may enter up to 100 characters in the box below.')
             ->schema([
                 Textarea::make('description')

--- a/app-modules/knowledge-base/src/Filament/Widgets/KnowledgeBaseItemConcernsTable.php
+++ b/app-modules/knowledge-base/src/Filament/Widgets/KnowledgeBaseItemConcernsTable.php
@@ -75,8 +75,7 @@ class KnowledgeBaseItemConcernsTable extends TableWidget
                 TextColumn::make('status'),
             ])
             ->recordActions([
-                ChangeConcernStatusAction::make()
-                    ->authorize(fn () => auth()->user()->can('update', $this->record)),
+                ChangeConcernStatusAction::make(),
             ])
             ->filters([
                 SelectFilter::make('status')

--- a/app-modules/knowledge-base/tests/Tenant/Filament/Actions/AssignManagerBulkActionTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/Filament/Actions/AssignManagerBulkActionTest.php
@@ -39,8 +39,28 @@ use AidingApp\KnowledgeBase\Models\KnowledgeBaseItem;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
+
+it('is gated by proper access control', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('knowledge_base_item.view-any');
+
+    asSuperAdmin();
+
+    $items = KnowledgeBaseItem::factory(3)->create();
+
+    actingAs($user);
+
+    livewire(ListKnowledgeBaseItems::class)
+        ->assertTableBulkActionHidden('bulkManagers');
+
+    $user->givePermissionTo('knowledge_base_item.*.update');
+
+    livewire(ListKnowledgeBaseItems::class)
+        ->assertTableBulkActionVisible('bulkManagers');
+});
 
 it('can bulk assign managers to items', function () {
     asSuperAdmin();

--- a/app-modules/knowledge-base/tests/Tenant/Filament/Actions/CreateConcernActionTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/Filament/Actions/CreateConcernActionTest.php
@@ -37,9 +37,32 @@
 use AidingApp\KnowledgeBase\Filament\Resources\KnowledgeBaseItems\Pages\ViewKnowledgeBaseItem;
 use AidingApp\KnowledgeBase\Models\KnowledgeBaseItem;
 use AidingApp\KnowledgeBase\Tests\Tenant\Filament\Actions\RequestFactories\CreateConcernActionRequestFactory;
+use App\Models\User;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
+
+it('is gated by proper access control', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('knowledge_base_item.view-any');
+    $user->givePermissionTo('knowledge_base_item.*.view');
+
+    asSuperAdmin();
+
+    $knowledgeBaseItem = KnowledgeBaseItem::factory()->create();
+
+    actingAs($user);
+
+    livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
+        ->assertActionVisible('raiseConcern');
+
+    $user->revokePermissionTo('knowledge_base_item.view-any');
+    $user->refresh();
+
+    livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
+        ->assertForbidden();
+});
 
 it('can create a concern properly', function () {
     asSuperAdmin();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1131

### Technical Description

> Implement access control for bulk manager assignment and concern actions

### Any deployment steps required?

> No

### Cleanup Tasks

> No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
