### PR TITLE
[AIDAPP-1135]: Display Support Assistant text streaming more fluidly

### DIFF
--- a/widgets/assistant/src/composables/useMarkdown.js
+++ b/widgets/assistant/src/composables/useMarkdown.js
@@ -43,7 +43,13 @@ export function useMarkdown() {
     const renderMarkdown = (content) => {
         if (!content) return '';
         try {
-            const cleanedContent = content.replace(/【[^】]*】/g, '');
+            // Strip the last line if it contains only a single "-" (with optional surrounding whitespace).
+            // This prevents setext H2 flashing during streaming when a nested bullet "-" appears
+            // alone on the final line before its text has arrived. Also removes any "【...】"
+            // patterns which are used for internal citations and should not be rendered.
+            const cleanedContent = content
+                .replace(/【[^】]*】/g, '')
+                .replace(/\n\s*-\s*$/, '');
             const html = marked.parse(cleanedContent, { async: false });
             return DOMPurify.sanitize(html);
         } catch (error) {

--- a/widgets/assistant/src/composables/useMarkdown.js
+++ b/widgets/assistant/src/composables/useMarkdown.js
@@ -47,9 +47,7 @@ export function useMarkdown() {
             // This prevents setext H2 flashing during streaming when a nested bullet "-" appears
             // alone on the final line before its text has arrived. Also removes any "【...】"
             // patterns which are used for internal citations and should not be rendered.
-            const cleanedContent = content
-                .replace(/【[^】]*】/g, '')
-                .replace(/\n\s*-\s*$/, '');
+            const cleanedContent = content.replace(/【[^】]*】/g, '').replace(/\n\s*-\s*$/, '');
             const html = marked.parse(cleanedContent, { async: false });
             return DOMPurify.sanitize(html);
         } catch (error) {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1135

### Technical Description

During MD rendering, strip the final line if it just contains whitespace and a `-` to prevent the previous line from being treated as a heading, while a bullet is streaming in.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
