### PR TITLE
[AIDAPP-1130]: Disable Service Monitoring check jobs if the feature is not enabled

### DIFF
--- a/app-modules/service-management/src/Jobs/ServiceMonitoringJob.php
+++ b/app-modules/service-management/src/Jobs/ServiceMonitoringJob.php
@@ -38,6 +38,7 @@ namespace AidingApp\ServiceManagement\Jobs;
 
 use AidingApp\ServiceManagement\Enums\ServiceMonitoringFrequency;
 use AidingApp\ServiceManagement\Models\ServiceMonitoringTarget;
+use App\Settings\LicenseSettings;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection;
@@ -78,6 +79,10 @@ class ServiceMonitoringJob implements ShouldQueue, ShouldBeUnique
 
     public function handle(): void
     {
+        if (! app(LicenseSettings::class)->data?->addons?->serviceMonitoring) {
+            return;
+        }
+
         ServiceMonitoringTarget::where('frequency', $this->interval)
             ->chunkById(100, function (Collection $serviceMonitoringTargets) {
                 foreach ($serviceMonitoringTargets as $serviceMonitoringTarget) {

--- a/app-modules/service-management/tests/Tenant/Jobs/ServiceMonitoringJobTest.php
+++ b/app-modules/service-management/tests/Tenant/Jobs/ServiceMonitoringJobTest.php
@@ -38,6 +38,7 @@ use AidingApp\ServiceManagement\Enums\ServiceMonitoringFrequency;
 use AidingApp\ServiceManagement\Jobs\ServiceMonitoringCheckJob;
 use AidingApp\ServiceManagement\Jobs\ServiceMonitoringJob;
 use AidingApp\ServiceManagement\Models\ServiceMonitoringTarget;
+use App\Settings\LicenseSettings;
 use Illuminate\Support\Facades\Queue;
 
 it('successfully dispatches', function ($frequency) {
@@ -50,6 +51,29 @@ it('successfully dispatches', function ($frequency) {
     (new ServiceMonitoringJob($frequency))->handle();
 
     Queue::assertPushed(ServiceMonitoringCheckJob::class, $numJobs);
+})
+    ->with(
+        [
+            fn () => ServiceMonitoringFrequency::FiveMinutes,
+            fn () => ServiceMonitoringFrequency::FifteenMinutes,
+            fn () => ServiceMonitoringFrequency::ThirtyMinutes,
+            fn () => ServiceMonitoringFrequency::OneHour,
+            fn () => ServiceMonitoringFrequency::TwentyFourHours,
+        ]
+    );
+
+it('does not dispatch when serviceMonitoring addon is disabled', function ($frequency) {
+    Queue::fake();
+
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->serviceMonitoring = false;
+    $settings->save();
+
+    ServiceMonitoringTarget::factory()->count(3)->create(['frequency' => $frequency]);
+
+    (new ServiceMonitoringJob($frequency))->handle();
+
+    Queue::assertNotPushed(ServiceMonitoringCheckJob::class);
 })
     ->with(
         [

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -51,6 +51,7 @@ use AidingApp\ServiceManagement\Jobs\ServiceMonitoringJob;
 use App\Models\HealthCheckResultHistoryItem;
 use App\Models\Scopes\SetupIsComplete;
 use App\Models\Tenant;
+use App\Settings\LicenseSettings;
 use Filament\Actions\Imports\Models\FailedImportRow;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -96,35 +97,45 @@ class Kernel extends ConsoleKernel
 
                     $schedule->call(function () use ($tenant) {
                         $tenant->execute(function () {
-                            dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::FiveMinutes));
+                            if (app(LicenseSettings::class)->data?->addons?->serviceMonitoring) {
+                                dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::FiveMinutes));
+                            }
                         });
                     })
                         ->everyFiveMinutes();
 
                     $schedule->call(function () use ($tenant) {
                         $tenant->execute(function () {
-                            dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::FifteenMinutes));
+                            if (app(LicenseSettings::class)->data?->addons?->serviceMonitoring) {
+                                dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::FifteenMinutes));
+                            }
                         });
                     })
                         ->everyFifteenMinutes();
 
                     $schedule->call(function () use ($tenant) {
                         $tenant->execute(function () {
-                            dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::ThirtyMinutes));
+                            if (app(LicenseSettings::class)->data?->addons?->serviceMonitoring) {
+                                dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::ThirtyMinutes));
+                            }
                         });
                     })
                         ->everyThirtyMinutes();
 
                     $schedule->call(function () use ($tenant) {
                         $tenant->execute(function () {
-                            dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::OneHour));
+                            if (app(LicenseSettings::class)->data?->addons?->serviceMonitoring) {
+                                dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::OneHour));
+                            }
                         });
                     })
                         ->hourly();
 
                     $schedule->call(function () use ($tenant) {
                         $tenant->execute(function () {
-                            dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::TwentyFourHours));
+                            if (app(LicenseSettings::class)->data?->addons?->serviceMonitoring) {
+                                dispatch(new ServiceMonitoringJob(ServiceMonitoringFrequency::TwentyFourHours));
+                            }
                         });
                     })
                         ->daily();

--- a/tests/Landlord/Console/KernelTest.php
+++ b/tests/Landlord/Console/KernelTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/tests/Landlord/Console/KernelTest.php
+++ b/tests/Landlord/Console/KernelTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\ServiceManagement\Jobs\ServiceMonitoringJob;
+use App\Models\Tenant;
+use App\Settings\LicenseSettings;
+use Illuminate\Support\Facades\Queue;
+
+use function Pest\Laravel\artisan;
+use function Pest\Laravel\travelTo;
+
+describe('ServiceMonitoringJob scheduling', function () {
+    it('dispatches ServiceMonitoringJob for each frequency when serviceMonitoring addon is enabled', function () {
+        Queue::fake();
+
+        travelTo(now()->startOfDay());
+
+        artisan('schedule:run');
+
+        Queue::assertPushed(ServiceMonitoringJob::class, 5);
+    });
+
+    it('does not dispatch ServiceMonitoringJob when serviceMonitoring addon is disabled', function () {
+        Queue::fake();
+
+        $tenant = Tenant::query()->first();
+
+        $tenant->execute(function () {
+            $settings = app(LicenseSettings::class);
+            $settings->data->addons->serviceMonitoring = false;
+            $settings->save();
+        });
+
+        travelTo(now()->startOfDay());
+
+        artisan('schedule:run');
+
+        Queue::assertNotPushed(ServiceMonitoringJob::class);
+    });
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1130

### Technical Description

Does NOT dispatch the service monitoring check jobs if the Tenant has the feature disabled.

Adds tests ensuring this is true.

Updates `devops` to align with `main`.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
