### PR TITLE
[AIDAPP-1115]: Enhance the user experience related to files associated with a service request

### DIFF
--- a/.cleanup-tasks/2026_05_19_media_created_by_feature.md
+++ b/.cleanup-tasks/2026_05_19_media_created_by_feature.md
@@ -1,0 +1,12 @@
+---
+title: Media Created By Feature
+created: 2026-05-19
+---
+
+## Feature Flags
+
+- App\Features\MediaCreatedByFeature
+
+## Temporary Migrations
+
+## Additional Cleanup

--- a/app-modules/ai/src/Models/AiAssistant.php
+++ b/app-modules/ai/src/Models/AiAssistant.php
@@ -39,6 +39,7 @@ namespace AidingApp\Ai\Models;
 use AidingApp\Ai\Database\Factories\AiAssistantFactory;
 use AidingApp\Ai\Enums\AiAssistantApplication;
 use AidingApp\Ai\Enums\AiModel;
+use App\Models\Media;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -56,7 +57,10 @@ class AiAssistant extends Model implements HasMedia
     use HasFactory;
 
     use HasUuids;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use SoftDeletes;
 
     protected $fillable = [

--- a/app-modules/ai/src/Models/AiAssistantFile.php
+++ b/app-modules/ai/src/Models/AiAssistantFile.php
@@ -39,6 +39,7 @@ namespace AidingApp\Ai\Models;
 use AidingApp\Ai\Database\Factories\AiAssistantFileFactory;
 use AidingApp\Ai\Models\Contracts\AiFile;
 use AidingApp\IntegrationOpenAi\Models\OpenAiVectorStore;
+use App\Models\Media;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -58,6 +59,8 @@ class AiAssistantFile extends Model implements AiFile, HasMedia
 
     use HasUuids;
     use SoftDeletes;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
 
     protected $fillable = [

--- a/app-modules/ai/src/Models/AiMessageFile.php
+++ b/app-modules/ai/src/Models/AiMessageFile.php
@@ -39,6 +39,7 @@ namespace AidingApp\Ai\Models;
 use AidingApp\Ai\Database\Factories\AiMessageFileFactory;
 use AidingApp\Ai\Models\Contracts\AiFile;
 use AidingApp\IntegrationOpenAi\Models\OpenAiVectorStore;
+use App\Models\Media;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -60,7 +61,10 @@ class AiMessageFile extends Model implements AiFile, HasMedia
 
     use HasUuids;
     use SoftDeletes;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use Prunable;
 
     protected $fillable = [

--- a/app-modules/ai/src/Models/AiThread.php
+++ b/app-modules/ai/src/Models/AiThread.php
@@ -37,6 +37,7 @@
 namespace AidingApp\Ai\Models;
 
 use AidingApp\Ai\Database\Factories\AiThreadFactory;
+use App\Models\Media;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -60,6 +61,8 @@ class AiThread extends Model implements HasMedia
     use HasUuids;
     use SoftDeletes;
     use Prunable;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
 
     protected $fillable = [

--- a/app-modules/contact/src/Models/Organization.php
+++ b/app-modules/contact/src/Models/Organization.php
@@ -39,6 +39,7 @@ namespace AidingApp\Contact\Models;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\Contact\Database\Factories\OrganizationFactory;
 use App\Models\BaseModel;
+use App\Models\Media;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -58,7 +59,10 @@ class Organization extends BaseModel implements HasMedia, Auditable
 
     use HasUuids;
     use SoftDeletes;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use AuditableTrait;
 
     protected $fillable = [

--- a/app-modules/contract-management/src/Models/Contract.php
+++ b/app-modules/contract-management/src/Models/Contract.php
@@ -41,6 +41,7 @@ use AidingApp\ContractManagement\Database\Factories\ContractFactory;
 use AidingApp\ContractManagement\Enums\ContractStatus;
 use App\Casts\CurrencyCast;
 use App\Models\BaseModel;
+use App\Models\Media;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -54,7 +55,9 @@ use Spatie\MediaLibrary\InteractsWithMedia;
  */
 class Contract extends BaseModel implements HasMedia, Auditable
 {
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use AuditableTrait;
     use SoftDeletes;
 

--- a/app-modules/engagement/src/Filament/Schemas/Components/EngagementBodyInput.php
+++ b/app-modules/engagement/src/Filament/Schemas/Components/EngagementBodyInput.php
@@ -39,6 +39,7 @@ namespace AidingApp\Engagement\Filament\Schemas\Components;
 use AidingApp\Engagement\Models\EmailTemplate;
 use AidingApp\Engagement\Models\Engagement;
 use AidingApp\Engagement\Models\EngagementBatch;
+use App\Models\Media;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Checkbox;
@@ -50,7 +51,6 @@ use Filament\Schemas\Components\Utilities\Set;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Str;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class EngagementBodyInput
 {

--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -54,7 +54,6 @@ use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\TenantServiceRequestTypeDomain;
 use App\Features\MediaCreatedByFeature;
-use App\Models\Media;
 use App\Models\Tenant;
 use Aws\Crypto\KmsMaterialsProviderV3;
 use Aws\Kms\KmsClient;
@@ -339,7 +338,6 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
 
             foreach ($parser->getAttachments(false) as $attachment) {
                 try {
-                    /** @var Media $media */
                     $media = $serviceRequestUpdate->addMediaFromStream($attachment->getStream())
                         ->setName($attachment->getFilename())
                         ->setFileName($attachment->getFilename())
@@ -526,7 +524,6 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
 
                 foreach ($parser->getAttachments(false) as $attachment) {
                     try {
-                        /** @var Media $media */
                         $media = $serviceRequest->addMediaFromStream($attachment->getStream())
                             ->setName($attachment->getFilename())
                             ->setFileName($attachment->getFilename())

--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -54,6 +54,7 @@ use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\TenantServiceRequestTypeDomain;
 use App\Features\MediaCreatedByFeature;
+use App\Models\Media;
 use App\Models\Tenant;
 use Aws\Crypto\KmsMaterialsProviderV3;
 use Aws\Kms\KmsClient;
@@ -338,7 +339,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
 
             foreach ($parser->getAttachments(false) as $attachment) {
                 try {
-                    /** @var \App\Models\Media $media */
+                    /** @var Media $media */
                     $media = $serviceRequestUpdate->addMediaFromStream($attachment->getStream())
                         ->setName($attachment->getFilename())
                         ->setFileName($attachment->getFilename())
@@ -525,7 +526,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
 
                 foreach ($parser->getAttachments(false) as $attachment) {
                     try {
-                        /** @var \App\Models\Media $media */
+                        /** @var Media $media */
                         $media = $serviceRequest->addMediaFromStream($attachment->getStream())
                             ->setName($attachment->getFilename())
                             ->setFileName($attachment->getFilename())

--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -344,6 +344,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                         ->toMediaCollection('uploads');
 
                     $respondent = $serviceRequest->respondent;
+
                     if (MediaCreatedByFeature::active() && is_null($media->created_by_id)) {
                         $media->created_by_id = $respondent->getKey();
                         $media->created_by_type = $respondent->getMorphClass();

--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -53,6 +53,7 @@ use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\TenantServiceRequestTypeDomain;
+use App\Features\MediaCreatedByFeature;
 use App\Models\Tenant;
 use Aws\Crypto\KmsMaterialsProviderV3;
 use Aws\Kms\KmsClient;
@@ -337,10 +338,17 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
 
             foreach ($parser->getAttachments(false) as $attachment) {
                 try {
-                    $serviceRequestUpdate->addMediaFromStream($attachment->getStream())
+                    $media = $serviceRequestUpdate->addMediaFromStream($attachment->getStream())
                         ->setName($attachment->getFilename())
                         ->setFileName($attachment->getFilename())
                         ->toMediaCollection('uploads');
+
+                    $respondent = $serviceRequest->respondent;
+                    if (MediaCreatedByFeature::active() && is_null($media->created_by_id)) {
+                        $media->created_by_id = $respondent->getKey();
+                        $media->created_by_type = $respondent->getMorphClass();
+                        $media->saveQuietly();
+                    }
                 } catch (Throwable $throw) {
                     report($throw);
                 }
@@ -516,10 +524,16 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
 
                 foreach ($parser->getAttachments(false) as $attachment) {
                     try {
-                        $serviceRequest->addMediaFromStream($attachment->getStream())
+                        $media = $serviceRequest->addMediaFromStream($attachment->getStream())
                             ->setName($attachment->getFilename())
                             ->setFileName($attachment->getFilename())
                             ->toMediaCollection('uploads');
+
+                        if (MediaCreatedByFeature::active() && is_null($media->created_by_id)) {
+                            $media->created_by_id = $contact->getKey();
+                            $media->created_by_type = $contact->getMorphClass();
+                            $media->saveQuietly();
+                        }
                     } catch (Throwable $throw) {
                         report($throw);
                     }

--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -338,6 +338,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
 
             foreach ($parser->getAttachments(false) as $attachment) {
                 try {
+                    /** @var \App\Models\Media $media */
                     $media = $serviceRequestUpdate->addMediaFromStream($attachment->getStream())
                         ->setName($attachment->getFilename())
                         ->setFileName($attachment->getFilename())
@@ -524,6 +525,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
 
                 foreach ($parser->getAttachments(false) as $attachment) {
                     try {
+                        /** @var \App\Models\Media $media */
                         $media = $serviceRequest->addMediaFromStream($attachment->getStream())
                             ->setName($attachment->getFilename())
                             ->setFileName($attachment->getFilename())

--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -346,8 +346,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                     $respondent = $serviceRequest->respondent;
 
                     if (MediaCreatedByFeature::active() && is_null($media->created_by_id)) {
-                        $media->created_by_id = $respondent->getKey();
-                        $media->created_by_type = $respondent->getMorphClass();
+                        $media->createdBy()->associate($respondent);
                         $media->saveQuietly();
                     }
                 } catch (Throwable $throw) {
@@ -531,8 +530,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                             ->toMediaCollection('uploads');
 
                         if (MediaCreatedByFeature::active() && is_null($media->created_by_id)) {
-                            $media->created_by_id = $contact->getKey();
-                            $media->created_by_type = $contact->getMorphClass();
+                            $media->createdBy()->associate($contact);
                             $media->saveQuietly();
                         }
                     } catch (Throwable $throw) {

--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -45,7 +45,6 @@ use AidingApp\Engagement\Exceptions\SesS3InboundServiceRequestTypeNotFound;
 use AidingApp\Engagement\Exceptions\SesS3InboundSpamOrVirusDetected;
 use AidingApp\Engagement\Exceptions\UnableToDetectTenantFromSesS3EmailPayload;
 use AidingApp\Engagement\Exceptions\UnableToRetrieveContentFromSesS3EmailPayload;
-use AidingApp\Engagement\Models\EngagementResponse;
 use AidingApp\Engagement\Models\UnmatchedInboundCommunication;
 use AidingApp\Engagement\Notifications\IneligibleContactSesS3InboundEmailServiceRequestNotification;
 use AidingApp\Notification\Models\OutboundEmailMessageId;
@@ -271,7 +270,6 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
             }
 
             $contacts->each(function (Contact $contact) use ($parser, $content) {
-                /** @var EngagementResponse $engagementResponse */
                 $engagementResponse = $contact->engagementResponses()
                     ->create([
                         'subject' => $parser->getHeader('subject'),
@@ -281,12 +279,17 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                         'raw' => $content,
                     ]);
 
-                collect($parser->getAttachments())->each(function (Attachment $attachment) use ($engagementResponse) {
+                collect($parser->getAttachments())->each(function (Attachment $attachment) use ($engagementResponse, $contact) {
                     try {
-                        $engagementResponse->addMediaFromStream($attachment->getStream())
+                        $media = $engagementResponse->addMediaFromStream($attachment->getStream())
                             ->setName($attachment->getFilename())
                             ->setFileName($attachment->getFilename())
                             ->toMediaCollection('attachments');
+
+                        if (MediaCreatedByFeature::active() && is_null($media->created_by_id)) {
+                            $media->createdBy()->associate($contact);
+                            $media->saveQuietly();
+                        }
                     } catch (Throwable $throw) {
                         report($throw);
                     }

--- a/app-modules/engagement/src/Models/EmailTemplate.php
+++ b/app-modules/engagement/src/Models/EmailTemplate.php
@@ -39,6 +39,7 @@ namespace AidingApp\Engagement\Models;
 use AidingApp\Engagement\Database\Factories\EmailTemplateFactory;
 use AidingApp\Engagement\Observers\EmailTemplateObserver;
 use App\Models\BaseModel;
+use App\Models\Media;
 use App\Models\User;
 use Filament\Forms\Components\RichEditor\FileAttachmentProviders\SpatieMediaLibraryFileAttachmentProvider;
 use Filament\Forms\Components\RichEditor\Models\Concerns\InteractsWithRichContent;
@@ -56,7 +57,9 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 #[ObservedBy([EmailTemplateObserver::class])]
 class EmailTemplate extends BaseModel implements HasMedia, HasRichContent
 {
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use InteractsWithRichContent;
     use SoftDeletes;
 

--- a/app-modules/engagement/src/Models/Engagement.php
+++ b/app-modules/engagement/src/Models/Engagement.php
@@ -48,6 +48,7 @@ use AidingApp\Timeline\Models\Timeline;
 use AidingApp\Timeline\Timelines\EngagementTimeline;
 use App\Models\BaseModel;
 use App\Models\Contracts\Educatable;
+use App\Models\Media;
 use App\Models\User;
 use Closure;
 use Filament\Forms\Components\RichEditor\FileAttachmentProviders\SpatieMediaLibraryFileAttachmentProvider;
@@ -77,7 +78,10 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 class Engagement extends BaseModel implements Auditable, ProvidesATimeline, HasDeliveryMethod, HasMedia, HasRichContent
 {
     use AuditableTrait;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use InteractsWithRichContent;
     use SoftDeletes;
 

--- a/app-modules/engagement/src/Models/EngagementBatch.php
+++ b/app-modules/engagement/src/Models/EngagementBatch.php
@@ -41,6 +41,7 @@ use AidingApp\Engagement\Models\Concerns\HasManyEngagements;
 use AidingApp\Engagement\Observers\EngagementBatchObserver;
 use AidingApp\Notification\Enums\NotificationChannel;
 use App\Models\BaseModel;
+use App\Models\Media;
 use App\Models\User;
 use Filament\Forms\Components\RichEditor\FileAttachmentProviders\SpatieMediaLibraryFileAttachmentProvider;
 use Filament\Forms\Components\RichEditor\Models\Concerns\InteractsWithRichContent;
@@ -58,7 +59,10 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 class EngagementBatch extends BaseModel implements HasMedia, HasRichContent
 {
     use HasManyEngagements;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use InteractsWithRichContent;
 
     /** @use HasFactory<EngagementBatchFactory> */

--- a/app-modules/engagement/src/Models/EngagementFile.php
+++ b/app-modules/engagement/src/Models/EngagementFile.php
@@ -40,6 +40,7 @@ use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Engagement\Database\Factories\EngagementFileFactory;
 use App\Models\BaseModel;
+use App\Models\Media;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Prunable;
@@ -53,7 +54,9 @@ use Spatie\MediaLibrary\InteractsWithMedia;
  */
 class EngagementFile extends BaseModel implements HasMedia, Auditable
 {
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use AuditableTrait;
     use Prunable;
 

--- a/app-modules/engagement/src/Models/EngagementResponse.php
+++ b/app-modules/engagement/src/Models/EngagementResponse.php
@@ -47,6 +47,7 @@ use AidingApp\Timeline\Models\Contracts\ProvidesATimeline;
 use AidingApp\Timeline\Models\Timeline;
 use AidingApp\Timeline\Timelines\EngagementResponseTimeline;
 use App\Models\BaseModel;
+use App\Models\Media;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -70,6 +71,8 @@ class EngagementResponse extends BaseModel implements Auditable, ProvidesATimeli
 {
     use AuditableTrait;
     use SoftDeletes;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
 
     /** @use HasFactory<EngagementResponseFactory> */

--- a/app-modules/engagement/tests/Landlord/Jobs/ProcessSesS3InboundEmailTest.php
+++ b/app-modules/engagement/tests/Landlord/Jobs/ProcessSesS3InboundEmailTest.php
@@ -323,6 +323,72 @@ describe('Engagement response processing', function () {
 
         $filesystem->assertMissing('s3_email');
     });
+
+    it('sets createdBy on media attachments', function () {
+        $fakeStorage = Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+
+        Event::listen(
+            MadeTenantCurrentEvent::class,
+            function (MadeTenantCurrentEvent $event) use ($fakeStorage) {
+                Storage::set('s3', $fakeStorage);
+            }
+        );
+
+        assert($filesystem instanceof FilesystemAdapter);
+
+        $tenant = Tenant::query()->first();
+
+        assert($tenant instanceof Tenant);
+
+        $contact = null;
+
+        $tenant->execute(function () use (&$contact) {
+            $contact = Contact::factory()->create([
+                'email' => 'kevin.ullyott@canyongbs.com',
+            ]);
+        });
+
+        assert($contact instanceof Contact);
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', 'tests/Landlord/Fixtures/s3_email_with_attachments'));
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        $mock->handle();
+
+        $tenant->execute(function () use ($contact) {
+            $engagementResponse = EngagementResponse::first();
+
+            assert($engagementResponse instanceof EngagementResponse);
+
+            $media = $engagementResponse->getMedia('attachments');
+
+            expect($media)->toHaveCount(3);
+
+            foreach ($media as $item) {
+                expect($item->created_by_id)->toBe($contact->getKey())
+                    ->and($item->created_by_type)->toBe($contact->getMorphClass());
+            }
+        });
+
+        $filesystem->assertMissing('s3_email');
+    });
 });
 
 describe('Failed job handling', function () {
@@ -1020,6 +1086,92 @@ describe('Service Request Type Service Request creation from inbound email', fun
 
         $filesystem->assertMissing('s3_email');
     });
+
+    it('sets createdBy on media attachments', function () {
+        $tenant = Tenant::query()->firstOrFail();
+
+        assert($tenant instanceof Tenant);
+
+        [$contact, $serviceRequestType, $assignedPriority] = $tenant->execute(function () {
+            $contact = Contact::factory()->create([
+                'email' => 'kevin.ullyott@canyongbs.com',
+            ]);
+
+            $serviceRequestType = ServiceRequestType::factory()
+                ->has(
+                    TenantServiceRequestTypeDomain::factory()->state([
+                        'domain' => 'help',
+                    ]),
+                    'domain'
+                )
+                ->has(
+                    ServiceRequestPriority::factory()->count(3),
+                    'priorities'
+                )
+                ->create([
+                    'is_email_automatic_creation_enabled' => true,
+                    'is_email_automatic_creation_contact_create_enabled' => false,
+                ]);
+
+            $assignedPriority = $serviceRequestType->priorities->first();
+
+            $serviceRequestType->update([
+                'email_automatic_creation_priority_id' => $assignedPriority->getKey(),
+            ]);
+
+            return [$contact, $serviceRequestType, $assignedPriority];
+        });
+
+        $fakeStorage = Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+
+        Event::listen(
+            MadeTenantCurrentEvent::class,
+            function (MadeTenantCurrentEvent $event) use ($fakeStorage) {
+                Storage::set('s3', $fakeStorage);
+            }
+        );
+
+        assert($filesystem instanceof FilesystemAdapter);
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', 'tests/Landlord/Fixtures/s3_email_for_service_request_with_attachments'));
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        $mock->handle();
+
+        $tenant->makeCurrent();
+
+        $serviceRequest = ServiceRequest::first();
+
+        assert($serviceRequest instanceof ServiceRequest);
+
+        $media = $serviceRequest->getMedia('uploads');
+
+        expect($media)->toHaveCount(2);
+
+        foreach ($media as $item) {
+            expect($item->created_by_id)->toBe($contact->getKey())
+                ->and($item->created_by_type)->toBe($contact->getMorphClass());
+        }
+
+        $filesystem->assertMissing('s3_email');
+    });
 });
 
 describe('Legacy inbound email handling', function () {
@@ -1223,6 +1375,88 @@ describe('Service request reply threading', function () {
             expect($media->first()->extension)->toBe('jpg');
             expect($media->last()->file_name)->toBe('SampleJPGImage_50kbmb.jpg');
             expect($media->last()->extension)->toBe('jpg');
+        });
+
+        $filesystem->assertMissing('s3_email');
+    });
+
+    it('sets createdBy on media attachments for SR reply', function () {
+        $fakeStorage = Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+        $tenant = Tenant::query()->firstOrFail();
+
+        assert($tenant instanceof Tenant);
+
+        Event::listen(
+            MadeTenantCurrentEvent::class,
+            function (MadeTenantCurrentEvent $event) use ($fakeStorage) {
+                Storage::set('s3', $fakeStorage);
+            }
+        );
+        assert($filesystem instanceof FilesystemAdapter);
+
+        [$contact, $serviceRequest] = $tenant->execute(function () {
+            $contact = Contact::factory()->create([
+                'email' => 'kevin.ullyott@canyongbs.com',
+            ]);
+
+            $serviceRequest = ServiceRequest::factory()->create([
+                'respondent_id' => $contact->getKey(),
+            ]);
+
+            $serviceRequest->outboundEmailMessageIds()->create([
+                'message_id' => "{$serviceRequest->service_request_number}.1.1740000000000",
+            ]);
+
+            return [$contact, $serviceRequest];
+        });
+
+        assert($contact instanceof Contact);
+
+        $messageId = "{$serviceRequest->service_request_number}.1.1740000000000@mail.aiding.app";
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', 'tests/Landlord/Fixtures/s3_email_sr_reply_with_attachments'));
+
+        $content = str_replace(
+            'SR-TEST123456.1.1740000000000@mail.aiding.app',
+            $messageId,
+            $content,
+        );
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        $mock->handle();
+
+        $tenant->makeCurrent();
+
+        $tenant->execute(function () use ($contact) {
+            $serviceRequestUpdate = ServiceRequestUpdate::first();
+
+            assert($serviceRequestUpdate instanceof ServiceRequestUpdate);
+
+            $media = $serviceRequestUpdate->getMedia('uploads');
+
+            expect($media)->toHaveCount(2);
+
+            foreach ($media as $item) {
+                expect($item->created_by_id)->toBe($contact->getKey())
+                    ->and($item->created_by_type)->toBe($contact->getMorphClass());
+            }
         });
 
         $filesystem->assertMissing('s3_email');

--- a/app-modules/form/resources/views/blocks/submissions/upload.blade.php
+++ b/app-modules/form/resources/views/blocks/submissions/upload.blade.php
@@ -31,7 +31,7 @@
     
     </COPYRIGHT>
 --}}
-@use('Spatie\MediaLibrary\MediaCollections\Models\Media')
+@use('App\Models\Media')
 
 <x-form::blocks.field-wrapper class="py-3" :$label :$isRequired>
     @php

--- a/app-modules/knowledge-base/src/Models/KnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Models/KnowledgeBaseItem.php
@@ -46,6 +46,7 @@ use AidingApp\Portal\Models\KnowledgeBaseArticleVote;
 use App\Models\BaseModel;
 use App\Models\Concerns\InteractsWithTags;
 use App\Models\Contracts\HasTags;
+use App\Models\Media;
 use App\Models\User;
 use CanyonGBS\Common\Filament\Forms\RichContentPlugins\VideoRichContentPlugin;
 use DateTimeInterface;
@@ -73,7 +74,10 @@ class KnowledgeBaseItem extends BaseModel implements AiFile, Auditable, HasMedia
 {
     use AuditableTrait;
     use HasUuids;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use InteractsWithRichContent;
     use SoftDeletes;
     use InteractsWithTags;

--- a/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
+++ b/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
@@ -38,6 +38,7 @@ namespace AidingApp\Portal\Jobs;
 
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use App\Features\MediaCreatedByFeature;
+use App\Models\Media;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -84,7 +85,7 @@ class PersistServiceRequestUpload implements ShouldQueue
         }
 
         try {
-            /** @var \App\Models\Media $media */
+            /** @var Media $media */
             $media = $this->serviceRequest
                 ->addMediaFromDisk($this->path)
                 ->usingName(pathinfo($this->originalFileName, PATHINFO_FILENAME))

--- a/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
+++ b/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
@@ -37,6 +37,7 @@
 namespace AidingApp\Portal\Jobs;
 
 use AidingApp\ServiceManagement\Models\ServiceRequest;
+use App\Features\MediaCreatedByFeature;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -83,10 +84,17 @@ class PersistServiceRequestUpload implements ShouldQueue
         }
 
         try {
-            $this->serviceRequest
+            $media = $this->serviceRequest
                 ->addMediaFromDisk($this->path)
                 ->usingName(pathinfo($this->originalFileName, PATHINFO_FILENAME))
                 ->toMediaCollection($this->collection);
+
+            $respondent = $this->serviceRequest->respondent;
+            if (MediaCreatedByFeature::active() && is_null($media->created_by_id)) {
+                $media->created_by_id = $respondent->getKey();
+                $media->created_by_type = $respondent->getMorphClass();
+                $media->saveQuietly();
+            }
         } finally {
             Storage::delete($this->path);
         }

--- a/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
+++ b/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
@@ -84,6 +84,7 @@ class PersistServiceRequestUpload implements ShouldQueue
         }
 
         try {
+            /** @var \App\Models\Media $media */
             $media = $this->serviceRequest
                 ->addMediaFromDisk($this->path)
                 ->usingName(pathinfo($this->originalFileName, PATHINFO_FILENAME))

--- a/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
+++ b/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
@@ -90,6 +90,7 @@ class PersistServiceRequestUpload implements ShouldQueue
                 ->toMediaCollection($this->collection);
 
             $respondent = $this->serviceRequest->respondent;
+
             if (MediaCreatedByFeature::active() && is_null($media->created_by_id)) {
                 $media->created_by_id = $respondent->getKey();
                 $media->created_by_type = $respondent->getMorphClass();

--- a/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
+++ b/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
@@ -38,7 +38,6 @@ namespace AidingApp\Portal\Jobs;
 
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use App\Features\MediaCreatedByFeature;
-use App\Models\Media;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -85,7 +84,6 @@ class PersistServiceRequestUpload implements ShouldQueue
         }
 
         try {
-            /** @var Media $media */
             $media = $this->serviceRequest
                 ->addMediaFromDisk($this->path)
                 ->usingName(pathinfo($this->originalFileName, PATHINFO_FILENAME))

--- a/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
+++ b/app-modules/portal/src/Jobs/PersistServiceRequestUpload.php
@@ -92,8 +92,7 @@ class PersistServiceRequestUpload implements ShouldQueue
             $respondent = $this->serviceRequest->respondent;
 
             if (MediaCreatedByFeature::active() && is_null($media->created_by_id)) {
-                $media->created_by_id = $respondent->getKey();
-                $media->created_by_type = $respondent->getMorphClass();
+                $media->createdBy()->associate($respondent);
                 $media->saveQuietly();
             }
         } finally {

--- a/app-modules/project/src/Models/ProjectFile.php
+++ b/app-modules/project/src/Models/ProjectFile.php
@@ -38,6 +38,7 @@ namespace AidingApp\Project\Models;
 
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\Project\Database\Factories\ProjectFileFactory;
+use App\Models\Media;
 use CanyonGBS\Common\Models\Concerns\HasUserSaveTracking;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
@@ -59,7 +60,10 @@ class ProjectFile extends Model implements HasMedia, Auditable
 
     use HasUuids;
     use HasUserSaveTracking;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use AuditableTrait;
     use Prunable;
 

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdates/Pages/ViewServiceRequestUpdate.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdates/Pages/ViewServiceRequestUpdate.php
@@ -40,21 +40,19 @@ use AidingApp\Contact\Filament\Resources\ContactResource;
 use AidingApp\Contact\Models\Contact;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\ServiceRequestResource;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdates\ServiceRequestUpdateResource;
+use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use App\Filament\Resources\Users\UserResource;
 use App\Models\User;
 use Exception;
-use Filament\Actions\Action;
 use Filament\Actions\EditAction;
 use Filament\Infolists\Components\IconEntry;
-use Filament\Infolists\Components\ImageEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Pages\ViewRecord;
+use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
-use Filament\Support\Enums\IconSize;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class ViewServiceRequestUpdate extends ViewRecord
 {
@@ -109,53 +107,13 @@ class ViewServiceRequestUpdate extends ViewRecord
                             ->columnSpanFull(),
                     ])
                     ->columns(),
-                Section::make('Uploads')
-                    ->visible(fn (ServiceRequestUpdate $record): bool => $record->hasMedia((new ServiceRequestUpdate())->getMediaCollection('uploads')->name))
-                    ->schema(
-                        fn (ServiceRequestUpdate $record) => $record
-                            ->getMedia((new ServiceRequestUpdate())->getMediaCollection('uploads')->name)
-                            ->map(function (Media $media) {
-                                $mimeType = $media->mime_type;
-                                $isImage = in_array($mimeType, ['image/jpeg', 'image/png']);
-
-                                $downloadAction = Action::make('download')
-                                    ->label('Download')
-                                    ->icon('heroicon-m-arrow-down-tray')
-                                    ->color('primary')
-                                    ->url(route('service-request.media.download', ['media' => $media->getKey()]));
-
-                                $displayName = $media->name . '.' . pathinfo($media->file_name, PATHINFO_EXTENSION);
-
-                                if ($isImage) {
-                                    return ImageEntry::make($media->getKey())
-                                        ->label($displayName)
-                                        ->visibility('private')
-                                        ->getStateUsing($media->getTemporaryUrl(now()->addMinute()))
-                                        ->hintAction($downloadAction);
-                                }
-
-                                return IconEntry::make($media->getKey())
-                                    ->label($displayName)
-                                    ->state($mimeType)
-                                    ->icon(match ($mimeType) {
-                                        'application/pdf',
-                                        'application/vnd.ms-word',
-                                        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                                        'image/pdf',
-                                        'text/markdown',
-                                        'text/plain' => 'heroicon-o-document-text',
-                                        'application/vnd.ms-excel',
-                                        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                                        'text/csv' => 'heroicon-o-table-cells',
-                                        'application/vnd.ms-powerpoint',
-                                        'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'heroicon-o-presentation-chart-bar',
-                                        default => 'heroicon-o-paper-clip',
-                                    })
-                                    ->size(IconSize::TwoExtraLarge)
-                                    ->hintAction($downloadAction);
-                            })
-                            ->toArray()
-                    ),
+                Section::make('Uploaded Files')
+                    ->schema([
+                        Livewire::make(ServiceRequestMediaTable::class, [
+                            'record' => $this->getRecord(),
+                            'collectionName' => (new ServiceRequestUpdate())->getMediaCollection('uploads')->name,
+                        ]),
+                    ]),
             ]);
     }
 

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/EditServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/EditServiceRequest.php
@@ -42,6 +42,7 @@ use AidingApp\ServiceManagement\Actions\ResolveUploadsMediaCollectionForServiceR
 use AidingApp\ServiceManagement\Enums\ServiceRequestCategory;
 use AidingApp\ServiceManagement\Filament\Actions\ReclassifyServiceRequestAction;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\ServiceRequestResource;
+use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
@@ -56,6 +57,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\ToggleButtons;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
@@ -159,6 +161,13 @@ class EditServiceRequest extends EditRecord
                             ->when($uploadsMediaCollection->getMaxFileSizeInMB(), fn (SpatieMediaLibraryFileUpload $component) => $component->maxSize($uploadsMediaCollection->getMaxFileSizeInMB() * 1000))
                             ->acceptedFileTypes($uploadsMediaCollection->getMimes())
                             ->downloadable(),
+                    ]),
+                Section::make('Uploaded Files')
+                    ->schema([
+                        Livewire::make(ServiceRequestMediaTable::class, [
+                            'record' => $this->getRecord(),
+                            'collectionName' => $uploadsMediaCollection->getName(),
+                        ]),
                     ]),
             ]);
     }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ViewServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ViewServiceRequest.php
@@ -44,23 +44,20 @@ use AidingApp\ServiceManagement\Enums\SlaComplianceStatus;
 use AidingApp\ServiceManagement\Filament\Actions\ReclassifyServiceRequestAction;
 use AidingApp\ServiceManagement\Filament\Concerns\ServiceRequestLocked;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\ServiceRequestResource;
+use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
-use Filament\Actions\Action;
 use Filament\Actions\EditAction;
-use Filament\Infolists\Components\IconEntry;
-use Filament\Infolists\Components\ImageEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Components\ViewEntry;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Group;
+use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
-use Filament\Support\Enums\IconSize;
 use Illuminate\Support\HtmlString;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class ViewServiceRequest extends ViewRecord
 {
@@ -139,53 +136,13 @@ class ViewServiceRequest extends ViewRecord
                         TextEntry::make('close_details')
                             ->hiddenLabel(),
                     ]),
-                Section::make('Uploads')
-                    ->visible(fn (ServiceRequest $record): bool => $record->hasMedia($uploadsMediaCollection->getName()))
-                    ->schema(
-                        fn (ServiceRequest $record) => $record
-                            ->getMedia($uploadsMediaCollection->getName())
-                            ->map(function (Media $media) {
-                                $mimeType = $media->mime_type;
-                                $isImage = in_array($mimeType, ['image/jpeg', 'image/png']);
-
-                                $downloadAction = Action::make('download')
-                                    ->label('Download')
-                                    ->icon('heroicon-m-arrow-down-tray')
-                                    ->color('primary')
-                                    ->url(route('service-request.media.download', ['media' => $media->getKey()]));
-
-                                $displayName = $media->name . '.' . pathinfo($media->file_name, PATHINFO_EXTENSION);
-
-                                if ($isImage) {
-                                    return ImageEntry::make($media->getKey())
-                                        ->label($displayName)
-                                        ->visibility('private')
-                                        ->getStateUsing($media->getTemporaryUrl(now()->addMinute()))
-                                        ->hintAction($downloadAction);
-                                }
-
-                                return IconEntry::make($media->getKey())
-                                    ->label($displayName)
-                                    ->state($mimeType)
-                                    ->icon(match ($mimeType) {
-                                        'application/pdf',
-                                        'application/vnd.ms-word',
-                                        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                                        'image/pdf',
-                                        'text/markdown',
-                                        'text/plain' => 'heroicon-o-document-text',
-                                        'application/vnd.ms-excel',
-                                        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                                        'text/csv' => 'heroicon-o-table-cells',
-                                        'application/vnd.ms-powerpoint',
-                                        'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'heroicon-o-presentation-chart-bar',
-                                        default => 'heroicon-o-paper-clip',
-                                    })
-                                    ->size(IconSize::TwoExtraLarge)
-                                    ->hintAction($downloadAction);
-                            })
-                            ->toArray()
-                    ),
+                Section::make('Uploaded Files')
+                    ->schema([
+                        Livewire::make(ServiceRequestMediaTable::class, [
+                            'record' => $this->getRecord(),
+                            'collectionName' => $uploadsMediaCollection->getName(),
+                        ]),
+                    ]),
                 Section::make('Form Details')
                     ->collapsed()
                     ->visible(fn (ServiceRequest $record): bool => ! is_null($record->serviceRequestFormSubmission))

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ViewServiceRequest.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ViewServiceRequest.php
@@ -137,9 +137,9 @@ class ViewServiceRequest extends ViewRecord
                             ->hiddenLabel(),
                     ]),
                 Section::make('Uploaded Files')
-                    ->schema([
+                    ->schema(fn (ServiceRequest $record): array => [
                         Livewire::make(ServiceRequestMediaTable::class, [
-                            'record' => $this->getRecord(),
+                            'record' => $record,
                             'collectionName' => $uploadsMediaCollection->getName(),
                         ]),
                     ]),

--- a/app-modules/service-management/src/Filament/Widgets/ServiceRequestMediaTable.php
+++ b/app-modules/service-management/src/Filament/Widgets/ServiceRequestMediaTable.php
@@ -36,7 +36,9 @@
 
 namespace AidingApp\ServiceManagement\Filament\Widgets;
 
+use AidingApp\Contact\Models\Contact;
 use App\Models\Media;
+use App\Models\User;
 use App\Settings\DisplaySettings;
 use Filament\Actions\Action;
 use Filament\Tables\Columns\TextColumn;
@@ -80,7 +82,9 @@ class ServiceRequestMediaTable extends TableWidget
                 TextColumn::make('display_name')
                     ->label('File Name')
                     ->getStateUsing(fn (Media $record): string => $record->name . '.' . pathinfo($record->file_name, PATHINFO_EXTENSION))
-                    ->searchable('name')
+                    ->searchable(
+                        query: fn (Builder $query, string $search) => $query->whereRaw('LOWER(name) LIKE ?', ['%' . strtolower($search) . '%'])
+                    )
                     ->wrap(),
 
                 TextColumn::make('created_by_name')
@@ -90,8 +94,20 @@ class ServiceRequestMediaTable extends TableWidget
                     ->searchable(
                         query: fn (Builder $query, string $search) => $query->whereHasMorph(
                             'createdBy',
-                            '*',
-                            fn ($subQuery) => $subQuery->whereRaw('LOWER(name) LIKE ?', ['%' . strtolower($search) . '%'])
+                            [User::class, Contact::class],
+                            function (Builder $subQuery, string $type) use ($search): void {
+                                $searchLower = strtolower($search);
+
+                                if ($type === User::class) {
+                                    $subQuery->whereRaw('LOWER(name) LIKE ?', ['%' . $searchLower . '%']);
+                                } elseif ($type === Contact::class) {
+                                    $subQuery->where(function (Builder $q) use ($searchLower): void {
+                                        $q->whereRaw('LOWER(first_name) LIKE ?', ['%' . $searchLower . '%'])
+                                            ->orWhereRaw('LOWER(last_name) LIKE ?', ['%' . $searchLower . '%'])
+                                            ->orWhereRaw('LOWER(full_name) LIKE ?', ['%' . $searchLower . '%']);
+                                    });
+                                }
+                            }
                         )
                     ),
 

--- a/app-modules/service-management/src/Filament/Widgets/ServiceRequestMediaTable.php
+++ b/app-modules/service-management/src/Filament/Widgets/ServiceRequestMediaTable.php
@@ -101,8 +101,8 @@ class ServiceRequestMediaTable extends TableWidget
                                 if ($type === User::class) {
                                     $subQuery->whereRaw('LOWER(name) LIKE ?', ['%' . $searchLower . '%']);
                                 } elseif ($type === Contact::class) {
-                                    $subQuery->where(function (Builder $q) use ($searchLower): void {
-                                        $q->whereRaw('LOWER(first_name) LIKE ?', ['%' . $searchLower . '%'])
+                                    $subQuery->where(function (Builder $query) use ($searchLower): void {
+                                        $query->whereRaw('LOWER(first_name) LIKE ?', ['%' . $searchLower . '%'])
                                             ->orWhereRaw('LOWER(last_name) LIKE ?', ['%' . $searchLower . '%'])
                                             ->orWhereRaw('LOWER(full_name) LIKE ?', ['%' . $searchLower . '%']);
                                     });

--- a/app-modules/service-management/src/Filament/Widgets/ServiceRequestMediaTable.php
+++ b/app-modules/service-management/src/Filament/Widgets/ServiceRequestMediaTable.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -117,4 +117,3 @@ class ServiceRequestMediaTable extends TableWidget
             ->defaultSort('created_at', 'desc');
     }
 }
-

--- a/app-modules/service-management/src/Filament/Widgets/ServiceRequestMediaTable.php
+++ b/app-modules/service-management/src/Filament/Widgets/ServiceRequestMediaTable.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AidingApp\ServiceManagement\Filament\Widgets;
+
+use App\Models\Media;
+use App\Settings\DisplaySettings;
+use Filament\Actions\Action;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class ServiceRequestMediaTable extends TableWidget
+{
+    public Model $record;
+
+    public string $collectionName = 'uploads';
+
+    protected static ?string $heading = 'Uploads';
+
+    protected int|string|array $columnSpan = 'full';
+
+    public function mount(Model $record, string $collectionName = 'uploads'): void
+    {
+        $this->record = $record;
+        $this->collectionName = $collectionName;
+    }
+
+    public function table(Table $table): Table
+    {
+        $timezone = app(DisplaySettings::class)->getTimezone();
+        $modelType = $this->record->getMorphClass();
+        $modelId = $this->record->getKey();
+        $collectionName = $this->collectionName;
+
+        return $table
+            ->query(
+                Media::query()
+                    ->where('model_type', $modelType)
+                    ->where('model_id', $modelId)
+                    ->where('collection_name', $collectionName)
+                    ->with('createdBy')
+            )
+            ->columns([
+                TextColumn::make('display_name')
+                    ->label('File Name')
+                    ->getStateUsing(fn (Media $record): string => $record->name . '.' . pathinfo($record->file_name, PATHINFO_EXTENSION))
+                    ->searchable('name')
+                    ->wrap(),
+
+                TextColumn::make('created_by_name')
+                    ->label('Uploaded By')
+                    ->getStateUsing(fn (Media $record): string => $record->created_by_name)
+                    ->description(fn (Media $record): ?string => $record->created_by_sub_label)
+                    ->searchable(
+                        query: fn (Builder $query, string $search) => $query->whereHasMorph(
+                            'createdBy',
+                            '*',
+                            fn ($subQuery) => $subQuery->whereRaw('LOWER(name) LIKE ?', ['%' . strtolower($search) . '%'])
+                        )
+                    ),
+
+                TextColumn::make('created_at')
+                    ->label('Date')
+                    ->dateTime('M j, Y')
+                    ->description(fn (Media $record): string => $record->created_at !== null
+                        ? $record->created_at
+                            ->copy()
+                            ->setTimezone($timezone)
+                            ->format('g:i A (T)')
+                        : '')
+                    ->sortable(),
+            ])
+            ->recordActions([
+                Action::make('download')
+                    ->label('Download')
+                    ->icon('heroicon-m-arrow-down-tray')
+                    ->color('primary')
+                    ->url(fn (Media $record): string => route('service-request.media.download', ['media' => $record->getKey()])),
+            ])
+            ->emptyStateHeading('No uploads')
+            ->defaultSort('created_at', 'desc');
+    }
+}
+

--- a/app-modules/service-management/src/Http/Controllers/ServiceRequestMediaDownloadController.php
+++ b/app-modules/service-management/src/Http/Controllers/ServiceRequestMediaDownloadController.php
@@ -38,8 +38,8 @@ namespace AidingApp\ServiceManagement\Http\Controllers;
 
 use AidingApp\ServiceManagement\Http\Requests\ServiceRequestMediaDownloadRequest;
 use App\Http\Controllers\Controller;
+use App\Models\Media;
 use Illuminate\Http\RedirectResponse;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class ServiceRequestMediaDownloadController extends Controller
 {

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -51,6 +51,7 @@ use AidingApp\ServiceManagement\Models\MediaCollections\UploadsMediaCollection;
 use AidingApp\ServiceManagement\Observers\ServiceRequestObserver;
 use AidingApp\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceRequestNumberGenerator;
 use App\Models\BaseModel;
+use App\Models\Media;
 use App\Models\User;
 use Carbon\CarbonInterface;
 use Closure;
@@ -82,6 +83,8 @@ class ServiceRequest extends BaseModel implements Auditable, HasMedia
     use SoftDeletes;
     use AuditableTrait;
     use HasRelationships;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
 
     /** @use HasFactory<ServiceRequestFactory> */

--- a/app-modules/service-management/src/Models/ServiceRequestTypeEmailTemplate.php
+++ b/app-modules/service-management/src/Models/ServiceRequestTypeEmailTemplate.php
@@ -42,6 +42,7 @@ use AidingApp\ServiceManagement\Enums\ServiceRequestEmailTemplateType;
 use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
 use AidingApp\ServiceManagement\Filament\Blocks\ServiceRequestTypeEmailTemplateButtonBlock;
 use AidingApp\ServiceManagement\Filament\Blocks\SurveyResponseEmailTemplateTakeSurveyButtonBlock;
+use App\Models\Media;
 use Filament\Forms\Components\RichEditor\FileAttachmentProviders\SpatieMediaLibraryFileAttachmentProvider;
 use Filament\Forms\Components\RichEditor\Models\Concerns\InteractsWithRichContent;
 use Filament\Forms\Components\RichEditor\Models\Contracts\HasRichContent;
@@ -65,7 +66,10 @@ class ServiceRequestTypeEmailTemplate extends Model implements Auditable, HasMed
 
     use HasUuids;
     use AuditableTrait;
+
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use InteractsWithRichContent;
 
     protected $fillable = [

--- a/app-modules/service-management/src/Models/ServiceRequestUpdate.php
+++ b/app-modules/service-management/src/Models/ServiceRequestUpdate.php
@@ -66,6 +66,8 @@ class ServiceRequestUpdate extends BaseModel implements Auditable, ProvidesATime
     use SoftDeletes;
     use HasUuids;
     use AuditableTrait;
+
+    /** @use InteractsWithMedia<\App\Models\Media> */
     use InteractsWithMedia;
 
     /** @use HasFactory<ServiceRequestUpdateFactory> */

--- a/app-modules/service-management/src/Models/ServiceRequestUpdate.php
+++ b/app-modules/service-management/src/Models/ServiceRequestUpdate.php
@@ -43,6 +43,7 @@ use AidingApp\ServiceManagement\Observers\ServiceRequestUpdateObserver;
 use AidingApp\Timeline\Models\Contracts\ProvidesATimeline;
 use AidingApp\Timeline\Timelines\ServiceRequestUpdateTimeline;
 use App\Models\BaseModel;
+use App\Models\Media;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
@@ -55,7 +56,6 @@ use Illuminate\Support\Collection;
 use OwenIt\Auditing\Contracts\Auditable;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 /**
  * @mixin IdeHelperServiceRequestUpdate
@@ -67,7 +67,7 @@ class ServiceRequestUpdate extends BaseModel implements Auditable, ProvidesATime
     use HasUuids;
     use AuditableTrait;
 
-    /** @use InteractsWithMedia<\App\Models\Media> */
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
 
     /** @use HasFactory<ServiceRequestUpdateFactory> */

--- a/app-modules/service-management/src/ServiceManagementPlugin.php
+++ b/app-modules/service-management/src/ServiceManagementPlugin.php
@@ -50,9 +50,9 @@ class ServiceManagementPlugin implements Plugin
     public function register(Panel $panel): void
     {
         $panel->discoverResources(
-                in: __DIR__ . '/Filament/Resources',
-                for: 'AidingApp\\ServiceManagement\\Filament\\Resources'
-            )
+            in: __DIR__ . '/Filament/Resources',
+            for: 'AidingApp\\ServiceManagement\\Filament\\Resources'
+        )
             ->livewireComponents([
                 ServiceRequestMediaTable::class,
             ]);

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequestUpdates/Pages/ViewServiceRequestUpdateTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequestUpdates/Pages/ViewServiceRequestUpdateTest.php
@@ -40,6 +40,7 @@ use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+
 use function Pest\Laravel\actingAs;
 use function Tests\asSuperAdmin;
 

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequestUpdates/Pages/ViewServiceRequestUpdateTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequestUpdates/Pages/ViewServiceRequestUpdateTest.php
@@ -40,11 +40,7 @@ use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use App\Models\User;
 use App\Settings\LicenseSettings;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
-
 use function Pest\Laravel\actingAs;
-use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
 test('The correct details are displayed on the ViewServiceRequestUpdate page', function () {
@@ -145,13 +141,7 @@ test('ViewServiceRequestUpdate is gated with proper feature access control', fun
 });
 
 test('ViewServiceRequestUpdate page displays the uploaded files section', function () {
-    Storage::fake('s3');
-
     $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('attachment.png'))
-        ->usingName('attachment')
-        ->toMediaCollection('uploads');
 
     asSuperAdmin()
         ->get(
@@ -161,103 +151,5 @@ test('ViewServiceRequestUpdate page displays the uploaded files section', functi
             ])
         )
         ->assertSuccessful()
-        ->assertSeeText('Uploaded Files')
-        ->assertSeeText('File Name')
-        ->assertSeeText('Uploaded By')
-        ->assertSeeText('Date');
-});
-
-test('ServiceRequestMediaTable renders uploaded files on service request update page', function () {
-    Storage::fake('s3');
-
-    asSuperAdmin();
-
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('attachment.png'))
-        ->usingName('attachment')
-        ->toMediaCollection('uploads');
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequestUpdate,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertCanSeeTableRecords($serviceRequestUpdate->getMedia('uploads'));
-});
-
-test('ServiceRequestMediaTable can search by file name on service request update page', function () {
-    Storage::fake('s3');
-
-    asSuperAdmin();
-
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('meeting-notes.png'))
-        ->usingName('meeting-notes')
-        ->toMediaCollection('uploads');
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('screenshot.png'))
-        ->usingName('screenshot')
-        ->toMediaCollection('uploads');
-
-    $allMedia = $serviceRequestUpdate->getMedia('uploads');
-    $meetingNotes = $allMedia->first(fn ($m) => $m->name === 'meeting-notes');
-    $screenshot = $allMedia->first(fn ($m) => $m->name === 'screenshot');
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequestUpdate,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('meeting')
-        ->assertCanSeeTableRecords([$meetingNotes])
-        ->assertCanNotSeeTableRecords([$screenshot]);
-});
-
-test('ServiceRequestMediaTable can search by uploader name on service request update page', function () {
-    Storage::fake('s3');
-
-    $userAlice = User::factory()->create(['name' => 'Alice Smith']);
-    $userBob = User::factory()->create(['name' => 'Bob Jones']);
-
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-
-    actingAs($userAlice);
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
-        ->usingName('alice-file')
-        ->toMediaCollection('uploads');
-
-    actingAs($userBob);
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
-        ->usingName('bob-file')
-        ->toMediaCollection('uploads');
-
-    $allMedia = $serviceRequestUpdate->getMedia('uploads');
-    $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
-    $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
-
-    asSuperAdmin();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequestUpdate,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('Alice')
-        ->assertCanSeeTableRecords([$aliceMedia])
-        ->assertCanNotSeeTableRecords([$bobMedia]);
-});
-
-test('ServiceRequestMediaTable shows empty state on service request update page when no uploads exist', function () {
-    asSuperAdmin();
-
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequestUpdate,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertSeeText('No uploads');
+        ->assertSeeLivewire(ServiceRequestMediaTable::class);
 });

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequestUpdates/Pages/ViewServiceRequestUpdateTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequestUpdates/Pages/ViewServiceRequestUpdateTest.php
@@ -41,6 +41,7 @@ use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use App\Models\User;
 use App\Settings\LicenseSettings;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -144,6 +145,8 @@ test('ViewServiceRequestUpdate is gated with proper feature access control', fun
 });
 
 test('ViewServiceRequestUpdate page displays the uploaded files section', function () {
+    Storage::fake('s3');
+
     $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
     $serviceRequestUpdate
         ->addMedia(UploadedFile::fake()->image('attachment.png'))
@@ -165,6 +168,8 @@ test('ViewServiceRequestUpdate page displays the uploaded files section', functi
 });
 
 test('ServiceRequestMediaTable renders uploaded files on service request update page', function () {
+    Storage::fake('s3');
+
     asSuperAdmin();
 
     $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
@@ -182,6 +187,8 @@ test('ServiceRequestMediaTable renders uploaded files on service request update 
 });
 
 test('ServiceRequestMediaTable can search by file name on service request update page', function () {
+    Storage::fake('s3');
+
     asSuperAdmin();
 
     $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
@@ -208,6 +215,8 @@ test('ServiceRequestMediaTable can search by file name on service request update
 });
 
 test('ServiceRequestMediaTable can search by uploader name on service request update page', function () {
+    Storage::fake('s3');
+
     $userAlice = User::factory()->create(['name' => 'Alice Smith']);
     $userBob = User::factory()->create(['name' => 'Bob Jones']);
 

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequestUpdates/Pages/ViewServiceRequestUpdateTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequestUpdates/Pages/ViewServiceRequestUpdateTest.php
@@ -36,11 +36,14 @@
 
 use AidingApp\Department\Models\Department;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequestUpdates\ServiceRequestUpdateResource;
+use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Illuminate\Http\UploadedFile;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
 test('The correct details are displayed on the ViewServiceRequestUpdate page', function () {
@@ -138,4 +141,114 @@ test('ViewServiceRequestUpdate is gated with proper feature access control', fun
                 'service_request' => $serviceRequestUpdate->service_request_id,
             ])
         )->assertSuccessful();
+});
+
+test('ViewServiceRequestUpdate page displays the uploaded files section', function () {
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('attachment.png'))
+        ->usingName('attachment')
+        ->toMediaCollection('uploads');
+
+    asSuperAdmin()
+        ->get(
+            ServiceRequestUpdateResource::getUrl('view', [
+                'record' => $serviceRequestUpdate,
+                'service_request' => $serviceRequestUpdate->service_request_id,
+            ])
+        )
+        ->assertSuccessful()
+        ->assertSeeText('Uploaded Files')
+        ->assertSeeText('File Name')
+        ->assertSeeText('Uploaded By')
+        ->assertSeeText('Date');
+});
+
+test('ServiceRequestMediaTable renders uploaded files on service request update page', function () {
+    asSuperAdmin();
+
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('attachment.png'))
+        ->usingName('attachment')
+        ->toMediaCollection('uploads');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequestUpdate,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertCanSeeTableRecords($serviceRequestUpdate->getMedia('uploads'));
+});
+
+test('ServiceRequestMediaTable can search by file name on service request update page', function () {
+    asSuperAdmin();
+
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('meeting-notes.png'))
+        ->usingName('meeting-notes')
+        ->toMediaCollection('uploads');
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('screenshot.png'))
+        ->usingName('screenshot')
+        ->toMediaCollection('uploads');
+
+    $allMedia = $serviceRequestUpdate->getMedia('uploads');
+    $meetingNotes = $allMedia->first(fn ($m) => $m->name === 'meeting-notes');
+    $screenshot = $allMedia->first(fn ($m) => $m->name === 'screenshot');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequestUpdate,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('meeting')
+        ->assertCanSeeTableRecords([$meetingNotes])
+        ->assertCanNotSeeTableRecords([$screenshot]);
+});
+
+test('ServiceRequestMediaTable can search by uploader name on service request update page', function () {
+    $userAlice = User::factory()->create(['name' => 'Alice Smith']);
+    $userBob = User::factory()->create(['name' => 'Bob Jones']);
+
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+
+    actingAs($userAlice);
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+        ->usingName('alice-file')
+        ->toMediaCollection('uploads');
+
+    actingAs($userBob);
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+        ->usingName('bob-file')
+        ->toMediaCollection('uploads');
+
+    $allMedia = $serviceRequestUpdate->getMedia('uploads');
+    $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
+    $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
+
+    asSuperAdmin();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequestUpdate,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('Alice')
+        ->assertCanSeeTableRecords([$aliceMedia])
+        ->assertCanNotSeeTableRecords([$bobMedia]);
+});
+
+test('ServiceRequestMediaTable shows empty state on service request update page when no uploads exist', function () {
+    asSuperAdmin();
+
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequestUpdate,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertSeeText('No uploads');
 });

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/EditServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/EditServiceRequestTest.php
@@ -49,9 +49,7 @@ use AidingApp\ServiceManagement\Notifications\SendClosedServiceFeedbackNotificat
 use AidingApp\ServiceManagement\Tests\Tenant\RequestFactories\EditServiceRequestRequestFactory;
 use App\Models\User;
 use App\Settings\LicenseSettings;
-use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Notification;
-use Illuminate\Support\Facades\Storage;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
@@ -774,101 +772,10 @@ test('service requests not authorized if user is a direct auditorUser of the ser
 });
 
 test('EditServiceRequest page displays the uploaded files section', function () {
-    Storage::fake('s3');
-
     $serviceRequest = ServiceRequest::factory()->create();
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('doc.png'))
-        ->usingName('doc')
-        ->toMediaCollection('uploads');
 
     asSuperAdmin()
         ->get(ServiceRequestResource::getUrl('edit', ['record' => $serviceRequest]))
         ->assertSuccessful()
-        ->assertSeeText('Uploaded Files')
-        ->assertSeeText('File Name')
-        ->assertSeeText('Uploaded By')
-        ->assertSeeText('Date');
-});
-
-test('ServiceRequestMediaTable renders uploaded files on edit page', function () {
-    Storage::fake('s3');
-
-    asSuperAdmin();
-
-    $serviceRequest = ServiceRequest::factory()->create();
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('report.png'))
-        ->usingName('report')
-        ->toMediaCollection('uploads');
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertCanSeeTableRecords($serviceRequest->getMedia('uploads'));
-});
-
-test('ServiceRequestMediaTable can search by file name on edit page', function () {
-    Storage::fake('s3');
-
-    asSuperAdmin();
-
-    $serviceRequest = ServiceRequest::factory()->create();
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('annual-report.png'))
-        ->usingName('annual-report')
-        ->toMediaCollection('uploads');
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('invoice.png'))
-        ->usingName('invoice')
-        ->toMediaCollection('uploads');
-
-    $allMedia = $serviceRequest->getMedia('uploads');
-    $annualReport = $allMedia->first(fn ($m) => $m->name === 'annual-report');
-    $invoice = $allMedia->first(fn ($m) => $m->name === 'invoice');
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('annual')
-        ->assertCanSeeTableRecords([$annualReport])
-        ->assertCanNotSeeTableRecords([$invoice]);
-});
-
-test('ServiceRequestMediaTable can search by uploader name on edit page', function () {
-    Storage::fake('s3');
-
-    $userAlice = User::factory()->create(['name' => 'Alice Smith']);
-    $userBob = User::factory()->create(['name' => 'Bob Jones']);
-
-    $serviceRequest = ServiceRequest::factory()->create();
-
-    actingAs($userAlice);
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
-        ->usingName('alice-file')
-        ->toMediaCollection('uploads');
-
-    actingAs($userBob);
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
-        ->usingName('bob-file')
-        ->toMediaCollection('uploads');
-
-    $allMedia = $serviceRequest->getMedia('uploads');
-    $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
-    $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
-
-    asSuperAdmin();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('Alice')
-        ->assertCanSeeTableRecords([$aliceMedia])
-        ->assertCanNotSeeTableRecords([$bobMedia]);
+        ->assertSeeLivewire(ServiceRequestMediaTable::class);
 });

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/EditServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/EditServiceRequestTest.php
@@ -51,6 +51,7 @@ use App\Models\User;
 use App\Settings\LicenseSettings;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
@@ -773,6 +774,8 @@ test('service requests not authorized if user is a direct auditorUser of the ser
 });
 
 test('EditServiceRequest page displays the uploaded files section', function () {
+    Storage::fake('s3');
+
     $serviceRequest = ServiceRequest::factory()->create();
     $serviceRequest
         ->addMedia(UploadedFile::fake()->image('doc.png'))
@@ -789,6 +792,8 @@ test('EditServiceRequest page displays the uploaded files section', function () 
 });
 
 test('ServiceRequestMediaTable renders uploaded files on edit page', function () {
+    Storage::fake('s3');
+
     asSuperAdmin();
 
     $serviceRequest = ServiceRequest::factory()->create();
@@ -806,6 +811,8 @@ test('ServiceRequestMediaTable renders uploaded files on edit page', function ()
 });
 
 test('ServiceRequestMediaTable can search by file name on edit page', function () {
+    Storage::fake('s3');
+
     asSuperAdmin();
 
     $serviceRequest = ServiceRequest::factory()->create();
@@ -832,6 +839,8 @@ test('ServiceRequestMediaTable can search by file name on edit page', function (
 });
 
 test('ServiceRequestMediaTable can search by uploader name on edit page', function () {
+    Storage::fake('s3');
+
     $userAlice = User::factory()->create(['name' => 'Alice Smith']);
     $userBob = User::factory()->create(['name' => 'Bob Jones']);
 

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/EditServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/EditServiceRequestTest.php
@@ -40,6 +40,7 @@ use AidingApp\Division\Models\Division;
 use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\Pages\EditServiceRequest;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\ServiceRequestResource;
+use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
@@ -48,6 +49,7 @@ use AidingApp\ServiceManagement\Notifications\SendClosedServiceFeedbackNotificat
 use AidingApp\ServiceManagement\Tests\Tenant\RequestFactories\EditServiceRequestRequestFactory;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Notification;
 
 use function Pest\Laravel\actingAs;
@@ -768,4 +770,96 @@ test('service requests not authorized if user is a direct auditorUser of the ser
     livewire(EditServiceRequest::class, [
         'record' => $serviceRequest->getRouteKey(),
     ])->assertForbidden();
+});
+
+test('EditServiceRequest page displays the uploaded files section', function () {
+    $serviceRequest = ServiceRequest::factory()->create();
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('doc.png'))
+        ->usingName('doc')
+        ->toMediaCollection('uploads');
+
+    asSuperAdmin()
+        ->get(ServiceRequestResource::getUrl('edit', ['record' => $serviceRequest]))
+        ->assertSuccessful()
+        ->assertSeeText('Uploaded Files')
+        ->assertSeeText('File Name')
+        ->assertSeeText('Uploaded By')
+        ->assertSeeText('Date');
+});
+
+test('ServiceRequestMediaTable renders uploaded files on edit page', function () {
+    asSuperAdmin();
+
+    $serviceRequest = ServiceRequest::factory()->create();
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('report.png'))
+        ->usingName('report')
+        ->toMediaCollection('uploads');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertCanSeeTableRecords($serviceRequest->getMedia('uploads'));
+});
+
+test('ServiceRequestMediaTable can search by file name on edit page', function () {
+    asSuperAdmin();
+
+    $serviceRequest = ServiceRequest::factory()->create();
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('annual-report.png'))
+        ->usingName('annual-report')
+        ->toMediaCollection('uploads');
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('invoice.png'))
+        ->usingName('invoice')
+        ->toMediaCollection('uploads');
+
+    $allMedia = $serviceRequest->getMedia('uploads');
+    $annualReport = $allMedia->first(fn ($m) => $m->name === 'annual-report');
+    $invoice = $allMedia->first(fn ($m) => $m->name === 'invoice');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('annual')
+        ->assertCanSeeTableRecords([$annualReport])
+        ->assertCanNotSeeTableRecords([$invoice]);
+});
+
+test('ServiceRequestMediaTable can search by uploader name on edit page', function () {
+    $userAlice = User::factory()->create(['name' => 'Alice Smith']);
+    $userBob = User::factory()->create(['name' => 'Bob Jones']);
+
+    $serviceRequest = ServiceRequest::factory()->create();
+
+    actingAs($userAlice);
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+        ->usingName('alice-file')
+        ->toMediaCollection('uploads');
+
+    actingAs($userBob);
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+        ->usingName('bob-file')
+        ->toMediaCollection('uploads');
+
+    $allMedia = $serviceRequest->getMedia('uploads');
+    $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
+    $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
+
+    asSuperAdmin();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('Alice')
+        ->assertCanSeeTableRecords([$aliceMedia])
+        ->assertCanNotSeeTableRecords([$bobMedia]);
 });

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/ViewServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/ViewServiceRequestTest.php
@@ -50,6 +50,7 @@ use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use App\Models\User;
 use App\Settings\LicenseSettings;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -313,6 +314,8 @@ test('view service request page visible if the user is a direct managerUser of t
 });
 
 test('ViewServiceRequest page displays the uploaded files section', function () {
+    Storage::fake('s3');
+
     $serviceRequest = ServiceRequest::factory()->create();
     $serviceRequest
         ->addMedia(UploadedFile::fake()->image('doc.png'))
@@ -329,6 +332,8 @@ test('ViewServiceRequest page displays the uploaded files section', function () 
 });
 
 test('ServiceRequestMediaTable renders uploaded files on view page', function () {
+    Storage::fake('s3');
+
     asSuperAdmin();
 
     $serviceRequest = ServiceRequest::factory()->create();
@@ -346,6 +351,8 @@ test('ServiceRequestMediaTable renders uploaded files on view page', function ()
 });
 
 test('ServiceRequestMediaTable shows uploader name on view page', function () {
+    Storage::fake('s3');
+
     $user = User::factory()->create(['name' => 'Jane Doe']);
     actingAs($user);
 
@@ -364,6 +371,8 @@ test('ServiceRequestMediaTable shows uploader name on view page', function () {
 });
 
 test('ServiceRequestMediaTable can search by file name on view page', function () {
+    Storage::fake('s3');
+
     asSuperAdmin();
 
     $serviceRequest = ServiceRequest::factory()->create();
@@ -390,6 +399,8 @@ test('ServiceRequestMediaTable can search by file name on view page', function (
 });
 
 test('ServiceRequestMediaTable can search by uploader name on view page', function () {
+    Storage::fake('s3');
+
     $userAlice = User::factory()->create(['name' => 'Alice Smith']);
     $userBob = User::factory()->create(['name' => 'Bob Jones']);
 

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/ViewServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/ViewServiceRequestTest.php
@@ -49,8 +49,6 @@ use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use App\Models\User;
 use App\Settings\LicenseSettings;
-use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Storage;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -314,134 +312,10 @@ test('view service request page visible if the user is a direct managerUser of t
 });
 
 test('ViewServiceRequest page displays the uploaded files section', function () {
-    Storage::fake('s3');
-
     $serviceRequest = ServiceRequest::factory()->create();
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('doc.png'))
-        ->usingName('doc')
-        ->toMediaCollection('uploads');
 
     asSuperAdmin()
         ->get(ServiceRequestResource::getUrl('view', ['record' => $serviceRequest]))
         ->assertSuccessful()
-        ->assertSeeText('Uploaded Files')
-        ->assertSeeText('File Name')
-        ->assertSeeText('Uploaded By')
-        ->assertSeeText('Date');
-});
-
-test('ServiceRequestMediaTable renders uploaded files on view page', function () {
-    Storage::fake('s3');
-
-    asSuperAdmin();
-
-    $serviceRequest = ServiceRequest::factory()->create();
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('report.png'))
-        ->usingName('report')
-        ->toMediaCollection('uploads');
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertCanSeeTableRecords($serviceRequest->getMedia('uploads'));
-});
-
-test('ServiceRequestMediaTable shows uploader name on view page', function () {
-    Storage::fake('s3');
-
-    $user = User::factory()->create(['name' => 'Jane Doe']);
-    actingAs($user);
-
-    $serviceRequest = ServiceRequest::factory()->create();
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('report.png'))
-        ->usingName('report')
-        ->toMediaCollection('uploads');
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertSeeText('Jane Doe');
-});
-
-test('ServiceRequestMediaTable can search by file name on view page', function () {
-    Storage::fake('s3');
-
-    asSuperAdmin();
-
-    $serviceRequest = ServiceRequest::factory()->create();
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('annual-report.png'))
-        ->usingName('annual-report')
-        ->toMediaCollection('uploads');
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('invoice.png'))
-        ->usingName('invoice')
-        ->toMediaCollection('uploads');
-
-    $allMedia = $serviceRequest->getMedia('uploads');
-    $annualReport = $allMedia->first(fn ($m) => $m->name === 'annual-report');
-    $invoice = $allMedia->first(fn ($m) => $m->name === 'invoice');
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('annual')
-        ->assertCanSeeTableRecords([$annualReport])
-        ->assertCanNotSeeTableRecords([$invoice]);
-});
-
-test('ServiceRequestMediaTable can search by uploader name on view page', function () {
-    Storage::fake('s3');
-
-    $userAlice = User::factory()->create(['name' => 'Alice Smith']);
-    $userBob = User::factory()->create(['name' => 'Bob Jones']);
-
-    $serviceRequest = ServiceRequest::factory()->create();
-
-    actingAs($userAlice);
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
-        ->usingName('alice-file')
-        ->toMediaCollection('uploads');
-
-    actingAs($userBob);
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
-        ->usingName('bob-file')
-        ->toMediaCollection('uploads');
-
-    $allMedia = $serviceRequest->getMedia('uploads');
-    $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
-    $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
-
-    asSuperAdmin();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('Alice')
-        ->assertCanSeeTableRecords([$aliceMedia])
-        ->assertCanNotSeeTableRecords([$bobMedia]);
-});
-
-test('ServiceRequestMediaTable shows empty state when no uploads exist on view page', function () {
-    asSuperAdmin();
-
-    $serviceRequest = ServiceRequest::factory()->create();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertSeeText('No uploads');
+        ->assertSeeLivewire(ServiceRequestMediaTable::class);
 });

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/ViewServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/ViewServiceRequestTest.php
@@ -42,12 +42,14 @@ use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\Pages\ManageA
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\Pages\ManageServiceRequestUpdate;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\Pages\ViewServiceRequest;
 use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\ServiceRequestResource;
+use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Illuminate\Http\UploadedFile;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -308,4 +310,127 @@ test('view service request page visible if the user is a direct managerUser of t
         'record' => $serviceRequestsWithManager->getRouteKey(),
     ])
         ->assertSuccessful();
+});
+
+test('ViewServiceRequest page displays the uploaded files section', function () {
+    $serviceRequest = ServiceRequest::factory()->create();
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('doc.png'))
+        ->usingName('doc')
+        ->toMediaCollection('uploads');
+
+    asSuperAdmin()
+        ->get(ServiceRequestResource::getUrl('view', ['record' => $serviceRequest]))
+        ->assertSuccessful()
+        ->assertSeeText('Uploaded Files')
+        ->assertSeeText('File Name')
+        ->assertSeeText('Uploaded By')
+        ->assertSeeText('Date');
+});
+
+test('ServiceRequestMediaTable renders uploaded files on view page', function () {
+    asSuperAdmin();
+
+    $serviceRequest = ServiceRequest::factory()->create();
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('report.png'))
+        ->usingName('report')
+        ->toMediaCollection('uploads');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertCanSeeTableRecords($serviceRequest->getMedia('uploads'));
+});
+
+test('ServiceRequestMediaTable shows uploader name on view page', function () {
+    $user = User::factory()->create(['name' => 'Jane Doe']);
+    actingAs($user);
+
+    $serviceRequest = ServiceRequest::factory()->create();
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('report.png'))
+        ->usingName('report')
+        ->toMediaCollection('uploads');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertSeeText('Jane Doe');
+});
+
+test('ServiceRequestMediaTable can search by file name on view page', function () {
+    asSuperAdmin();
+
+    $serviceRequest = ServiceRequest::factory()->create();
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('annual-report.png'))
+        ->usingName('annual-report')
+        ->toMediaCollection('uploads');
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('invoice.png'))
+        ->usingName('invoice')
+        ->toMediaCollection('uploads');
+
+    $allMedia = $serviceRequest->getMedia('uploads');
+    $annualReport = $allMedia->first(fn ($m) => $m->name === 'annual-report');
+    $invoice = $allMedia->first(fn ($m) => $m->name === 'invoice');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('annual')
+        ->assertCanSeeTableRecords([$annualReport])
+        ->assertCanNotSeeTableRecords([$invoice]);
+});
+
+test('ServiceRequestMediaTable can search by uploader name on view page', function () {
+    $userAlice = User::factory()->create(['name' => 'Alice Smith']);
+    $userBob = User::factory()->create(['name' => 'Bob Jones']);
+
+    $serviceRequest = ServiceRequest::factory()->create();
+
+    actingAs($userAlice);
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+        ->usingName('alice-file')
+        ->toMediaCollection('uploads');
+
+    actingAs($userBob);
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+        ->usingName('bob-file')
+        ->toMediaCollection('uploads');
+
+    $allMedia = $serviceRequest->getMedia('uploads');
+    $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
+    $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
+
+    asSuperAdmin();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('Alice')
+        ->assertCanSeeTableRecords([$aliceMedia])
+        ->assertCanNotSeeTableRecords([$bobMedia]);
+});
+
+test('ServiceRequestMediaTable shows empty state when no uploads exist on view page', function () {
+    asSuperAdmin();
+
+    $serviceRequest = ServiceRequest::factory()->create();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertSeeText('No uploads');
 });

--- a/app-modules/service-management/tests/Tenant/Filament/Widgets/ServiceRequestMediaTableTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Widgets/ServiceRequestMediaTableTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app-modules/service-management/tests/Tenant/Filament/Widgets/ServiceRequestMediaTableTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Widgets/ServiceRequestMediaTableTest.php
@@ -1,0 +1,502 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Contact\Models\Contact;
+use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
+use App\Features\MediaCreatedByFeature;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+// ─── ServiceRequest ───────────────────────────────────────────────────────────
+
+test('ServiceRequestMediaTable renders uploaded files for a ServiceRequest', function () {
+    Storage::fake('s3');
+
+    asSuperAdmin();
+
+    $serviceRequest = ServiceRequest::factory()->create();
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('report.png'))
+        ->usingName('report')
+        ->toMediaCollection('uploads');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertCanSeeTableRecords($serviceRequest->getMedia('uploads'));
+});
+
+test('ServiceRequestMediaTable shows uploader name for a User on a ServiceRequest', function () {
+    Storage::fake('s3');
+
+    MediaCreatedByFeature::activate();
+
+    $user = User::factory()->create(['name' => 'Jane Doe']);
+    actingAs($user);
+
+    $serviceRequest = ServiceRequest::factory()->create();
+    $media = $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('report.png'))
+        ->usingName('report')
+        ->toMediaCollection('uploads');
+
+    asSuperAdmin();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertTableColumnStateSet('created_by_name', 'Jane Doe', record: $media);
+});
+
+test('ServiceRequestMediaTable shows uploader name for a Contact on a ServiceRequest', function () {
+    Storage::fake('s3');
+
+    MediaCreatedByFeature::activate();
+
+    asSuperAdmin();
+
+    $contact = Contact::factory()->create([
+        'first_name' => 'Carol',
+        'last_name' => 'Williams',
+        'full_name' => 'Carol Williams',
+    ]);
+
+    $serviceRequest = ServiceRequest::factory()->create();
+    $media = $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('contact-file.png'))
+        ->usingName('contact-file')
+        ->toMediaCollection('uploads');
+
+    $media->createdBy()->associate($contact);
+    $media->save();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertTableColumnStateSet('created_by_name', 'Carol Williams', record: $media);
+});
+
+test('ServiceRequestMediaTable can search by file name (case-insensitive) for a ServiceRequest', function () {
+    Storage::fake('s3');
+
+    asSuperAdmin();
+
+    $serviceRequest = ServiceRequest::factory()->create();
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('Annual-Report.png'))
+        ->usingName('Annual-Report')
+        ->toMediaCollection('uploads');
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('invoice.png'))
+        ->usingName('invoice')
+        ->toMediaCollection('uploads');
+
+    $allMedia = $serviceRequest->getMedia('uploads');
+    $annualReport = $allMedia->first(fn ($m) => $m->name === 'Annual-Report');
+    $invoice = $allMedia->first(fn ($m) => $m->name === 'invoice');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('annual-report')
+        ->assertCanSeeTableRecords([$annualReport])
+        ->assertCanNotSeeTableRecords([$invoice]);
+});
+
+test('ServiceRequestMediaTable can search by User uploader name (case-insensitive) for a ServiceRequest', function () {
+    Storage::fake('s3');
+
+    MediaCreatedByFeature::activate();
+
+    $userAlice = User::factory()->create(['name' => 'Alice Smith']);
+    $userBob = User::factory()->create(['name' => 'Bob Jones']);
+
+    $serviceRequest = ServiceRequest::factory()->create();
+
+    actingAs($userAlice);
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+        ->usingName('alice-file')
+        ->toMediaCollection('uploads');
+
+    actingAs($userBob);
+    $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+        ->usingName('bob-file')
+        ->toMediaCollection('uploads');
+
+    $allMedia = $serviceRequest->getMedia('uploads');
+    $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
+    $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
+
+    asSuperAdmin();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('alice')
+        ->assertCanSeeTableRecords([$aliceMedia])
+        ->assertCanNotSeeTableRecords([$bobMedia]);
+});
+
+test('ServiceRequestMediaTable can search by Contact uploader first name (case-insensitive) for a ServiceRequest', function () {
+    Storage::fake('s3');
+
+    MediaCreatedByFeature::activate();
+
+    asSuperAdmin();
+
+    $contactAlice = Contact::factory()->create([
+        'first_name' => 'Alice',
+        'last_name' => 'Smith',
+        'full_name' => 'Alice Smith',
+    ]);
+    $contactBob = Contact::factory()->create([
+        'first_name' => 'Bob',
+        'last_name' => 'Jones',
+        'full_name' => 'Bob Jones',
+    ]);
+
+    $serviceRequest = ServiceRequest::factory()->create();
+
+    $aliceMedia = $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+        ->usingName('alice-file')
+        ->toMediaCollection('uploads');
+    $aliceMedia->createdBy()->associate($contactAlice);
+    $aliceMedia->save();
+
+    $bobMedia = $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+        ->usingName('bob-file')
+        ->toMediaCollection('uploads');
+    $bobMedia->createdBy()->associate($contactBob);
+    $bobMedia->save();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('ALICE')
+        ->assertCanSeeTableRecords([$aliceMedia])
+        ->assertCanNotSeeTableRecords([$bobMedia]);
+});
+
+test('ServiceRequestMediaTable can search by Contact uploader last name (case-insensitive) for a ServiceRequest', function () {
+    Storage::fake('s3');
+
+    MediaCreatedByFeature::activate();
+
+    asSuperAdmin();
+
+    $contactAlice = Contact::factory()->create([
+        'first_name' => 'Alice',
+        'last_name' => 'Smith',
+        'full_name' => 'Alice Smith',
+    ]);
+    $contactBob = Contact::factory()->create([
+        'first_name' => 'Bob',
+        'last_name' => 'Jones',
+        'full_name' => 'Bob Jones',
+    ]);
+
+    $serviceRequest = ServiceRequest::factory()->create();
+
+    $aliceMedia = $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+        ->usingName('alice-file')
+        ->toMediaCollection('uploads');
+    $aliceMedia->createdBy()->associate($contactAlice);
+    $aliceMedia->save();
+
+    $bobMedia = $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+        ->usingName('bob-file')
+        ->toMediaCollection('uploads');
+    $bobMedia->createdBy()->associate($contactBob);
+    $bobMedia->save();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('SMITH')
+        ->assertCanSeeTableRecords([$aliceMedia])
+        ->assertCanNotSeeTableRecords([$bobMedia]);
+});
+
+test('ServiceRequestMediaTable can search by Contact uploader full name (case-insensitive) for a ServiceRequest', function () {
+    Storage::fake('s3');
+
+    MediaCreatedByFeature::activate();
+
+    asSuperAdmin();
+
+    $contactAlice = Contact::factory()->create([
+        'first_name' => 'Alice',
+        'last_name' => 'Smith',
+        'full_name' => 'Alice Smith',
+    ]);
+    $contactBob = Contact::factory()->create([
+        'first_name' => 'Bob',
+        'last_name' => 'Jones',
+        'full_name' => 'Bob Jones',
+    ]);
+
+    $serviceRequest = ServiceRequest::factory()->create();
+
+    $aliceMedia = $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+        ->usingName('alice-file')
+        ->toMediaCollection('uploads');
+    $aliceMedia->createdBy()->associate($contactAlice);
+    $aliceMedia->save();
+
+    $bobMedia = $serviceRequest
+        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+        ->usingName('bob-file')
+        ->toMediaCollection('uploads');
+    $bobMedia->createdBy()->associate($contactBob);
+    $bobMedia->save();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('alice smith')
+        ->assertCanSeeTableRecords([$aliceMedia])
+        ->assertCanNotSeeTableRecords([$bobMedia]);
+});
+
+test('ServiceRequestMediaTable shows empty state when no uploads exist for a ServiceRequest', function () {
+    asSuperAdmin();
+
+    $serviceRequest = ServiceRequest::factory()->create();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequest,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertSeeText('No uploads');
+});
+
+// ─── ServiceRequestUpdate ─────────────────────────────────────────────────────
+
+test('ServiceRequestMediaTable renders uploaded files for a ServiceRequestUpdate', function () {
+    Storage::fake('s3');
+
+    asSuperAdmin();
+
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('attachment.png'))
+        ->usingName('attachment')
+        ->toMediaCollection('uploads');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequestUpdate,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertCanSeeTableRecords($serviceRequestUpdate->getMedia('uploads'));
+});
+
+test('ServiceRequestMediaTable shows uploader name for a Contact on a ServiceRequestUpdate', function () {
+    Storage::fake('s3');
+
+    MediaCreatedByFeature::activate();
+
+    asSuperAdmin();
+
+    $contact = Contact::factory()->create([
+        'first_name' => 'Carol',
+        'last_name' => 'Williams',
+        'full_name' => 'Carol Williams',
+    ]);
+
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+    $media = $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('contact-file.png'))
+        ->usingName('contact-file')
+        ->toMediaCollection('uploads');
+
+    $media->createdBy()->associate($contact);
+    $media->save();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequestUpdate,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertTableColumnStateSet('created_by_name', 'Carol Williams', record: $media);
+});
+
+test('ServiceRequestMediaTable can search by file name (case-insensitive) for a ServiceRequestUpdate', function () {
+    Storage::fake('s3');
+
+    asSuperAdmin();
+
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('Meeting-Notes.png'))
+        ->usingName('Meeting-Notes')
+        ->toMediaCollection('uploads');
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('screenshot.png'))
+        ->usingName('screenshot')
+        ->toMediaCollection('uploads');
+
+    $allMedia = $serviceRequestUpdate->getMedia('uploads');
+    $meetingNotes = $allMedia->first(fn ($m) => $m->name === 'Meeting-Notes');
+    $screenshot = $allMedia->first(fn ($m) => $m->name === 'screenshot');
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequestUpdate,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('meeting-notes')
+        ->assertCanSeeTableRecords([$meetingNotes])
+        ->assertCanNotSeeTableRecords([$screenshot]);
+});
+
+test('ServiceRequestMediaTable can search by User uploader name for a ServiceRequestUpdate', function () {
+    Storage::fake('s3');
+
+    MediaCreatedByFeature::activate();
+
+    $userAlice = User::factory()->create(['name' => 'Alice Smith']);
+    $userBob = User::factory()->create(['name' => 'Bob Jones']);
+
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+
+    actingAs($userAlice);
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+        ->usingName('alice-file')
+        ->toMediaCollection('uploads');
+
+    actingAs($userBob);
+    $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+        ->usingName('bob-file')
+        ->toMediaCollection('uploads');
+
+    $allMedia = $serviceRequestUpdate->getMedia('uploads');
+    $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
+    $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
+
+    asSuperAdmin();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequestUpdate,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('Alice')
+        ->assertCanSeeTableRecords([$aliceMedia])
+        ->assertCanNotSeeTableRecords([$bobMedia]);
+});
+
+test('ServiceRequestMediaTable can search by Contact uploader name for a ServiceRequestUpdate', function () {
+    Storage::fake('s3');
+
+    MediaCreatedByFeature::activate();
+
+    asSuperAdmin();
+
+    $contactAlice = Contact::factory()->create([
+        'first_name' => 'Alice',
+        'last_name' => 'Smith',
+        'full_name' => 'Alice Smith',
+    ]);
+    $contactBob = Contact::factory()->create([
+        'first_name' => 'Bob',
+        'last_name' => 'Jones',
+        'full_name' => 'Bob Jones',
+    ]);
+
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+
+    $aliceMedia = $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+        ->usingName('alice-file')
+        ->toMediaCollection('uploads');
+    $aliceMedia->createdBy()->associate($contactAlice);
+    $aliceMedia->save();
+
+    $bobMedia = $serviceRequestUpdate
+        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+        ->usingName('bob-file')
+        ->toMediaCollection('uploads');
+    $bobMedia->createdBy()->associate($contactBob);
+    $bobMedia->save();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequestUpdate,
+        'collectionName' => 'uploads',
+    ])
+        ->searchTable('Alice')
+        ->assertCanSeeTableRecords([$aliceMedia])
+        ->assertCanNotSeeTableRecords([$bobMedia]);
+});
+
+test('ServiceRequestMediaTable shows empty state when no uploads exist for a ServiceRequestUpdate', function () {
+    asSuperAdmin();
+
+    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+
+    livewire(ServiceRequestMediaTable::class, [
+        'record' => $serviceRequestUpdate,
+        'collectionName' => 'uploads',
+    ])
+        ->assertSuccessful()
+        ->assertSeeText('No uploads');
+});

--- a/app-modules/service-management/tests/Tenant/Filament/Widgets/ServiceRequestMediaTableTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Widgets/ServiceRequestMediaTableTest.php
@@ -38,7 +38,6 @@ use AidingApp\Contact\Models\Contact;
 use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
-use App\Features\MediaCreatedByFeature;
 use App\Models\User;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -47,456 +46,438 @@ use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
-// ─── ServiceRequest ───────────────────────────────────────────────────────────
+describe('ServiceRequest', function () {
+    test('renders uploaded files', function () {
+        Storage::fake('s3');
 
-test('ServiceRequestMediaTable renders uploaded files for a ServiceRequest', function () {
-    Storage::fake('s3');
+        asSuperAdmin();
 
-    asSuperAdmin();
+        $serviceRequest = ServiceRequest::factory()->create();
+        $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('report.png'))
+            ->usingName('report')
+            ->toMediaCollection('uploads');
 
-    $serviceRequest = ServiceRequest::factory()->create();
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('report.png'))
-        ->usingName('report')
-        ->toMediaCollection('uploads');
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords($serviceRequest->getMedia('uploads'));
+    });
 
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertCanSeeTableRecords($serviceRequest->getMedia('uploads'));
+    test('shows uploader name for a User', function () {
+        Storage::fake('s3');
+
+        $user = User::factory()->create(['name' => 'Jane Doe']);
+        actingAs($user);
+
+        $serviceRequest = ServiceRequest::factory()->create();
+        $media = $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('report.png'))
+            ->usingName('report')
+            ->toMediaCollection('uploads');
+
+        asSuperAdmin();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->assertSuccessful()
+            ->assertTableColumnStateSet('created_by_name', 'Jane Doe', record: $media);
+    });
+
+    test('shows uploader name for a Contact', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        $contact = Contact::factory()->create([
+            'first_name' => 'Carol',
+            'last_name' => 'Williams',
+            'full_name' => 'Carol Williams',
+        ]);
+
+        $serviceRequest = ServiceRequest::factory()->create();
+        $media = $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('contact-file.png'))
+            ->usingName('contact-file')
+            ->toMediaCollection('uploads');
+
+        $media->createdBy()->associate($contact);
+        $media->save();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->assertSuccessful()
+            ->assertTableColumnStateSet('created_by_name', 'Carol Williams', record: $media);
+    });
+
+    test('can search by file name (case-insensitive)', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        $serviceRequest = ServiceRequest::factory()->create();
+        $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('Annual-Report.png'))
+            ->usingName('Annual-Report')
+            ->toMediaCollection('uploads');
+        $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('invoice.png'))
+            ->usingName('invoice')
+            ->toMediaCollection('uploads');
+
+        $allMedia = $serviceRequest->getMedia('uploads');
+        $annualReport = $allMedia->first(fn ($m) => $m->name === 'Annual-Report');
+        $invoice = $allMedia->first(fn ($m) => $m->name === 'invoice');
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->searchTable('annual-report')
+            ->assertCanSeeTableRecords([$annualReport])
+            ->assertCanNotSeeTableRecords([$invoice]);
+    });
+
+    test('can search by User uploader name (case-insensitive)', function () {
+        Storage::fake('s3');
+
+        $userAlice = User::factory()->create(['name' => 'Alice Smith']);
+        $userBob = User::factory()->create(['name' => 'Bob Jones']);
+
+        $serviceRequest = ServiceRequest::factory()->create();
+
+        actingAs($userAlice);
+        $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+            ->usingName('alice-file')
+            ->toMediaCollection('uploads');
+
+        actingAs($userBob);
+        $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+            ->usingName('bob-file')
+            ->toMediaCollection('uploads');
+
+        $allMedia = $serviceRequest->getMedia('uploads');
+        $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
+        $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
+
+        asSuperAdmin();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->searchTable('alice')
+            ->assertCanSeeTableRecords([$aliceMedia])
+            ->assertCanNotSeeTableRecords([$bobMedia]);
+    });
+
+    test('can search by Contact uploader first name (case-insensitive)', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        $contactAlice = Contact::factory()->create([
+            'first_name' => 'Alice',
+            'last_name' => 'Smith',
+            'full_name' => 'Alice Smith',
+        ]);
+        $contactBob = Contact::factory()->create([
+            'first_name' => 'Bob',
+            'last_name' => 'Jones',
+            'full_name' => 'Bob Jones',
+        ]);
+
+        $serviceRequest = ServiceRequest::factory()->create();
+
+        $aliceMedia = $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+            ->usingName('alice-file')
+            ->toMediaCollection('uploads');
+        $aliceMedia->createdBy()->associate($contactAlice);
+        $aliceMedia->save();
+
+        $bobMedia = $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+            ->usingName('bob-file')
+            ->toMediaCollection('uploads');
+        $bobMedia->createdBy()->associate($contactBob);
+        $bobMedia->save();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->searchTable('ALICE')
+            ->assertCanSeeTableRecords([$aliceMedia])
+            ->assertCanNotSeeTableRecords([$bobMedia]);
+    });
+
+    test('can search by Contact uploader last name (case-insensitive)', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        $contactAlice = Contact::factory()->create([
+            'first_name' => 'Alice',
+            'last_name' => 'Smith',
+            'full_name' => 'Alice Smith',
+        ]);
+        $contactBob = Contact::factory()->create([
+            'first_name' => 'Bob',
+            'last_name' => 'Jones',
+            'full_name' => 'Bob Jones',
+        ]);
+
+        $serviceRequest = ServiceRequest::factory()->create();
+
+        $aliceMedia = $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+            ->usingName('alice-file')
+            ->toMediaCollection('uploads');
+        $aliceMedia->createdBy()->associate($contactAlice);
+        $aliceMedia->save();
+
+        $bobMedia = $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+            ->usingName('bob-file')
+            ->toMediaCollection('uploads');
+        $bobMedia->createdBy()->associate($contactBob);
+        $bobMedia->save();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->searchTable('SMITH')
+            ->assertCanSeeTableRecords([$aliceMedia])
+            ->assertCanNotSeeTableRecords([$bobMedia]);
+    });
+
+    test('can search by Contact uploader full name (case-insensitive)', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        $contactAlice = Contact::factory()->create([
+            'first_name' => 'Alice',
+            'last_name' => 'Smith',
+            'full_name' => 'Alice Smith',
+        ]);
+        $contactBob = Contact::factory()->create([
+            'first_name' => 'Bob',
+            'last_name' => 'Jones',
+            'full_name' => 'Bob Jones',
+        ]);
+
+        $serviceRequest = ServiceRequest::factory()->create();
+
+        $aliceMedia = $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+            ->usingName('alice-file')
+            ->toMediaCollection('uploads');
+        $aliceMedia->createdBy()->associate($contactAlice);
+        $aliceMedia->save();
+
+        $bobMedia = $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+            ->usingName('bob-file')
+            ->toMediaCollection('uploads');
+        $bobMedia->createdBy()->associate($contactBob);
+        $bobMedia->save();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->searchTable('alice smith')
+            ->assertCanSeeTableRecords([$aliceMedia])
+            ->assertCanNotSeeTableRecords([$bobMedia]);
+    });
+
+    test('shows empty state when no uploads exist', function () {
+        asSuperAdmin();
+
+        $serviceRequest = ServiceRequest::factory()->create();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->assertSuccessful()
+            ->assertSeeText('No uploads');
+    });
 });
 
-test('ServiceRequestMediaTable shows uploader name for a User on a ServiceRequest', function () {
-    Storage::fake('s3');
-
-    MediaCreatedByFeature::activate();
-
-    $user = User::factory()->create(['name' => 'Jane Doe']);
-    actingAs($user);
-
-    $serviceRequest = ServiceRequest::factory()->create();
-    $media = $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('report.png'))
-        ->usingName('report')
-        ->toMediaCollection('uploads');
-
-    asSuperAdmin();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertTableColumnStateSet('created_by_name', 'Jane Doe', record: $media);
-});
-
-test('ServiceRequestMediaTable shows uploader name for a Contact on a ServiceRequest', function () {
-    Storage::fake('s3');
-
-    MediaCreatedByFeature::activate();
-
-    asSuperAdmin();
-
-    $contact = Contact::factory()->create([
-        'first_name' => 'Carol',
-        'last_name' => 'Williams',
-        'full_name' => 'Carol Williams',
-    ]);
-
-    $serviceRequest = ServiceRequest::factory()->create();
-    $media = $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('contact-file.png'))
-        ->usingName('contact-file')
-        ->toMediaCollection('uploads');
-
-    $media->createdBy()->associate($contact);
-    $media->save();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertTableColumnStateSet('created_by_name', 'Carol Williams', record: $media);
-});
-
-test('ServiceRequestMediaTable can search by file name (case-insensitive) for a ServiceRequest', function () {
-    Storage::fake('s3');
-
-    asSuperAdmin();
-
-    $serviceRequest = ServiceRequest::factory()->create();
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('Annual-Report.png'))
-        ->usingName('Annual-Report')
-        ->toMediaCollection('uploads');
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('invoice.png'))
-        ->usingName('invoice')
-        ->toMediaCollection('uploads');
-
-    $allMedia = $serviceRequest->getMedia('uploads');
-    $annualReport = $allMedia->first(fn ($m) => $m->name === 'Annual-Report');
-    $invoice = $allMedia->first(fn ($m) => $m->name === 'invoice');
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('annual-report')
-        ->assertCanSeeTableRecords([$annualReport])
-        ->assertCanNotSeeTableRecords([$invoice]);
-});
-
-test('ServiceRequestMediaTable can search by User uploader name (case-insensitive) for a ServiceRequest', function () {
-    Storage::fake('s3');
-
-    MediaCreatedByFeature::activate();
-
-    $userAlice = User::factory()->create(['name' => 'Alice Smith']);
-    $userBob = User::factory()->create(['name' => 'Bob Jones']);
-
-    $serviceRequest = ServiceRequest::factory()->create();
-
-    actingAs($userAlice);
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
-        ->usingName('alice-file')
-        ->toMediaCollection('uploads');
-
-    actingAs($userBob);
-    $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
-        ->usingName('bob-file')
-        ->toMediaCollection('uploads');
-
-    $allMedia = $serviceRequest->getMedia('uploads');
-    $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
-    $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
-
-    asSuperAdmin();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('alice')
-        ->assertCanSeeTableRecords([$aliceMedia])
-        ->assertCanNotSeeTableRecords([$bobMedia]);
-});
-
-test('ServiceRequestMediaTable can search by Contact uploader first name (case-insensitive) for a ServiceRequest', function () {
-    Storage::fake('s3');
-
-    MediaCreatedByFeature::activate();
-
-    asSuperAdmin();
-
-    $contactAlice = Contact::factory()->create([
-        'first_name' => 'Alice',
-        'last_name' => 'Smith',
-        'full_name' => 'Alice Smith',
-    ]);
-    $contactBob = Contact::factory()->create([
-        'first_name' => 'Bob',
-        'last_name' => 'Jones',
-        'full_name' => 'Bob Jones',
-    ]);
-
-    $serviceRequest = ServiceRequest::factory()->create();
-
-    $aliceMedia = $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
-        ->usingName('alice-file')
-        ->toMediaCollection('uploads');
-    $aliceMedia->createdBy()->associate($contactAlice);
-    $aliceMedia->save();
-
-    $bobMedia = $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
-        ->usingName('bob-file')
-        ->toMediaCollection('uploads');
-    $bobMedia->createdBy()->associate($contactBob);
-    $bobMedia->save();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('ALICE')
-        ->assertCanSeeTableRecords([$aliceMedia])
-        ->assertCanNotSeeTableRecords([$bobMedia]);
-});
-
-test('ServiceRequestMediaTable can search by Contact uploader last name (case-insensitive) for a ServiceRequest', function () {
-    Storage::fake('s3');
-
-    MediaCreatedByFeature::activate();
-
-    asSuperAdmin();
-
-    $contactAlice = Contact::factory()->create([
-        'first_name' => 'Alice',
-        'last_name' => 'Smith',
-        'full_name' => 'Alice Smith',
-    ]);
-    $contactBob = Contact::factory()->create([
-        'first_name' => 'Bob',
-        'last_name' => 'Jones',
-        'full_name' => 'Bob Jones',
-    ]);
-
-    $serviceRequest = ServiceRequest::factory()->create();
-
-    $aliceMedia = $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
-        ->usingName('alice-file')
-        ->toMediaCollection('uploads');
-    $aliceMedia->createdBy()->associate($contactAlice);
-    $aliceMedia->save();
-
-    $bobMedia = $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
-        ->usingName('bob-file')
-        ->toMediaCollection('uploads');
-    $bobMedia->createdBy()->associate($contactBob);
-    $bobMedia->save();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('SMITH')
-        ->assertCanSeeTableRecords([$aliceMedia])
-        ->assertCanNotSeeTableRecords([$bobMedia]);
-});
-
-test('ServiceRequestMediaTable can search by Contact uploader full name (case-insensitive) for a ServiceRequest', function () {
-    Storage::fake('s3');
-
-    MediaCreatedByFeature::activate();
-
-    asSuperAdmin();
-
-    $contactAlice = Contact::factory()->create([
-        'first_name' => 'Alice',
-        'last_name' => 'Smith',
-        'full_name' => 'Alice Smith',
-    ]);
-    $contactBob = Contact::factory()->create([
-        'first_name' => 'Bob',
-        'last_name' => 'Jones',
-        'full_name' => 'Bob Jones',
-    ]);
-
-    $serviceRequest = ServiceRequest::factory()->create();
-
-    $aliceMedia = $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
-        ->usingName('alice-file')
-        ->toMediaCollection('uploads');
-    $aliceMedia->createdBy()->associate($contactAlice);
-    $aliceMedia->save();
-
-    $bobMedia = $serviceRequest
-        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
-        ->usingName('bob-file')
-        ->toMediaCollection('uploads');
-    $bobMedia->createdBy()->associate($contactBob);
-    $bobMedia->save();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('alice smith')
-        ->assertCanSeeTableRecords([$aliceMedia])
-        ->assertCanNotSeeTableRecords([$bobMedia]);
-});
-
-test('ServiceRequestMediaTable shows empty state when no uploads exist for a ServiceRequest', function () {
-    asSuperAdmin();
-
-    $serviceRequest = ServiceRequest::factory()->create();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequest,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertSeeText('No uploads');
-});
-
-// ─── ServiceRequestUpdate ─────────────────────────────────────────────────────
-
-test('ServiceRequestMediaTable renders uploaded files for a ServiceRequestUpdate', function () {
-    Storage::fake('s3');
-
-    asSuperAdmin();
-
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('attachment.png'))
-        ->usingName('attachment')
-        ->toMediaCollection('uploads');
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequestUpdate,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertCanSeeTableRecords($serviceRequestUpdate->getMedia('uploads'));
-});
-
-test('ServiceRequestMediaTable shows uploader name for a Contact on a ServiceRequestUpdate', function () {
-    Storage::fake('s3');
-
-    MediaCreatedByFeature::activate();
-
-    asSuperAdmin();
-
-    $contact = Contact::factory()->create([
-        'first_name' => 'Carol',
-        'last_name' => 'Williams',
-        'full_name' => 'Carol Williams',
-    ]);
-
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-    $media = $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('contact-file.png'))
-        ->usingName('contact-file')
-        ->toMediaCollection('uploads');
-
-    $media->createdBy()->associate($contact);
-    $media->save();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequestUpdate,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertTableColumnStateSet('created_by_name', 'Carol Williams', record: $media);
-});
-
-test('ServiceRequestMediaTable can search by file name (case-insensitive) for a ServiceRequestUpdate', function () {
-    Storage::fake('s3');
-
-    asSuperAdmin();
-
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('Meeting-Notes.png'))
-        ->usingName('Meeting-Notes')
-        ->toMediaCollection('uploads');
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('screenshot.png'))
-        ->usingName('screenshot')
-        ->toMediaCollection('uploads');
-
-    $allMedia = $serviceRequestUpdate->getMedia('uploads');
-    $meetingNotes = $allMedia->first(fn ($m) => $m->name === 'Meeting-Notes');
-    $screenshot = $allMedia->first(fn ($m) => $m->name === 'screenshot');
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequestUpdate,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('meeting-notes')
-        ->assertCanSeeTableRecords([$meetingNotes])
-        ->assertCanNotSeeTableRecords([$screenshot]);
-});
-
-test('ServiceRequestMediaTable can search by User uploader name for a ServiceRequestUpdate', function () {
-    Storage::fake('s3');
-
-    MediaCreatedByFeature::activate();
-
-    $userAlice = User::factory()->create(['name' => 'Alice Smith']);
-    $userBob = User::factory()->create(['name' => 'Bob Jones']);
-
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-
-    actingAs($userAlice);
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
-        ->usingName('alice-file')
-        ->toMediaCollection('uploads');
-
-    actingAs($userBob);
-    $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
-        ->usingName('bob-file')
-        ->toMediaCollection('uploads');
-
-    $allMedia = $serviceRequestUpdate->getMedia('uploads');
-    $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
-    $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
-
-    asSuperAdmin();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequestUpdate,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('Alice')
-        ->assertCanSeeTableRecords([$aliceMedia])
-        ->assertCanNotSeeTableRecords([$bobMedia]);
-});
-
-test('ServiceRequestMediaTable can search by Contact uploader name for a ServiceRequestUpdate', function () {
-    Storage::fake('s3');
-
-    MediaCreatedByFeature::activate();
-
-    asSuperAdmin();
-
-    $contactAlice = Contact::factory()->create([
-        'first_name' => 'Alice',
-        'last_name' => 'Smith',
-        'full_name' => 'Alice Smith',
-    ]);
-    $contactBob = Contact::factory()->create([
-        'first_name' => 'Bob',
-        'last_name' => 'Jones',
-        'full_name' => 'Bob Jones',
-    ]);
-
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-
-    $aliceMedia = $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('alice-file.png'))
-        ->usingName('alice-file')
-        ->toMediaCollection('uploads');
-    $aliceMedia->createdBy()->associate($contactAlice);
-    $aliceMedia->save();
-
-    $bobMedia = $serviceRequestUpdate
-        ->addMedia(UploadedFile::fake()->image('bob-file.png'))
-        ->usingName('bob-file')
-        ->toMediaCollection('uploads');
-    $bobMedia->createdBy()->associate($contactBob);
-    $bobMedia->save();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequestUpdate,
-        'collectionName' => 'uploads',
-    ])
-        ->searchTable('Alice')
-        ->assertCanSeeTableRecords([$aliceMedia])
-        ->assertCanNotSeeTableRecords([$bobMedia]);
-});
-
-test('ServiceRequestMediaTable shows empty state when no uploads exist for a ServiceRequestUpdate', function () {
-    asSuperAdmin();
-
-    $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
-
-    livewire(ServiceRequestMediaTable::class, [
-        'record' => $serviceRequestUpdate,
-        'collectionName' => 'uploads',
-    ])
-        ->assertSuccessful()
-        ->assertSeeText('No uploads');
+describe('ServiceRequestUpdate', function () {
+    test('renders uploaded files', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+        $serviceRequestUpdate
+            ->addMedia(UploadedFile::fake()->image('attachment.png'))
+            ->usingName('attachment')
+            ->toMediaCollection('uploads');
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequestUpdate,
+            'collectionName' => 'uploads',
+        ])
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords($serviceRequestUpdate->getMedia('uploads'));
+    });
+
+    test('shows uploader name for a Contact', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        $contact = Contact::factory()->create([
+            'first_name' => 'Carol',
+            'last_name' => 'Williams',
+            'full_name' => 'Carol Williams',
+        ]);
+
+        $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+        $media = $serviceRequestUpdate
+            ->addMedia(UploadedFile::fake()->image('contact-file.png'))
+            ->usingName('contact-file')
+            ->toMediaCollection('uploads');
+
+        $media->createdBy()->associate($contact);
+        $media->save();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequestUpdate,
+            'collectionName' => 'uploads',
+        ])
+            ->assertSuccessful()
+            ->assertTableColumnStateSet('created_by_name', 'Carol Williams', record: $media);
+    });
+
+    test('can search by file name (case-insensitive)', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+        $serviceRequestUpdate
+            ->addMedia(UploadedFile::fake()->image('Meeting-Notes.png'))
+            ->usingName('Meeting-Notes')
+            ->toMediaCollection('uploads');
+        $serviceRequestUpdate
+            ->addMedia(UploadedFile::fake()->image('screenshot.png'))
+            ->usingName('screenshot')
+            ->toMediaCollection('uploads');
+
+        $allMedia = $serviceRequestUpdate->getMedia('uploads');
+        $meetingNotes = $allMedia->first(fn ($m) => $m->name === 'Meeting-Notes');
+        $screenshot = $allMedia->first(fn ($m) => $m->name === 'screenshot');
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequestUpdate,
+            'collectionName' => 'uploads',
+        ])
+            ->searchTable('meeting-notes')
+            ->assertCanSeeTableRecords([$meetingNotes])
+            ->assertCanNotSeeTableRecords([$screenshot]);
+    });
+
+    test('can search by User uploader name', function () {
+        Storage::fake('s3');
+
+        $userAlice = User::factory()->create(['name' => 'Alice Smith']);
+        $userBob = User::factory()->create(['name' => 'Bob Jones']);
+
+        $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+
+        actingAs($userAlice);
+        $serviceRequestUpdate
+            ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+            ->usingName('alice-file')
+            ->toMediaCollection('uploads');
+
+        actingAs($userBob);
+        $serviceRequestUpdate
+            ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+            ->usingName('bob-file')
+            ->toMediaCollection('uploads');
+
+        $allMedia = $serviceRequestUpdate->getMedia('uploads');
+        $aliceMedia = $allMedia->first(fn ($m) => $m->name === 'alice-file');
+        $bobMedia = $allMedia->first(fn ($m) => $m->name === 'bob-file');
+
+        asSuperAdmin();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequestUpdate,
+            'collectionName' => 'uploads',
+        ])
+            ->searchTable('Alice')
+            ->assertCanSeeTableRecords([$aliceMedia])
+            ->assertCanNotSeeTableRecords([$bobMedia]);
+    });
+
+    test('can search by Contact uploader name', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        $contactAlice = Contact::factory()->create([
+            'first_name' => 'Alice',
+            'last_name' => 'Smith',
+            'full_name' => 'Alice Smith',
+        ]);
+        $contactBob = Contact::factory()->create([
+            'first_name' => 'Bob',
+            'last_name' => 'Jones',
+            'full_name' => 'Bob Jones',
+        ]);
+
+        $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+
+        $aliceMedia = $serviceRequestUpdate
+            ->addMedia(UploadedFile::fake()->image('alice-file.png'))
+            ->usingName('alice-file')
+            ->toMediaCollection('uploads');
+        $aliceMedia->createdBy()->associate($contactAlice);
+        $aliceMedia->save();
+
+        $bobMedia = $serviceRequestUpdate
+            ->addMedia(UploadedFile::fake()->image('bob-file.png'))
+            ->usingName('bob-file')
+            ->toMediaCollection('uploads');
+        $bobMedia->createdBy()->associate($contactBob);
+        $bobMedia->save();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequestUpdate,
+            'collectionName' => 'uploads',
+        ])
+            ->searchTable('Alice')
+            ->assertCanSeeTableRecords([$aliceMedia])
+            ->assertCanNotSeeTableRecords([$bobMedia]);
+    });
+
+    test('shows empty state when no uploads exist', function () {
+        asSuperAdmin();
+
+        $serviceRequestUpdate = ServiceRequestUpdate::factory()->create();
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequestUpdate,
+            'collectionName' => 'uploads',
+        ])
+            ->assertSuccessful()
+            ->assertSeeText('No uploads');
+    });
 });

--- a/app/Features/MediaCreatedByFeature.php
+++ b/app/Features/MediaCreatedByFeature.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app/Features/MediaCreatedByFeature.php
+++ b/app/Features/MediaCreatedByFeature.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -34,29 +34,14 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement;
+namespace App\Features;
 
-use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
-use Filament\Contracts\Plugin;
-use Filament\Panel;
+use App\Support\AbstractFeatureFlag;
 
-class ServiceManagementPlugin implements Plugin
+class MediaCreatedByFeature extends AbstractFeatureFlag
 {
-    public function getId(): string
+    public function resolve(mixed $scope): mixed
     {
-        return 'service-request';
+        return false;
     }
-
-    public function register(Panel $panel): void
-    {
-        $panel->discoverResources(
-                in: __DIR__ . '/Filament/Resources',
-                for: 'AidingApp\\ServiceManagement\\Filament\\Resources'
-            )
-            ->livewireComponents([
-                ServiceRequestMediaTable::class,
-            ]);
-    }
-
-    public function boot(Panel $panel): void {}
 }

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Models;
+
+use App\Features\MediaCreatedByFeature;
+use App\Observers\MediaObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Spatie\MediaLibrary\MediaCollections\Models\Media as SpatieMedia;
+
+#[ObservedBy([MediaObserver::class])]
+class Media extends SpatieMedia
+{
+    /**
+     * @return MorphTo<Model, Media>
+     */
+    public function createdBy(): MorphTo
+    {
+        /** @var MorphTo<Model, Media> */
+        return $this->morphTo('createdBy', 'created_by_type', 'created_by_id');
+    }
+
+    public function getCreatedByNameAttribute(): string
+    {
+        if (! MediaCreatedByFeature::active() || ! ($creator = $this->createdBy)) {
+            return 'N/A';
+        }
+
+        // Handle User (has 'name')
+        if (isset($creator->name)) {
+            return (string) $creator->name;
+        }
+
+        // Handle Contact (has 'first_name', 'last_name')
+        $fullName = trim(trim($creator->first_name ?? '') . ' ' . trim($creator->last_name ?? ''));
+
+        return $fullName ?: 'N/A';
+    }
+
+    public function getCreatedBySubLabelAttribute(): ?string
+    {
+        if (! MediaCreatedByFeature::active() || ! ($creator = $this->createdBy)) {
+            return null;
+        }
+
+        if (isset($creator->job_title)) {
+            $jobTitle = (string) ($creator->job_title ?? '');
+            $teamName = (string) (($creator->getAttribute('team')?->getAttribute('name')) ?? '');
+
+            if ($jobTitle && $teamName) {
+                return "{$jobTitle} ({$teamName})";
+            }
+
+            return $jobTitle ?: ($teamName ?: null);
+        }
+
+        if (isset($creator->type)) {
+            $typeName = (string) ($creator->type->getAttribute('name') ?? '');
+            $orgName = (string) ($creator->getAttribute('organization')?->getAttribute('name') ?? '');
+
+            if ($typeName && $orgName) {
+                return "{$typeName} - {$orgName}";
+            }
+
+            return $typeName ?: ($orgName ?: null);
+        }
+
+        return null;
+    }
+}

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -36,6 +36,7 @@
 
 namespace App\Models;
 
+use AidingApp\Contact\Models\Contact;
 use App\Features\MediaCreatedByFeature;
 use App\Observers\MediaObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
@@ -43,16 +44,18 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Spatie\MediaLibrary\MediaCollections\Models\Media as SpatieMedia;
 
+/**
+ * @mixin IdeHelperMedia
+ */
 #[ObservedBy([MediaObserver::class])]
 class Media extends SpatieMedia
 {
     /**
-     * @return MorphTo<Model, Media>
+     * @return MorphTo<Model, $this>
      */
     public function createdBy(): MorphTo
     {
-        /** @var MorphTo<Model, Media> */
-        return $this->morphTo('createdBy', 'created_by_type', 'created_by_id');
+        return $this->morphTo('createdBy');
     }
 
     public function getCreatedByNameAttribute(): string
@@ -61,15 +64,11 @@ class Media extends SpatieMedia
             return 'N/A';
         }
 
-        // Handle User (has 'name')
-        if (isset($creator->name)) {
-            return (string) $creator->name;
-        }
-
-        // Handle Contact (has 'first_name', 'last_name')
-        $fullName = trim(trim($creator->first_name ?? '') . ' ' . trim($creator->last_name ?? ''));
-
-        return $fullName ?: 'N/A';
+        return match (true) {
+            $creator instanceof User => (string) $creator->name,
+            $creator instanceof Contact => trim("{$creator->first_name} {$creator->last_name}") ?: 'N/A',
+            default => 'N/A',
+        };
     }
 
     public function getCreatedBySubLabelAttribute(): ?string
@@ -78,28 +77,34 @@ class Media extends SpatieMedia
             return null;
         }
 
-        if (isset($creator->job_title)) {
-            $jobTitle = (string) ($creator->job_title ?? '');
-            $teamName = (string) (($creator->getAttribute('team')?->getAttribute('name')) ?? '');
+        return match (true) {
+            $creator instanceof User => $this->getUserSubLabel($creator),
+            $creator instanceof Contact => $this->getContactSubLabel($creator),
+            default => null,
+        };
+    }
 
-            if ($jobTitle && $teamName) {
-                return "{$jobTitle} ({$teamName})";
-            }
+    private function getUserSubLabel(User $creator): ?string
+    {
+        $jobTitle = (string) ($creator->job_title ?? '');
+        $teamName = (string) ($creator->team->name ?? '');
 
-            return $jobTitle ?: ($teamName ?: null);
+        if ($jobTitle && $teamName) {
+            return "{$jobTitle} ({$teamName})";
         }
 
-        if (isset($creator->type)) {
-            $typeName = (string) ($creator->type->getAttribute('name') ?? '');
-            $orgName = (string) ($creator->getAttribute('organization')?->getAttribute('name') ?? '');
+        return $jobTitle ?: ($teamName ?: null);
+    }
 
-            if ($typeName && $orgName) {
-                return "{$typeName} - {$orgName}";
-            }
+    private function getContactSubLabel(Contact $creator): ?string
+    {
+        $typeName = (string) ($creator->type->name ?? '');
+        $orgName = (string) ($creator->organization->name ?? '');
 
-            return $typeName ?: ($orgName ?: null);
+        if ($typeName && $orgName) {
+            return "{$typeName} - {$orgName}";
         }
 
-        return null;
+        return $typeName ?: ($orgName ?: null);
     }
 }

--- a/app/Models/NotificationSetting.php
+++ b/app/Models/NotificationSetting.php
@@ -48,7 +48,9 @@ use Spatie\MediaLibrary\InteractsWithMedia;
  */
 class NotificationSetting extends BaseModel implements HasMedia
 {
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
+
     use SoftDeletes;
 
     protected $fillable = [

--- a/app/Models/SettingsPropertyWithMedia.php
+++ b/app/Models/SettingsPropertyWithMedia.php
@@ -41,5 +41,6 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 
 abstract class SettingsPropertyWithMedia extends SettingsProperty implements HasMedia
 {
+    /** @use InteractsWithMedia<Media> */
     use InteractsWithMedia;
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -104,6 +104,8 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
     use HasManyEngagements;
     use HasManyEngagementBatches;
     use Impersonate;
+
+    /** @use InteractsWithMedia<\App\Models\Media> */
     use InteractsWithMedia;
 
     protected $hidden = [

--- a/app/Observers/MediaObserver.php
+++ b/app/Observers/MediaObserver.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app/Observers/MediaObserver.php
+++ b/app/Observers/MediaObserver.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -34,29 +34,25 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement;
+namespace App\Observers;
 
-use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
-use Filament\Contracts\Plugin;
-use Filament\Panel;
+use App\Features\MediaCreatedByFeature;
+use App\Models\Media;
+use Illuminate\Support\Facades\Auth;
 
-class ServiceManagementPlugin implements Plugin
+class MediaObserver
 {
-    public function getId(): string
+    public function creating(Media $media): void
     {
-        return 'service-request';
-    }
+        if (! MediaCreatedByFeature::active() || filled($media->created_by_id)) {
+            return;
+        }
 
-    public function register(Panel $panel): void
-    {
-        $panel->discoverResources(
-                in: __DIR__ . '/Filament/Resources',
-                for: 'AidingApp\\ServiceManagement\\Filament\\Resources'
-            )
-            ->livewireComponents([
-                ServiceRequestMediaTable::class,
-            ]);
-    }
+        $user = Auth::user();
 
-    public function boot(Panel $panel): void {}
+        if ($user && ($key = $user->getKey()) !== null) {
+            $media->created_by_id = (string) $key;
+            $media->created_by_type = $user->getMorphClass();
+        }
+    }
 }

--- a/app/Observers/MediaObserver.php
+++ b/app/Observers/MediaObserver.php
@@ -44,15 +44,14 @@ class MediaObserver
 {
     public function creating(Media $media): void
     {
-        if (! MediaCreatedByFeature::active() || filled($media->created_by_id)) {
+        if (! MediaCreatedByFeature::active() || $media->createdBy) {
             return;
         }
 
-        $user = Auth::user();
+        $creator = Auth::user();
 
-        if ($user && ($key = $user->getKey()) !== null) {
-            $media->created_by_id = (string) $key;
-            $media->created_by_type = $user->getMorphClass();
+        if ($creator) {
+            $media->createdBy()->associate($creator);
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "App\\Rector\\": "rector-rules/",
             "Tests\\": "tests/"
         }
     },
@@ -170,11 +171,19 @@
         "clear-prettier-cache": [
             "rm -rf ./.cache/prettier"
         ],
+        "rector": [
+            "./vendor/bin/rector process"
+        ],
+        "rector-dryrun": [
+            "./vendor/bin/rector process --dry-run"
+        ],
         "format-dryrun": [
+            "@rector-dryrun",
             "@php-cs-format-dryrun",
             "@prettier-format-dryrun"
         ],
         "format": [
+            "@rector",
             "@php-cs-format",
             "@prettier-format"
         ],

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -15,7 +15,6 @@ use Spatie\MediaLibrary\Conversions\ImageGenerators\Video;
 use Spatie\MediaLibrary\Conversions\ImageGenerators\Webp;
 use Spatie\MediaLibrary\Conversions\Jobs\PerformConversionsJob;
 use Spatie\MediaLibrary\Downloaders\DefaultDownloader;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\MediaLibrary\ResponsiveImages\Jobs\GenerateResponsiveImagesJob;
 use Spatie\MediaLibrary\ResponsiveImages\TinyPlaceholderGenerator\Blurred;
 use Spatie\MediaLibrary\ResponsiveImages\WidthCalculator\FileSizeOptimizedWidthCalculator;
@@ -23,6 +22,7 @@ use Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer;
 use Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator;
 use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
 use Spatie\MediaLibraryPro\Models\TemporaryUpload;
+use App\Models\Media;
 
 /*
 <COPYRIGHT>

--- a/config/media-library.php
+++ b/config/media-library.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Media;
 use Spatie\ImageOptimizer\Optimizers\Avifenc;
 use Spatie\ImageOptimizer\Optimizers\Cwebp;
 use Spatie\ImageOptimizer\Optimizers\Gifsicle;
@@ -22,7 +23,6 @@ use Spatie\MediaLibrary\Support\FileNamer\DefaultFileNamer;
 use Spatie\MediaLibrary\Support\PathGenerator\DefaultPathGenerator;
 use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
 use Spatie\MediaLibraryPro\Models\TemporaryUpload;
-use App\Models\Media;
 
 /*
 <COPYRIGHT>

--- a/database/migrations/2026_05_12_254102_add_created_by_to_media_table.php
+++ b/database/migrations/2026_05_12_254102_add_created_by_to_media_table.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/database/migrations/2026_05_12_254102_add_created_by_to_media_table.php
+++ b/database/migrations/2026_05_12_254102_add_created_by_to_media_table.php
@@ -45,13 +45,7 @@ return new class () extends Migration {
     {
         DB::transaction(function () {
             Schema::table('media', function (Blueprint $table) {
-                if (! Schema::hasColumn('media', 'created_by_type')) {
-                    $table->string('created_by_type')->nullable();
-                }
-
-                if (! Schema::hasColumn('media', 'created_by_id')) {
-                    $table->uuid('created_by_id')->nullable()->index();
-                }
+                $table->nullableUuidMorphs('created_by');
             });
 
             MediaCreatedByFeature::activate();
@@ -64,13 +58,7 @@ return new class () extends Migration {
             MediaCreatedByFeature::deactivate();
 
             Schema::table('media', function (Blueprint $table) {
-                if (Schema::hasColumn('media', 'created_by_type')) {
-                    $table->dropColumn('created_by_type');
-                }
-
-                if (Schema::hasColumn('media', 'created_by_id')) {
-                    $table->dropColumn('created_by_id');
-                }
+                $table->dropMorphs('created_by');
             });
         });
     }

--- a/database/migrations/2026_05_12_254102_add_created_by_to_media_table.php
+++ b/database/migrations/2026_05_12_254102_add_created_by_to_media_table.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -34,29 +34,44 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement;
+use App\Features\MediaCreatedByFeature;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
-use AidingApp\ServiceManagement\Filament\Widgets\ServiceRequestMediaTable;
-use Filament\Contracts\Plugin;
-use Filament\Panel;
-
-class ServiceManagementPlugin implements Plugin
-{
-    public function getId(): string
+return new class () extends Migration {
+    public function up(): void
     {
-        return 'service-request';
+        DB::transaction(function () {
+            Schema::table('media', function (Blueprint $table) {
+                if (! Schema::hasColumn('media', 'created_by_type')) {
+                    $table->string('created_by_type')->nullable();
+                }
+
+                if (! Schema::hasColumn('media', 'created_by_id')) {
+                    $table->uuid('created_by_id')->nullable()->index();
+                }
+            });
+
+            MediaCreatedByFeature::activate();
+        });
     }
 
-    public function register(Panel $panel): void
+    public function down(): void
     {
-        $panel->discoverResources(
-                in: __DIR__ . '/Filament/Resources',
-                for: 'AidingApp\\ServiceManagement\\Filament\\Resources'
-            )
-            ->livewireComponents([
-                ServiceRequestMediaTable::class,
-            ]);
-    }
+        DB::transaction(function () {
+            MediaCreatedByFeature::deactivate();
 
-    public function boot(Panel $panel): void {}
-}
+            Schema::table('media', function (Blueprint $table) {
+                if (Schema::hasColumn('media', 'created_by_type')) {
+                    $table->dropColumn('created_by_type');
+                }
+
+                if (Schema::hasColumn('media', 'created_by_id')) {
+                    $table->dropColumn('created_by_id');
+                }
+            });
+        });
+    }
+};

--- a/phpstan-stubs/InteractsWithMedia.stub
+++ b/phpstan-stubs/InteractsWithMedia.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\MediaLibrary;
+
+/**
+ * @template TMedia of \Spatie\MediaLibrary\MediaCollections\Models\Media = \App\Models\Media
+ */
+trait InteractsWithMedia {}

--- a/phpstan-stubs/InteractsWithMedia.stub
+++ b/phpstan-stubs/InteractsWithMedia.stub
@@ -1,8 +1,0 @@
-<?php
-
-namespace Spatie\MediaLibrary;
-
-/**
- * @template TMedia of \Spatie\MediaLibrary\MediaCollections\Models\Media = \App\Models\Media
- */
-trait InteractsWithMedia {}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -77,5 +77,8 @@ parameters:
             message: '#Anonymous function should return Illuminate\\Database\\Eloquent\\Builder<Illuminate\\Database\\Eloquent\\Model> but returns Illuminate\\Database\\Eloquent\\Builder<.+>#'
             identifier: return.type
 
+    stubFiles:
+        - phpstan-stubs/InteractsWithMedia.stub
+
     typeAliases:
         ValidationRules: 'array<string, array<\Illuminate\Contracts\Validation\Rule|\Illuminate\Contracts\Validation\ValidationRule|string>|string>'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -77,8 +77,5 @@ parameters:
             message: '#Anonymous function should return Illuminate\\Database\\Eloquent\\Builder<Illuminate\\Database\\Eloquent\\Model> but returns Illuminate\\Database\\Eloquent\\Builder<.+>#'
             identifier: return.type
 
-    stubFiles:
-        - phpstan-stubs/InteractsWithMedia.stub
-
     typeAliases:
         ValidationRules: 'array<string, array<\Illuminate\Contracts\Validation\Rule|\Illuminate\Contracts\Validation\ValidationRule|string>|string>'

--- a/rector-rules/AddInteractsWithMediaUseTagRector.php
+++ b/rector-rules/AddInteractsWithMediaUseTagRector.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/rector-rules/AddInteractsWithMediaUseTagRector.php
+++ b/rector-rules/AddInteractsWithMediaUseTagRector.php
@@ -34,14 +34,18 @@
 </COPYRIGHT>
 */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace App\Rector;
 
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\TraitUse;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\UseItem;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -63,11 +67,12 @@ class AddInteractsWithMediaUseTagRector extends AbstractRector
                         }
                         CODE_SAMPLE,
                     <<<'CODE_SAMPLE'
+                        use App\Models\Media;
                         use Spatie\MediaLibrary\InteractsWithMedia;
 
                         class MyModel extends Model
                         {
-                            /** @use InteractsWithMedia<\App\Models\Media> */
+                            /** @use InteractsWithMedia<Media> */
                             use InteractsWithMedia;
                         }
                         CODE_SAMPLE,
@@ -78,28 +83,58 @@ class AddInteractsWithMediaUseTagRector extends AbstractRector
 
     public function getNodeTypes(): array
     {
-        return [Class_::class];
+        return [Namespace_::class];
     }
 
     public function refactor(Node $node): ?Node
     {
-        /** @var Class_ $node */
-        foreach ($node->stmts as $stmt) {
-            if (! $stmt instanceof TraitUse) {
-                continue;
+        /** @var Namespace_ $node */
+        $class = $this->findClass($node);
+
+        if ($class === null) {
+            return null;
+        }
+
+        $traitUse = $this->findInteractsWithMediaTraitUse($class);
+
+        if ($traitUse === null) {
+            return null;
+        }
+
+        if ($this->hasUseTag($traitUse)) {
+            return null;
+        }
+
+        if ($this->hasConflictingMediaImport($node)) {
+            $traitUse->setDocComment(new Doc('/** @use InteractsWithMedia<\App\Models\Media> */'));
+        } else {
+            $traitUse->setDocComment(new Doc('/** @use InteractsWithMedia<Media> */'));
+
+            if (! $this->hasUseImport($node, 'App\Models\Media')) {
+                $this->addUseImport($node, 'App\Models\Media');
             }
+        }
 
-            if (! $this->hasInteractsWithMediaTrait($stmt)) {
-                continue;
+        return $node;
+    }
+
+    private function findClass(Namespace_ $namespace): ?Class_
+    {
+        foreach ($namespace->stmts as $stmt) {
+            if ($stmt instanceof Class_) {
+                return $stmt;
             }
+        }
 
-            if ($this->hasUseTag($stmt)) {
-                return null;
+        return null;
+    }
+
+    private function findInteractsWithMediaTraitUse(Class_ $class): ?TraitUse
+    {
+        foreach ($class->stmts as $stmt) {
+            if ($stmt instanceof TraitUse && $this->hasInteractsWithMediaTrait($stmt)) {
+                return $stmt;
             }
-
-            $stmt->setDocComment(new Doc('/** @use InteractsWithMedia<\App\Models\Media> */'));
-
-            return $node;
         }
 
         return null;
@@ -125,5 +160,59 @@ class AddInteractsWithMediaUseTagRector extends AbstractRector
         }
 
         return str_contains($docComment->getText(), '@use InteractsWithMedia<');
+    }
+
+    private function hasUseImport(Namespace_ $namespace, string $fullyQualifiedName): bool
+    {
+        foreach ($namespace->stmts as $stmt) {
+            if (! $stmt instanceof Use_) {
+                continue;
+            }
+
+            foreach ($stmt->uses as $use) {
+                if ($use->name->toString() === $fullyQualifiedName) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function hasConflictingMediaImport(Namespace_ $namespace): bool
+    {
+        foreach ($namespace->stmts as $stmt) {
+            if (! $stmt instanceof Use_) {
+                continue;
+            }
+
+            foreach ($stmt->uses as $use) {
+                $shortName = $use->alias?->toString() ?? $use->name->getLast();
+
+                if ($shortName === 'Media' && $use->name->toString() !== 'App\Models\Media') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function addUseImport(Namespace_ $namespace, string $fullyQualifiedName): void
+    {
+        $newUse = new Use_([new UseItem(new Name($fullyQualifiedName))]);
+
+        // Find the last use statement and insert after it
+        $lastUseIndex = null;
+
+        foreach ($namespace->stmts as $index => $stmt) {
+            if ($stmt instanceof Use_) {
+                $lastUseIndex = $index;
+            }
+        }
+
+        if ($lastUseIndex !== null) {
+            array_splice($namespace->stmts, $lastUseIndex + 1, 0, [$newUse]);
+        }
     }
 }

--- a/rector-rules/AddInteractsWithMediaUseTagRector.php
+++ b/rector-rules/AddInteractsWithMediaUseTagRector.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+declare(strict_types=1);
+
+namespace App\Rector;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\TraitUse;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class AddInteractsWithMediaUseTagRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Add @use InteractsWithMedia<\App\Models\Media> annotation to classes using InteractsWithMedia trait',
+            [
+                new CodeSample(
+                    <<<'CODE_SAMPLE'
+                        use Spatie\MediaLibrary\InteractsWithMedia;
+
+                        class MyModel extends Model
+                        {
+                            use InteractsWithMedia;
+                        }
+                        CODE_SAMPLE,
+                    <<<'CODE_SAMPLE'
+                        use Spatie\MediaLibrary\InteractsWithMedia;
+
+                        class MyModel extends Model
+                        {
+                            /** @use InteractsWithMedia<\App\Models\Media> */
+                            use InteractsWithMedia;
+                        }
+                        CODE_SAMPLE,
+                ),
+            ]
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        /** @var Class_ $node */
+        foreach ($node->stmts as $stmt) {
+            if (! $stmt instanceof TraitUse) {
+                continue;
+            }
+
+            if (! $this->hasInteractsWithMediaTrait($stmt)) {
+                continue;
+            }
+
+            if ($this->hasUseTag($stmt)) {
+                return null;
+            }
+
+            $stmt->setDocComment(new Doc('/** @use InteractsWithMedia<\App\Models\Media> */'));
+
+            return $node;
+        }
+
+        return null;
+    }
+
+    private function hasInteractsWithMediaTrait(TraitUse $traitUse): bool
+    {
+        foreach ($traitUse->traits as $trait) {
+            if ($this->isName($trait, 'Spatie\MediaLibrary\InteractsWithMedia')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasUseTag(TraitUse $traitUse): bool
+    {
+        $docComment = $traitUse->getDocComment();
+
+        if ($docComment === null) {
+            return false;
+        }
+
+        return str_contains($docComment->getText(), '@use InteractsWithMedia<');
+    }
+}

--- a/rector.php
+++ b/rector.php
@@ -36,6 +36,18 @@
 
 declare(strict_types = 1);
 
+use App\Rector\AddInteractsWithMediaUseTagRector;
 use Rector\Config\RectorConfig;
 
-return static function (RectorConfig $rectorConfig): void {};
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/app',
+        __DIR__ . '/app-modules',
+    ]);
+
+    $rectorConfig->skip([
+        __DIR__ . '/app-modules/*/vendor',
+    ]);
+
+    $rectorConfig->rule(AddInteractsWithMediaUseTagRector::class);
+};

--- a/rector.php
+++ b/rector.php
@@ -39,11 +39,9 @@ declare(strict_types = 1);
 use App\Rector\AddInteractsWithMediaUseTagRector;
 use Rector\Config\RectorConfig;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->autoloadPaths([
-        __DIR__ . '/rector-rules',
-    ]);
+require_once __DIR__ . '/rector-rules/AddInteractsWithMediaUseTagRector.php';
 
+return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
         __DIR__ . '/app',
         __DIR__ . '/app-modules',

--- a/rector.php
+++ b/rector.php
@@ -40,6 +40,10 @@ use App\Rector\AddInteractsWithMediaUseTagRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->autoloadPaths([
+        __DIR__ . '/rector-rules',
+    ]);
+
     $rectorConfig->paths([
         __DIR__ . '/app',
         __DIR__ . '/app-modules',


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1115

### Technical Description

- Implemented file upload tracking for service requests by adding created_by_id and created_by_type polymorphic columns to the media table via a new migration
- Created a Media observer that automatically stamps the authenticated user as the creator when uploading files
- Built a reusable `ServiceRequestMediaTable` Filament table widget showing file name, uploader info, date, and download action

### Any deployment steps required?

> No

### Cleanup Tasks

> Feature Flag Added: `MediaCreatedByFeature`

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
