### PR TITLE
[AIDAPP-1201]: Some users have reported that in emails, header images are not rendering at their intended size

### DIFF
--- a/resources/views/vendor/mail/html/layout.blade.php
+++ b/resources/views/vendor/mail/html/layout.blade.php
@@ -130,7 +130,9 @@
                                     style="height: 75px; max-height: 75px; max-width: 100vw;"
                                     alt="Logo">
                             @elseif ($headerLogo)
-                                <img src="{{ $headerLogo }}" class="logo" alt="Logo">
+                                <img src="{{ $headerLogo }}"
+                                    style="height: 75px; max-height: 75px; max-width: 100vw;"
+                                    alt="Logo">
                             @elseif ($themeSettings->is_logo_active && $logo)
                                 <img src="{{ $settingsProperty->getFirstMediaUrl('logo') }}"
                                     style="height: 75px; max-height: 75px; max-width: 100vw;"


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1201

### Technical Description

Ensure header logos are not restricted to 75px width by replicating styles used in other branches of header image determination

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
