### PR TITLE
[AIDAPP-1227]: Hide knowledge base categories from display in the self-service portal if they have no articles in them.

### DIFF
--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategoryController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategoryController.php
@@ -52,6 +52,7 @@ class KnowledgeManagementPortalCategoryController extends Controller
             KnowledgeBaseCategoryData::collect(
                 KnowledgeBaseCategory::query()
                     ->where('parent_id', null)
+                    ->whereHas('knowledgeBaseItems', fn (Builder $query) => $query->public())
                     ->orderBy(KnowledgeBaseCategorySortFeature::active() ? 'sort' : 'name')
                     ->get()
                     ->map(function (KnowledgeBaseCategory $category) {

--- a/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategoryControllerTest.php
+++ b/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategoryControllerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
+use AidingApp\KnowledgeBase\Models\KnowledgeBaseItem;
+use AidingApp\Portal\Settings\PortalSettings;
+
+use function Pest\Laravel\getJson;
+
+it('only returns categories that have at least one public article', function () {
+    $portalSettings = app(PortalSettings::class);
+    $portalSettings->knowledge_management_portal_enabled = true;
+    $portalSettings->save();
+
+    $categoryWithPublicArticle = KnowledgeBaseCategory::factory()->create(['parent_id' => null]);
+    KnowledgeBaseItem::factory()->create([
+        'category_id' => $categoryWithPublicArticle->id,
+        'public' => true,
+    ]);
+
+    $categoryWithPrivateArticle = KnowledgeBaseCategory::factory()->create(['parent_id' => null]);
+    KnowledgeBaseItem::factory()->create([
+        'category_id' => $categoryWithPrivateArticle->id,
+        'public' => false,
+    ]);
+
+    $categoryWithNoArticles = KnowledgeBaseCategory::factory()->create(['parent_id' => null]);
+
+    $response = getJson(route('api.portal.category.index'));
+
+    $response->assertOk();
+
+    $slugs = collect($response->json())->pluck('slug');
+
+    expect($slugs)->toContain($categoryWithPublicArticle->slug)
+        ->and($slugs)->not->toContain($categoryWithPrivateArticle->slug)
+        ->and($slugs)->not->toContain($categoryWithNoArticles->slug);
+});

--- a/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategorySortTest.php
+++ b/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategorySortTest.php
@@ -35,6 +35,7 @@
 */
 
 use AidingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
+use AidingApp\KnowledgeBase\Models\KnowledgeBaseItem;
 use AidingApp\Portal\Settings\PortalSettings;
 
 use function Pest\Laravel\getJson;
@@ -43,12 +44,17 @@ beforeEach(function () {
     $settings = app(PortalSettings::class);
     $settings->knowledge_management_portal_enabled = true;
     $settings->save();
+
 });
 
 it('returns parent categories ordered by sort on the portal', function () {
-    KnowledgeBaseCategory::factory()->create(['name' => 'Zebra', 'sort' => 3]);
-    KnowledgeBaseCategory::factory()->create(['name' => 'Apple', 'sort' => 1]);
-    KnowledgeBaseCategory::factory()->create(['name' => 'Mango', 'sort' => 2]);
+    $zebra = KnowledgeBaseCategory::factory()->create(['name' => 'Zebra', 'sort' => 3]);
+    $apple = KnowledgeBaseCategory::factory()->create(['name' => 'Apple', 'sort' => 1]);
+    $mango = KnowledgeBaseCategory::factory()->create(['name' => 'Mango', 'sort' => 2]);
+
+    KnowledgeBaseItem::factory()->create(['category_id' => $zebra->id, 'public' => true]);
+    KnowledgeBaseItem::factory()->create(['category_id' => $apple->id, 'public' => true]);
+    KnowledgeBaseItem::factory()->create(['category_id' => $mango->id, 'public' => true]);
 
     $response = getJson(route('api.portal.category.index'));
 

--- a/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategorySortTest.php
+++ b/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalCategorySortTest.php
@@ -44,7 +44,6 @@ beforeEach(function () {
     $settings = app(PortalSettings::class);
     $settings->knowledge_management_portal_enabled = true;
     $settings->save();
-
 });
 
 it('returns parent categories ordered by sort on the portal', function () {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1227

### Technical Description

> Hide knowledge base categories from display in the self-service portal if they have no articles in them.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
