### PR TITLE
[AIDAPP-1224]: Consolidate the display for metadata into properties for knowledge base articles

### DIFF
--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/EditKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/EditKnowledgeBaseItem.php
@@ -132,16 +132,48 @@ class EditKnowledgeBaseItem extends EditRecord
                                             }),
                                     )
                                     ->columnSpanFull(),
-                                Toggle::make('has_table_of_contents')
-                                    ->label('Table of Contents')
-                                    ->default(false)
-                                    ->onColor('success')
-                                    ->offColor('gray'),
-                                Textarea::make('notes')
-                                    ->label('Notes')
-                                    ->columnSpanFull()
-                                    ->extraInputAttributes(['style' => 'min-height: 12rem;']),
-                                Grid::make(2)
+                                Grid::make(Division::count() > 1 ? 4 : 3)
+                                    ->schema([
+                                        Select::make('status_id')
+                                            ->label('Status')
+                                            ->relationship('status', 'name')
+                                            ->searchable()
+                                            ->preload()
+                                            ->exists((new KnowledgeBaseStatus())->getTable(), (new KnowledgeBaseStatus())->getKeyName()),
+                                        SelectTree::make('category_id')
+                                            ->label('Category')
+                                            ->required()
+                                            ->relationship(
+                                                'category',
+                                                'name',
+                                                'parent_id',
+                                                modifyQueryUsing: fn (Builder $query) => $query->orderBy(KnowledgeBaseCategorySortFeature::active() ? 'sort' : 'name'),
+                                                modifyChildQueryUsing: fn (Builder $query) => $query->orderBy(KnowledgeBaseCategorySortFeature::active() ? 'sort' : 'name'),
+                                            )
+                                            ->enableBranchNode()
+                                            ->searchable()
+                                            ->exists((new KnowledgeBaseCategory())->getTable(), (new KnowledgeBaseCategory())->getKeyName()),
+                                        Select::make('division')
+                                            ->label('Division')
+                                            ->multiple()
+                                            ->relationship('division', 'name')
+                                            ->searchable(['name', 'code'])
+                                            ->preload()
+                                            ->afterStateHydrated(function (array $state, Set $set) {
+                                                if (empty($state)) {
+                                                    $set('division', [Division::count() === 1 ? Division::query()->first()?->getKey() : null]);
+                                                }
+                                            })
+                                            ->visible(fn (): bool => Division::count() > 1)
+                                            ->saveRelationshipsWhenHidden()
+                                            ->exists((new Division())->getTable(), (new Division())->getKeyName()),
+                                        UserSelect::make('manager_ids')
+                                            ->label('Managers')
+                                            ->relationship('managers')
+                                            ->multiple()
+                                            ->exists('users', 'id'),
+                                    ]),
+                                Grid::make(3)
                                     ->schema([
                                         Toggle::make('public')
                                             ->label('Public')
@@ -153,7 +185,16 @@ class EditKnowledgeBaseItem extends EditRecord
                                             ->default(false)
                                             ->onColor('success')
                                             ->offColor('gray'),
+                                        Toggle::make('has_table_of_contents')
+                                            ->label('Table of Contents')
+                                            ->default(false)
+                                            ->onColor('success')
+                                            ->offColor('gray'),
                                     ]),
+                                Textarea::make('notes')
+                                    ->label('Notes')
+                                    ->columnSpanFull()
+                                    ->extraInputAttributes(['style' => 'min-height: 12rem;']),
                                 Select::make('tags')
                                     ->relationship(
                                         'tags',
@@ -166,47 +207,6 @@ class EditKnowledgeBaseItem extends EditRecord
                                     ->columnSpanFull(),
                             ])
                             ->columns(2),
-                        Tab::make('Metadata')
-                            ->schema([
-                                Select::make('status_id')
-                                    ->label('Status')
-                                    ->relationship('status', 'name')
-                                    ->searchable()
-                                    ->preload()
-                                    ->exists((new KnowledgeBaseStatus())->getTable(), (new KnowledgeBaseStatus())->getKeyName()),
-                                SelectTree::make('category_id')
-                                    ->label('Category')
-                                    ->required()
-                                    ->relationship(
-                                        'category',
-                                        'name',
-                                        'parent_id',
-                                        modifyQueryUsing: fn (Builder $query) => $query->orderBy(KnowledgeBaseCategorySortFeature::active() ? 'sort' : 'name'),
-                                        modifyChildQueryUsing: fn (Builder $query) => $query->orderBy(KnowledgeBaseCategorySortFeature::active() ? 'sort' : 'name'),
-                                    )
-                                    ->enableBranchNode()
-                                    ->searchable()
-                                    ->exists((new KnowledgeBaseCategory())->getTable(), (new KnowledgeBaseCategory())->getKeyName()),
-                                Select::make('division')
-                                    ->label('Division')
-                                    ->multiple()
-                                    ->relationship('division', 'name')
-                                    ->searchable(['name', 'code'])
-                                    ->preload()
-                                    ->afterStateHydrated(function (array $state, Set $set) {
-                                        if (empty($state)) {
-                                            $set('division', [Division::count() === 1 ? Division::query()->first()?->getKey() : null]);
-                                        }
-                                    })
-                                    ->visible(fn (): bool => Division::count() > 1)
-                                    ->saveRelationshipsWhenHidden()
-                                    ->exists((new Division())->getTable(), (new Division())->getKeyName()),
-                                UserSelect::make('manager_ids')
-                                    ->label('Managers')
-                                    ->relationship('managers')
-                                    ->multiple()
-                                    ->exists('users', 'id'),
-                            ]),
                     ])
                     ->columnSpanFull(),
             ]);

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItem.php
@@ -47,7 +47,6 @@ use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Grid;
-use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItem.php
@@ -46,6 +46,8 @@ use Filament\Actions\EditAction;
 use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Pages\ViewRecord;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;
@@ -87,18 +89,38 @@ class ViewKnowledgeBaseItem extends ViewRecord
                             ->id('content'),
                         Tab::make('Properties')
                             ->schema([
+                                Grid::make(Division::count() > 1 ? 4 : 3)
+                                    ->schema([
+                                        TextEntry::make('status.name')
+                                            ->label('Status'),
+                                        TextEntry::make('category.name')
+                                            ->label('Category'),
+                                        TextEntry::make('division.name')
+                                            ->visible(fn (): bool => Division::count() > 1)
+                                            ->label('Division'),
+                                        TextEntry::make('managers')
+                                            ->label('Managers')
+                                            ->getStateUsing(fn (KnowledgeBaseItem $record) => $record->managers->pluck('name')->join(', ')),
+                                    ]),
+                                Grid::make(3)
+                                    ->schema([
+                                        TextEntry::make('public')
+                                            ->label('Public')
+                                            ->formatStateUsing(fn (bool $state): string => $state ? 'Yes' : 'No'),
+                                        TextEntry::make('is_featured')
+                                            ->label('Featured')
+                                            ->formatStateUsing(fn (bool $state): string => $state ? 'Yes' : 'No'),
+                                        TextEntry::make('has_table_of_contents')
+                                            ->label('Table of Contents')
+                                            ->formatStateUsing(fn (bool $state): string => $state ? 'Yes' : 'No'),
+                                    ]),
                                 TextEntry::make('notes')
                                     ->label('Notes')
                                     ->columnSpanFull(),
-                                TextEntry::make('public')
-                                    ->label('Public')
-                                    ->formatStateUsing(fn (bool $state): string => $state ? 'Yes' : 'No'),
-                                TextEntry::make('is_featured')
-                                    ->label('Featured')
-                                    ->formatStateUsing(fn (bool $state): string => $state ? 'Yes' : 'No'),
                                 TextEntry::make('tags')
                                     ->getStateUsing(fn (KnowledgeBaseItem $record) => $record->tags->pluck('name'))
-                                    ->badge(),
+                                    ->badge()
+                                    ->columnSpanFull(),
                                 TextEntry::make('rating')
                                     ->label('Rating')
                                     ->getStateUsing(function (KnowledgeBaseItem $record): string {
@@ -113,20 +135,6 @@ class ViewKnowledgeBaseItem extends ViewRecord
                             ])
                             ->id('properties')
                             ->columns(2),
-                        Tab::make('Metadata')
-                            ->schema([
-                                TextEntry::make('status.name')
-                                    ->label('Status'),
-                                TextEntry::make('category.name')
-                                    ->label('Category'),
-                                TextEntry::make('division.name')
-                                    ->visible(fn (): bool => Division::count() > 1)
-                                    ->label('Division'),
-                                TextEntry::make('managers')
-                                    ->label('Managers')
-                                    ->getStateUsing(fn (KnowledgeBaseItem $record) => $record->managers->pluck('name')->join(', ')),
-                            ])
-                            ->id('metadata'),
                         Tab::make('Concerns')
                             ->schema([
                                 Livewire::make(KnowledgeBaseItemConcernsTable::class, ['record' => $this->getRecord()]),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1224

### Technical Description

Remove metadata tab, reorganize fields into properties tab

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
