### PR TITLE
[AIDAPP-1221]: Some users have reported that the filter for service request types display as unselectable when collapsed

### DIFF
--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
@@ -345,7 +345,7 @@ class ListServiceRequests extends ListRecords
      * @param  Collection<(int|string), mixed>  $categoriesByParent
      * @param  Collection<(int|string), mixed>  $typesByCategory
      *
-     * @return array{name: string, value: string, disabled: bool, children: array<int, mixed>}
+     * @return array{name: string, value: string, children: array<int, mixed>}
      */
     protected static function buildCategoryNode(
         ServiceRequestTypeCategory $category,

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
@@ -320,6 +320,8 @@ class ListServiceRequests extends ListRecords
 
         $tree = collect($categories->get('', collect()))
             ->map(fn (ServiceRequestTypeCategory $category) => static::buildCategoryNode($category, $categories, $types))
+            ->filter(fn (array $node) => ! empty($node['children']))
+            ->values()
             ->all();
 
         $uncategorizedTypes = $types->get('', collect())
@@ -353,6 +355,8 @@ class ListServiceRequests extends ListRecords
     ): array {
         $childCategories = $categoriesByParent->get($category->getKey(), collect())
             ->map(fn (ServiceRequestTypeCategory $child) => static::buildCategoryNode($child, $categoriesByParent, $typesByCategory))
+            ->filter(fn (array $node) => ! empty($node['children']))
+            ->values()
             ->all();
 
         $childTypes = $typesByCategory->get($category->getKey(), collect())

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
@@ -184,9 +184,7 @@ class ListServiceRequests extends ListRecords
                             ->label('Type')
                             ->getTreeUsing(fn () => static::buildTypeTreeOptions())
                             ->multiple()
-                            ->placeholder('All')
-                            ->independent(true)
-                            ->expandSelected(true),
+                            ->placeholder('All'),
                     ])
                     ->query(fn (Builder $query, array $data): Builder => $query->when(
                         ! empty($data['types']),
@@ -370,7 +368,6 @@ class ListServiceRequests extends ListRecords
         return [
             'name' => $category->name,
             'value' => 'category_' . $category->getKey(),
-            'disabled' => true,
             'children' => array_merge($childCategories, $childTypes),
         ];
     }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
@@ -304,7 +304,7 @@ class ListServiceRequests extends ListRecords
     }
 
     /**
-     * @return array<int, array{name: string, value: string, disabled: bool, children: array<int, mixed>}>
+     * @return array<int, array{name: string, value: string, children: array<int, mixed>}>
      */
     public static function buildTypeTreeOptions(): array
     {
@@ -326,7 +326,6 @@ class ListServiceRequests extends ListRecords
             ->map(fn (ServiceRequestType $type) => [
                 'name' => $type->name,
                 'value' => $type->getKey(),
-                'disabled' => false,
                 'children' => [],
             ])
             ->all();
@@ -360,7 +359,6 @@ class ListServiceRequests extends ListRecords
             ->map(fn (ServiceRequestType $type) => [
                 'name' => $type->name,
                 'value' => $type->getKey(),
-                'disabled' => false,
                 'children' => [],
             ])
             ->all();

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/ListServiceRequestsTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/ListServiceRequestsTest.php
@@ -914,7 +914,7 @@ it('shows all service requests when no type filter is selected', function () {
         ->assertCanSeeTableRecords($serviceRequestsTypeA->merge($serviceRequestsTypeB));
 });
 
-it('builds type tree options with categories as disabled groups and types as selectable items', function () {
+it('builds type tree options with categories as groups and types as selectable items', function () {
     ServiceRequestType::query()->delete();
     ServiceRequestTypeCategory::query()->delete();
 
@@ -954,24 +954,19 @@ it('builds type tree options with categories as disabled groups and types as sel
 
     // Area A
     expect($tree[0]['name'])->toBe('Area A');
-    expect($tree[0]['disabled'])->toBeTrue();
     expect($tree[0]['value'])->toBe('category_' . $categoryA->getKey());
     expect($tree[0]['children'])->toHaveCount(2);
     expect($tree[0]['children'][0]['name'])->toBe('Type A1');
     expect($tree[0]['children'][0]['value'])->toBe($typeA1->getKey());
-    expect($tree[0]['children'][0]['disabled'])->toBeFalse();
     expect($tree[0]['children'][1]['name'])->toBe('Type A2');
     expect($tree[0]['children'][1]['value'])->toBe($typeA2->getKey());
-    expect($tree[0]['children'][1]['disabled'])->toBeFalse();
 
     // Area B
     expect($tree[1]['name'])->toBe('Area B');
-    expect($tree[1]['disabled'])->toBeTrue();
     expect($tree[1]['value'])->toBe('category_' . $categoryB->getKey());
     expect($tree[1]['children'])->toHaveCount(1);
     expect($tree[1]['children'][0]['name'])->toBe('Type B1');
     expect($tree[1]['children'][0]['value'])->toBe($typeB1->getKey());
-    expect($tree[1]['children'][0]['disabled'])->toBeFalse();
 });
 
 it('builds type tree options with nested categories maintaining sort order', function () {
@@ -1008,21 +1003,17 @@ it('builds type tree options with nested categories maintaining sort order', fun
 
     // Parent Area
     expect($tree[0]['name'])->toBe('Parent Area');
-    expect($tree[0]['disabled'])->toBeTrue();
     expect($tree[0]['children'])->toHaveCount(2);
 
     // Child Area (nested category, comes first by sort order)
     expect($tree[0]['children'][0]['name'])->toBe('Child Area');
-    expect($tree[0]['children'][0]['disabled'])->toBeTrue();
     expect($tree[0]['children'][0]['children'])->toHaveCount(1);
     expect($tree[0]['children'][0]['children'][0]['name'])->toBe('Child Type');
     expect($tree[0]['children'][0]['children'][0]['value'])->toBe($childType->getKey());
-    expect($tree[0]['children'][0]['children'][0]['disabled'])->toBeFalse();
 
     // Parent Type (type in parent category)
     expect($tree[0]['children'][1]['name'])->toBe('Parent Type');
     expect($tree[0]['children'][1]['value'])->toBe($parentType->getKey());
-    expect($tree[0]['children'][1]['disabled'])->toBeFalse();
 });
 
 it('builds type tree options with uncategorized types at root level', function () {
@@ -1054,11 +1045,9 @@ it('builds type tree options with uncategorized types at root level', function (
     // Uncategorized type at root level first
     expect($tree[0]['name'])->toBe('Uncategorized Type');
     expect($tree[0]['value'])->toBe($uncategorizedType->getKey());
-    expect($tree[0]['disabled'])->toBeFalse();
 
     // Categorized area after uncategorized types
     expect($tree[1]['name'])->toBe('Categorized Area');
-    expect($tree[1]['disabled'])->toBeTrue();
     expect($tree[1]['children'])->toHaveCount(1);
     expect($tree[1]['children'][0]['name'])->toBe('Categorized Type');
 });

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/ListServiceRequestsTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/ListServiceRequestsTest.php
@@ -1051,3 +1051,64 @@ it('builds type tree options with uncategorized types at root level', function (
     expect($tree[1]['children'])->toHaveCount(1);
     expect($tree[1]['children'][0]['name'])->toBe('Categorized Type');
 });
+
+it('filters out empty categories from type tree options', function () {
+    ServiceRequestType::query()->delete();
+    ServiceRequestTypeCategory::query()->delete();
+
+    $categoryWithTypes = ServiceRequestTypeCategory::factory()->create([
+        'name' => 'Has Types',
+        'sort' => 1,
+        'parent_id' => null,
+    ]);
+
+    $emptyCategory = ServiceRequestTypeCategory::factory()->create([
+        'name' => 'Empty Category',
+        'sort' => 2,
+        'parent_id' => null,
+    ]);
+
+    ServiceRequestType::factory()->create([
+        'name' => 'Type A',
+        'sort' => 1,
+        'category_id' => $categoryWithTypes->getKey(),
+    ]);
+
+    $tree = ListServiceRequests::buildTypeTreeOptions();
+
+    expect($tree)->toHaveCount(1);
+    expect($tree[0]['name'])->toBe('Has Types');
+    expect($tree[0]['children'])->toHaveCount(1);
+    expect($tree[0]['children'][0]['name'])->toBe('Type A');
+});
+
+it('filters out nested empty categories from type tree options', function () {
+    ServiceRequestType::query()->delete();
+    ServiceRequestTypeCategory::query()->delete();
+
+    $parentCategory = ServiceRequestTypeCategory::factory()->create([
+        'name' => 'Parent',
+        'sort' => 1,
+        'parent_id' => null,
+    ]);
+
+    ServiceRequestTypeCategory::factory()->create([
+        'name' => 'Empty Child',
+        'sort' => 1,
+        'parent_id' => $parentCategory->getKey(),
+    ]);
+
+    $type = ServiceRequestType::factory()->create([
+        'name' => 'Direct Type',
+        'sort' => 2,
+        'category_id' => $parentCategory->getKey(),
+    ]);
+
+    $tree = ListServiceRequests::buildTypeTreeOptions();
+
+    expect($tree)->toHaveCount(1);
+    expect($tree[0]['name'])->toBe('Parent');
+    expect($tree[0]['children'])->toHaveCount(1);
+    expect($tree[0]['children'][0]['name'])->toBe('Direct Type');
+    expect($tree[0]['children'][0]['value'])->toBe($type->getKey());
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1221

### Technical Description

Removes the `disabled` state for categories so they are not disabled. Also removes two other config lines that are just setting the config options to their default values, so they don't do anything.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
