### PR TITLE
[AIDAPP-1230]: Hide the display of a service request area in the self-service portal if there are no available types stored within it

### DIFF
--- a/app-modules/ai/src/Http/Controllers/AssistantWidget/GetServiceRequestTypesController.php
+++ b/app-modules/ai/src/Http/Controllers/AssistantWidget/GetServiceRequestTypesController.php
@@ -133,6 +133,16 @@ class GetServiceRequestTypesController extends Controller
 
         usort($topLevelTypes, fn (array $first, array $second) => ($first['sort'] ?? 0) <=> ($second['sort'] ?? 0));
 
+        $filterEmptyCategories = function (array &$nodes) use (&$filterEmptyCategories): array {
+            return array_values(array_filter($nodes, function (array &$node) use (&$filterEmptyCategories): bool {
+                $node['children'] = $filterEmptyCategories($node['children']);
+
+                return ! empty($node['types']) || ! empty($node['children']);
+            }));
+        };
+
+        $topLevelCategories = $filterEmptyCategories($topLevelCategories);
+
         return response()->json([
             'categories' => $topLevelCategories,
             'types' => $topLevelTypes,

--- a/app-modules/ai/tests/Tenant/Http/Controllers/AssistantWidget/GetServiceRequestTypesControllerTest.php
+++ b/app-modules/ai/tests/Tenant/Http/Controllers/AssistantWidget/GetServiceRequestTypesControllerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Contact\Models\Contact;
+use AidingApp\Portal\Settings\PortalSettings;
+use AidingApp\ServiceManagement\Models\ServiceRequestType;
+use AidingApp\ServiceManagement\Models\ServiceRequestTypeCategory;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\getJson;
+
+beforeEach(function () {
+    $portalSettings = app(PortalSettings::class);
+    $portalSettings->knowledge_management_portal_enabled = true;
+    $portalSettings->ai_support_assistant = true;
+    $portalSettings->save();
+});
+
+function authenticatedWidgetRequest(string $url): \Illuminate\Testing\TestResponse
+{
+    $contact = Contact::factory()->create();
+    $contact->createToken('assistant-widget-access-token');
+
+    actingAs($contact, 'contact');
+
+    return getJson($url, ['Origin' => config('app.url')]);
+}
+
+it('does not return categories that have no service request types', function () {
+    $categoryWithType = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+    ServiceRequestType::factory()->create(['category_id' => $categoryWithType->id]);
+
+    $emptyCategory = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+
+    $response = authenticatedWidgetRequest(route('widgets.assistant.api.service-request-types'));
+
+    $response->assertOk();
+
+    $categoryIds = collect($response->json('categories'))->pluck('id');
+
+    expect($categoryIds)->toContain($categoryWithType->id)
+        ->and($categoryIds)->not->toContain($emptyCategory->id);
+});
+
+it('returns a parent category when a child category has types', function () {
+    $parentCategory = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+    $childCategory = ServiceRequestTypeCategory::factory()->create(['parent_id' => $parentCategory->id]);
+    ServiceRequestType::factory()->create(['category_id' => $childCategory->id]);
+
+    $response = authenticatedWidgetRequest(route('widgets.assistant.api.service-request-types'));
+
+    $response->assertOk();
+
+    $categoryIds = collect($response->json('categories'))->pluck('id');
+
+    expect($categoryIds)->toContain($parentCategory->id);
+});
+
+it('does not return a parent category when all child categories are empty', function () {
+    $parentCategory = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+    ServiceRequestTypeCategory::factory()->create(['parent_id' => $parentCategory->id]);
+
+    $response = authenticatedWidgetRequest(route('widgets.assistant.api.service-request-types'));
+
+    $response->assertOk();
+
+    $categoryIds = collect($response->json('categories'))->pluck('id');
+
+    expect($categoryIds)->not->toContain($parentCategory->id);
+});
+
+it('does not return archived service request types as part of a category', function () {
+    $categoryWithOnlyArchivedType = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+    ServiceRequestType::factory()->create([
+        'category_id' => $categoryWithOnlyArchivedType->id,
+        'archived_at' => now(),
+    ]);
+
+    $categoryWithActiveType = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+    ServiceRequestType::factory()->create(['category_id' => $categoryWithActiveType->id]);
+
+    $response = authenticatedWidgetRequest(route('widgets.assistant.api.service-request-types'));
+
+    $response->assertOk();
+
+    $categoryIds = collect($response->json('categories'))->pluck('id');
+
+    expect($categoryIds)->toContain($categoryWithActiveType->id)
+        ->and($categoryIds)->not->toContain($categoryWithOnlyArchivedType->id);
+});

--- a/app-modules/ai/tests/Tenant/Http/Controllers/AssistantWidget/GetServiceRequestTypesControllerTest.php
+++ b/app-modules/ai/tests/Tenant/Http/Controllers/AssistantWidget/GetServiceRequestTypesControllerTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -38,6 +38,7 @@ use AidingApp\Contact\Models\Contact;
 use AidingApp\Portal\Settings\PortalSettings;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use AidingApp\ServiceManagement\Models\ServiceRequestTypeCategory;
+use Illuminate\Testing\TestResponse;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\getJson;
@@ -49,7 +50,7 @@ beforeEach(function () {
     $portalSettings->save();
 });
 
-function authenticatedWidgetRequest(string $url): \Illuminate\Testing\TestResponse
+function authenticatedWidgetRequest(string $url): TestResponse
 {
     $contact = Contact::factory()->create();
     $contact->createToken('assistant-widget-access-token');

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/ServiceRequestTypesController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/ServiceRequestTypesController.php
@@ -120,6 +120,17 @@ class ServiceRequestTypesController extends Controller
             return ($left['sort'] ?? 0) <=> ($right['sort'] ?? 0);
         });
 
+        // Remove categories that have no types and no children with types (recursively)
+        $filterEmptyCategories = function (array &$nodes) use (&$filterEmptyCategories): array {
+            return array_values(array_filter($nodes, function (array &$node) use (&$filterEmptyCategories): bool {
+                $node['children'] = $filterEmptyCategories($node['children']);
+
+                return ! empty($node['types']) || ! empty($node['children']);
+            }));
+        };
+
+        $topLevelCategories = $filterEmptyCategories($topLevelCategories);
+
         return response()->json([
             'categories' => $topLevelCategories,
             'types' => $topLevelTypes,

--- a/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/ServiceRequestTypesControllerTest.php
+++ b/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/ServiceRequestTypesControllerTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/ServiceRequestTypesControllerTest.php
+++ b/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/ServiceRequestTypesControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Portal\Settings\PortalSettings;
+use AidingApp\ServiceManagement\Models\ServiceRequestType;
+use AidingApp\ServiceManagement\Models\ServiceRequestTypeCategory;
+
+use function Pest\Laravel\getJson;
+
+beforeEach(function () {
+    $portalSettings = app(PortalSettings::class);
+    $portalSettings->knowledge_management_portal_enabled = true;
+    $portalSettings->save();
+});
+
+it('does not return categories that have no service request types', function () {
+    $categoryWithType = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+    ServiceRequestType::factory()->create(['category_id' => $categoryWithType->id]);
+
+    $emptyCategory = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+
+    $response = getJson(route('api.portal.service-request-type.index'));
+
+    $response->assertOk();
+
+    $categoryIds = collect($response->json('categories'))->pluck('id');
+
+    expect($categoryIds)->toContain($categoryWithType->id)
+        ->and($categoryIds)->not->toContain($emptyCategory->id);
+});
+
+it('returns a category with a child category that has types', function () {
+    $parentCategory = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+    $childCategory = ServiceRequestTypeCategory::factory()->create(['parent_id' => $parentCategory->id]);
+    ServiceRequestType::factory()->create(['category_id' => $childCategory->id]);
+
+    $response = getJson(route('api.portal.service-request-type.index'));
+
+    $response->assertOk();
+
+    $categoryIds = collect($response->json('categories'))->pluck('id');
+
+    expect($categoryIds)->toContain($parentCategory->id);
+});
+
+it('does not return a parent category when all child categories are empty', function () {
+    $parentCategory = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+    ServiceRequestTypeCategory::factory()->create(['parent_id' => $parentCategory->id]);
+
+    $response = getJson(route('api.portal.service-request-type.index'));
+
+    $response->assertOk();
+
+    $categoryIds = collect($response->json('categories'))->pluck('id');
+
+    expect($categoryIds)->not->toContain($parentCategory->id);
+});
+
+it('does not return archived service request types as part of a category', function () {
+    $categoryWithOnlyArchivedType = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+    ServiceRequestType::factory()->create([
+        'category_id' => $categoryWithOnlyArchivedType->id,
+        'archived_at' => now(),
+    ]);
+
+    $categoryWithActiveType = ServiceRequestTypeCategory::factory()->create(['parent_id' => null]);
+    ServiceRequestType::factory()->create(['category_id' => $categoryWithActiveType->id]);
+
+    $response = getJson(route('api.portal.service-request-type.index'));
+
+    $response->assertOk();
+
+    $categoryIds = collect($response->json('categories'))->pluck('id');
+
+    expect($categoryIds)->toContain($categoryWithActiveType->id)
+        ->and($categoryIds)->not->toContain($categoryWithOnlyArchivedType->id);
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1230

### Technical Description

> Hide the display of a service request area in the self-service portal and in support assistant if there are no available types stored within it

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
