### PR TITLE
[AIDAPP-1232]: Enhance the management of client types

### DIFF
--- a/.cleanup-tasks/2026_06_11_contact_type_management_feature.md
+++ b/.cleanup-tasks/2026_06_11_contact_type_management_feature.md
@@ -24,7 +24,7 @@ Once the feature flag is removed, the application should behave as if the flag w
     - `app-modules/contact/src/Enums/SystemContactClassification.php`
     - `app-modules/contact/src/Enums/ContactTypeColorOptions.php`
 
-- Add a migration to drop the `classification` column from `contact_types` (it was only kept nullable for the flag-off fallback).
+- Add a migration to drop the `classification` column from `contact_types` (it was only kept nullable for the flag-off fallback). When you do, also remove the classification backfill and the `->string('classification')->nullable(false)->change()` restore from the `down()` of `2026_06_11_183351_add_is_default_to_contact_types_table.php` (see the `TODO: ContactTypeManagementFeature cleanup` comment there) — that column will no longer exist.
 
 - In `app-modules/contact/database/migrations/2026_06_11_183351_add_is_default_to_contact_types_table.php` (the combined setup migration): remove the `ContactTypeManagementFeature::activate()` / `deactivate()` calls and the `use App\Features\ContactTypeManagementFeature;` import. Do NOT delete the whole migration — it also adds the permanent `is_default` column and performs the one-time color data conversion. Leaving the flag class referenced here would fatal on `migrate:fresh` once the class is deleted.
 

--- a/.cleanup-tasks/2026_06_11_contact_type_management_feature.md
+++ b/.cleanup-tasks/2026_06_11_contact_type_management_feature.md
@@ -1,0 +1,47 @@
+---
+title: Contact Type Management Feature
+created: 2026-06-11
+---
+
+## Feature Flags
+
+- App\Features\ContactTypeManagementFeature
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+Search the codebase for `TODO: ContactTypeManagementFeature cleanup` for inline cleanup instructions at each point of change.
+
+Once the feature flag is removed, the application should behave as if the flag were always active (new `is_default` + `Color` enum behavior). Work through the following:
+
+- In `app-modules/contact/src/Models/ContactType.php`:
+    1. Remove the `'classification'` entry from `$fillable` and from `casts()`.
+    2. Replace the dynamic color cast `ContactTypeManagementFeature::active() ? Color::class : ContactTypeColorOptions::class` with `Color::class`.
+    3. Remove the `use AidingApp\Contact\Enums\SystemContactClassification;`, `use AidingApp\Contact\Enums\ContactTypeColorOptions;`, and `use App\Features\ContactTypeManagementFeature;` imports.
+
+- Delete the now-unused enums:
+    - `app-modules/contact/src/Enums/SystemContactClassification.php`
+    - `app-modules/contact/src/Enums/ContactTypeColorOptions.php`
+
+- Add a migration to drop the `classification` column from `contact_types` (it was only kept nullable for the flag-off fallback).
+
+- In `app-modules/contact/database/migrations/2026_06_11_183351_add_is_default_to_contact_types_table.php` (the combined setup migration): remove the `ContactTypeManagementFeature::activate()` / `deactivate()` calls and the `use App\Features\ContactTypeManagementFeature;` import. Do NOT delete the whole migration — it also adds the permanent `is_default` column and performs the one-time color data conversion. Leaving the flag class referenced here would fatal on `migrate:fresh` once the class is deleted.
+
+- In `app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/CreateContactType.php` and `EditContactType.php`: remove the old `classification` Select and the old `color` Select (the `->hidden(...)`/`->visible(...)` flag conditionals), keeping only the `ColorSelect` and the `is_default` Toggle unconditionally. Remove the feature flag and old enum imports.
+
+- In `app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/ListContactTypes.php` and `ViewContactType.php`: remove the `classification` column/entry and its `->visible(...)` guard; show the `is_default` column/entry and `color` badge unconditionally. Remove the feature flag import.
+
+- In `app-modules/contact/database/factories/ContactTypeFactory.php`: remove the `classification` definition and the feature flag conditional around `color`; always use `Color::cases()`. Remove the old enum and feature flag imports.
+
+- In `app-modules/contact/database/seeders/ContactTypeSeeder.php`: no flag conditional should remain (already seeds the new shape) — verify and remove any leftover references.
+
+- In `app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php` and `app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalRegisterController.php`: remove the `ContactTypeManagementFeature::active()` ternary, keeping only the `ContactType::resolveDefault()` path. Remove the `use AidingApp\Contact\Enums\SystemContactClassification;` and `use App\Features\ContactTypeManagementFeature;` imports.
+
+- In `app-modules/contact/src/Filament/Resources/ContactResource/Pages/CreateContact.php`: on the `type_id` Select, drop the `ContactTypeManagementFeature::active()` guard in `->default(...)` so it always defaults to `ContactType::resolveDefault()?->getKey()`. Remove the `use App\Features\ContactTypeManagementFeature;` import.
+
+- In `app-modules/contact/src/Imports/ContactImporter.php`: in the `type` column's `resolveUsing` closure, drop the `ContactTypeManagementFeature::active()` guard so a blank/unmatched type always falls back to `ContactType::resolveDefault()`. Remove the `use App\Features\ContactTypeManagementFeature;` import.
+
+- Update any tests that still exercise the flag-off (classification) path — notably `app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalRegisterControllerTest.php`, which seeds a ContactType via `'classification' => SystemContactClassification::New` (replace with `'is_default' => true`). Remove the `use AidingApp\Contact\Enums\SystemContactClassification;` import there.
+
+- Delete the feature flag class itself: `app/Features/ContactTypeManagementFeature.php`.

--- a/app-modules/contact/database/factories/ContactTypeFactory.php
+++ b/app-modules/contact/database/factories/ContactTypeFactory.php
@@ -39,6 +39,8 @@ namespace AidingApp\Contact\Database\Factories;
 use AidingApp\Contact\Enums\ContactTypeColorOptions;
 use AidingApp\Contact\Enums\SystemContactClassification;
 use AidingApp\Contact\Models\ContactType;
+use App\Features\ContactTypeManagementFeature;
+use CanyonGBS\Common\Enums\Color;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -51,7 +53,13 @@ class ContactTypeFactory extends Factory
         return [
             'classification' => $this->faker->randomElement(SystemContactClassification::cases()),
             'name' => $this->faker->word,
-            'color' => $this->faker->randomElement(ContactTypeColorOptions::cases()),
+            /*
+             * TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed:
+             * - Remove the `classification` line and the ternary; always use Color::cases().
+             */
+            'color' => ContactTypeManagementFeature::active()
+                ? $this->faker->randomElement(Color::cases())
+                : $this->faker->randomElement(ContactTypeColorOptions::cases()),
         ];
     }
 }

--- a/app-modules/contact/database/migrations/2026_06_11_183351_add_is_default_to_contact_types_table.php
+++ b/app-modules/contact/database/migrations/2026_06_11_183351_add_is_default_to_contact_types_table.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+use App\Features\ContactTypeManagementFeature;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * @var array<string, string>
+     */
+    private array $colorMap = [
+        'info' => 'blue',
+        'warning' => 'amber',
+        'success' => 'green',
+        'danger' => 'red',
+        'primary' => 'gray',
+    ];
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            Schema::table('contact_types', function (Blueprint $table) {
+                $table->boolean('is_default')->default(false);
+
+                /*
+                 * TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed:
+                 * - Drop the `classification` column entirely (a follow-up migration).
+                 * It is only kept (made nullable) here so the flag-off path can continue to
+                 * write/read classification while the feature is being rolled out.
+                 */
+                $table->string('classification')->nullable()->change();
+            });
+
+            foreach ($this->colorMap as $from => $to) {
+                DB::table('contact_types')
+                    ->where('color', $from)
+                    ->update(['color' => $to]);
+            }
+
+            ContactTypeManagementFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            ContactTypeManagementFeature::deactivate();
+
+            // 'primary' -> 'gray' is not reversible (both legacy 'primary' and 'gray'
+            // become 'gray'), so 'gray' rows are left untouched on rollback.
+            $reverse = [
+                'blue' => 'info',
+                'amber' => 'warning',
+                'green' => 'success',
+                'red' => 'danger',
+            ];
+
+            foreach ($reverse as $from => $to) {
+                DB::table('contact_types')
+                    ->where('color', $from)
+                    ->update(['color' => $to]);
+            }
+
+            Schema::table('contact_types', function (Blueprint $table) {
+                $table->dropColumn('is_default');
+
+                $table->string('classification')->nullable(false)->change();
+            });
+        });
+    }
+};

--- a/app-modules/contact/database/migrations/2026_06_11_183351_add_is_default_to_contact_types_table.php
+++ b/app-modules/contact/database/migrations/2026_06_11_183351_add_is_default_to_contact_types_table.php
@@ -96,6 +96,21 @@ return new class () extends Migration {
                     ->update(['color' => $to]);
             }
 
+            DB::table('contact_types')
+                ->whereNotIn('color', ['info', 'warning', 'success', 'danger', 'primary', 'gray'])
+                ->update(['color' => 'gray']);
+
+            /*
+             * TODO: ContactTypeManagementFeature cleanup — when the feature flag is removed and a
+             * migration is added to drop the `classification` column, delete this classification
+             * backfill and the `->string('classification')->nullable(false)->change()` restore below
+             * (the column will no longer exist). The color reversal above stays — it reverses the
+             * permanent color conversion, not the flag.
+             */
+            DB::table('contact_types')
+                ->whereNull('classification')
+                ->update(['classification' => 'new']);
+
             Schema::table('contact_types', function (Blueprint $table) {
                 $table->dropColumn('is_default');
 

--- a/app-modules/contact/src/Filament/Resources/ContactResource/Pages/CreateContact.php
+++ b/app-modules/contact/src/Filament/Resources/ContactResource/Pages/CreateContact.php
@@ -40,6 +40,7 @@ use AidingApp\Contact\Filament\Resources\ContactResource;
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Contact\Models\ContactType;
 use AidingApp\Contact\Models\Organization;
+use App\Features\ContactTypeManagementFeature;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -146,6 +147,11 @@ class CreateContact extends CreateRecord
                         ->label('Type')
                         ->required()
                         ->relationship('type', 'name')
+                        // TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed,
+                        // drop the active() guard and always default to ContactType::resolveDefault().
+                        ->default(fn () => ContactTypeManagementFeature::active()
+                            ? ContactType::resolveDefault()?->getKey()
+                            : null)
                         ->exists(
                             table: (new ContactType())->getTable(),
                             column: (new ContactType())->getKeyName()

--- a/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/CreateContactType.php
+++ b/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/CreateContactType.php
@@ -39,8 +39,12 @@ namespace AidingApp\Contact\Filament\Resources\ContactTypeResource\Pages;
 use AidingApp\Contact\Enums\ContactTypeColorOptions;
 use AidingApp\Contact\Enums\SystemContactClassification;
 use AidingApp\Contact\Filament\Resources\ContactTypeResource;
+use AidingApp\Contact\Models\ContactType;
+use App\Features\ContactTypeManagementFeature;
+use CanyonGBS\Common\Filament\Forms\Components\ColorSelect;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Schema;
 
@@ -48,6 +52,11 @@ class CreateContactType extends CreateRecord
 {
     protected static string $resource = ContactTypeResource::class;
 
+    /*
+     * TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed:
+     * - Delete the `classification` Select and the legacy `color` Select below.
+     * - Drop the `->visible(...)` guards on ColorSelect and the `is_default` Toggle.
+     */
     public function form(Schema $schema): Schema
     {
         return $schema
@@ -61,13 +70,42 @@ class CreateContactType extends CreateRecord
                     ->searchable()
                     ->options(SystemContactClassification::class)
                     ->required()
-                    ->enum(SystemContactClassification::class),
+                    ->enum(SystemContactClassification::class)
+                    ->hidden(ContactTypeManagementFeature::active()),
                 Select::make('color')
                     ->label('Color')
                     ->searchable()
                     ->options(ContactTypeColorOptions::class)
                     ->required()
-                    ->enum(ContactTypeColorOptions::class),
+                    ->enum(ContactTypeColorOptions::class)
+                    ->hidden(ContactTypeManagementFeature::active()),
+                ColorSelect::make()
+                    ->required()
+                    ->visible(ContactTypeManagementFeature::active()),
+                Toggle::make('is_default')
+                    ->label('Default')
+                    ->live()
+                    ->hint(function (?ContactType $record, $state): ?string {
+                        if ($record?->is_default) {
+                            return null;
+                        }
+
+                        if (! $state) {
+                            return null;
+                        }
+
+                        $currentDefault = ContactType::query()
+                            ->where('is_default', true)
+                            ->value('name');
+
+                        if (blank($currentDefault)) {
+                            return null;
+                        }
+
+                        return "The current default type is '{$currentDefault}', you are replacing it.";
+                    })
+                    ->hintColor('danger')
+                    ->visible(ContactTypeManagementFeature::active()),
             ]);
     }
 }

--- a/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/CreateContactType.php
+++ b/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/CreateContactType.php
@@ -85,7 +85,7 @@ class CreateContactType extends CreateRecord
                 Toggle::make('is_default')
                     ->label('Default')
                     ->live()
-                    ->hint(function (?ContactType $record, $state): ?string {
+                    ->hint(function (?ContactType $record, ?bool $state): ?string {
                         if ($record?->is_default) {
                             return null;
                         }

--- a/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/EditContactType.php
+++ b/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/EditContactType.php
@@ -90,7 +90,7 @@ class EditContactType extends EditRecord
                 Toggle::make('is_default')
                     ->label('Default')
                     ->live()
-                    ->hint(function (?ContactType $record, $state): ?string {
+                    ->hint(function (?ContactType $record, ?bool $state): ?string {
                         if ($record?->is_default) {
                             return null;
                         }

--- a/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/EditContactType.php
+++ b/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/EditContactType.php
@@ -39,11 +39,15 @@ namespace AidingApp\Contact\Filament\Resources\ContactTypeResource\Pages;
 use AidingApp\Contact\Enums\ContactTypeColorOptions;
 use AidingApp\Contact\Enums\SystemContactClassification;
 use AidingApp\Contact\Filament\Resources\ContactTypeResource;
+use AidingApp\Contact\Models\ContactType;
 use App\Concerns\EditPageRedirection;
+use App\Features\ContactTypeManagementFeature;
+use CanyonGBS\Common\Filament\Forms\Components\ColorSelect;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Schemas\Schema;
 
@@ -53,6 +57,11 @@ class EditContactType extends EditRecord
 
     protected static string $resource = ContactTypeResource::class;
 
+    /*
+     * TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed:
+     * - Delete the `classification` Select and the legacy `color` Select below.
+     * - Drop the `->visible(...)` guards on ColorSelect and the `is_default` Toggle.
+     */
     public function form(Schema $schema): Schema
     {
         return $schema
@@ -66,13 +75,42 @@ class EditContactType extends EditRecord
                     ->searchable()
                     ->options(SystemContactClassification::class)
                     ->required()
-                    ->enum(SystemContactClassification::class),
+                    ->enum(SystemContactClassification::class)
+                    ->hidden(ContactTypeManagementFeature::active()),
                 Select::make('color')
                     ->label('Color')
                     ->searchable()
                     ->options(ContactTypeColorOptions::class)
                     ->required()
-                    ->enum(ContactTypeColorOptions::class),
+                    ->enum(ContactTypeColorOptions::class)
+                    ->hidden(ContactTypeManagementFeature::active()),
+                ColorSelect::make()
+                    ->required()
+                    ->visible(ContactTypeManagementFeature::active()),
+                Toggle::make('is_default')
+                    ->label('Default')
+                    ->live()
+                    ->hint(function (?ContactType $record, $state): ?string {
+                        if ($record?->is_default) {
+                            return null;
+                        }
+
+                        if (! $state) {
+                            return null;
+                        }
+
+                        $currentDefault = ContactType::query()
+                            ->where('is_default', true)
+                            ->value('name');
+
+                        if (blank($currentDefault)) {
+                            return null;
+                        }
+
+                        return "The current default type is '{$currentDefault}', you are replacing it.";
+                    })
+                    ->hintColor('danger')
+                    ->visible(ContactTypeManagementFeature::active()),
             ]);
     }
 

--- a/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/ListContactTypes.php
+++ b/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/ListContactTypes.php
@@ -38,6 +38,7 @@ namespace AidingApp\Contact\Filament\Resources\ContactTypeResource\Pages;
 
 use AidingApp\Contact\Filament\Resources\ContactTypeResource;
 use AidingApp\Contact\Models\ContactType;
+use App\Features\ContactTypeManagementFeature;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
@@ -45,6 +46,7 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Resources\Pages\ListRecords;
+use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 
@@ -52,6 +54,10 @@ class ListContactTypes extends ListRecords
 {
     protected static string $resource = ContactTypeResource::class;
 
+    /*
+     * TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed:
+     * - Delete the `classification` column and the `->visible(...)` guard on `is_default`.
+     */
     public function table(Table $table): Table
     {
         return $table
@@ -64,11 +70,16 @@ class ListContactTypes extends ListRecords
                 TextColumn::make('classification')
                     ->label('Classification')
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->visible(! ContactTypeManagementFeature::active()),
                 TextColumn::make('color')
                     ->label('Color')
                     ->badge()
                     ->color(fn (ContactType $contactType) => $contactType->color->value),
+                IconColumn::make('is_default')
+                    ->label('Default')
+                    ->boolean()
+                    ->visible(ContactTypeManagementFeature::active()),
                 TextColumn::make('contacts_count')
                     ->label('# of Contacts')
                     ->counts('contacts')

--- a/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/ViewContactType.php
+++ b/app-modules/contact/src/Filament/Resources/ContactTypeResource/Pages/ViewContactType.php
@@ -38,7 +38,9 @@ namespace AidingApp\Contact\Filament\Resources\ContactTypeResource\Pages;
 
 use AidingApp\Contact\Filament\Resources\ContactTypeResource;
 use AidingApp\Contact\Models\ContactType;
+use App\Features\ContactTypeManagementFeature;
 use Filament\Actions\EditAction;
+use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Section;
@@ -48,6 +50,10 @@ class ViewContactType extends ViewRecord
 {
     protected static string $resource = ContactTypeResource::class;
 
+    /*
+     * TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed:
+     * - Delete the `classification` entry and the `->visible(...)` guard on `is_default`.
+     */
     public function infolist(Schema $schema): Schema
     {
         return $schema
@@ -57,11 +63,16 @@ class ViewContactType extends ViewRecord
                         TextEntry::make('name')
                             ->label('Name'),
                         TextEntry::make('classification')
-                            ->label('Classification'),
+                            ->label('Classification')
+                            ->visible(! ContactTypeManagementFeature::active()),
                         TextEntry::make('color')
                             ->label('Color')
                             ->badge()
                             ->color(fn (ContactType $contactType) => $contactType->color->value),
+                        IconEntry::make('is_default')
+                            ->label('Default')
+                            ->boolean()
+                            ->visible(ContactTypeManagementFeature::active()),
                     ])
                     ->columns(),
             ]);

--- a/app-modules/contact/src/Imports/ContactImporter.php
+++ b/app-modules/contact/src/Imports/ContactImporter.php
@@ -140,7 +140,6 @@ class ContactImporter extends Importer
         /** @var User $user */
         $user = $this->import->user;
 
-        $record->assignedTo()->associate($user);
         $record->createdBy()->associate($user);
     }
 

--- a/app-modules/contact/src/Imports/ContactImporter.php
+++ b/app-modules/contact/src/Imports/ContactImporter.php
@@ -38,6 +38,7 @@ namespace AidingApp\Contact\Imports;
 
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Contact\Models\ContactType;
+use App\Features\ContactTypeManagementFeature;
 use App\Models\User;
 use Filament\Actions\Imports\ImportColumn;
 use Filament\Actions\Imports\Importer;
@@ -69,13 +70,25 @@ class ContactImporter extends Importer
                 ->example('John'),
             ImportColumn::make('type')
                 ->relationship(
-                    resolveUsing: fn (mixed $state) => ContactType::query()
-                        ->when(
-                            Str::isUuid($state),
-                            fn (Builder $query) => $query->whereKey($state),
-                            fn (Builder $query) => $query->where('name', $state),
-                        )
-                        ->first(),
+                    resolveUsing: function (mixed $state): ?ContactType {
+                        $type = ContactType::query()
+                            ->when(
+                                Str::isUuid($state),
+                                fn (Builder $query) => $query->whereKey($state),
+                                fn (Builder $query) => $query->where('name', $state),
+                            )
+                            ->first();
+
+                        /*
+                         * TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed,
+                         * drop the active() guard and always fall back to ContactType::resolveDefault().
+                         */
+                        if ($type === null && ContactTypeManagementFeature::active()) {
+                            return ContactType::resolveDefault();
+                        }
+
+                        return $type;
+                    },
                 )
                 ->guess(['type_id', 'type_name'])
                 ->requiredMapping()

--- a/app-modules/contact/src/Models/ContactType.php
+++ b/app-modules/contact/src/Models/ContactType.php
@@ -40,8 +40,12 @@ use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\Contact\Database\Factories\ContactTypeFactory;
 use AidingApp\Contact\Enums\ContactTypeColorOptions;
 use AidingApp\Contact\Enums\SystemContactClassification;
+use AidingApp\Contact\Observers\ContactTypeObserver;
+use App\Features\ContactTypeManagementFeature;
 use App\Models\BaseModel;
+use CanyonGBS\Common\Enums\Color;
 use DateTimeInterface;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -50,6 +54,7 @@ use OwenIt\Auditing\Contracts\Auditable;
 /**
  * @mixin IdeHelperContactType
  */
+#[ObservedBy([ContactTypeObserver::class])]
 class ContactType extends BaseModel implements Auditable
 {
     use SoftDeletes;
@@ -62,12 +67,19 @@ class ContactType extends BaseModel implements Auditable
         'classification',
         'name',
         'color',
+        'is_default',
     ];
 
-    protected $casts = [
-        'classification' => SystemContactClassification::class,
-        'color' => ContactTypeColorOptions::class,
-    ];
+    /**
+     * Resolve the ContactType used when one must be assigned without an explicit
+     * selection (e.g. inbound email, portal self-registration): the configured
+     * default, otherwise the oldest non-trashed type.
+     */
+    public static function resolveDefault(): ?self
+    {
+        return static::query()->where('is_default', true)->first()
+            ?? static::query()->oldest()->first();
+    }
 
     /**
      * @return HasMany<Contact, $this>
@@ -80,6 +92,23 @@ class ContactType extends BaseModel implements Auditable
     public function getTable()
     {
         return 'contact_types';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'classification' => SystemContactClassification::class,
+            /*
+             * TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed:
+             * - Replace this ternary with `'color' => Color::class,`
+             * - Drop the SystemContactClassification cast (and the column) entirely.
+             */
+            'color' => ContactTypeManagementFeature::active() ? Color::class : ContactTypeColorOptions::class,
+            'is_default' => 'boolean',
+        ];
     }
 
     protected function serializeDate(DateTimeInterface $date): string

--- a/app-modules/contact/src/Observers/ContactTypeObserver.php
+++ b/app-modules/contact/src/Observers/ContactTypeObserver.php
@@ -34,33 +34,25 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Contact\Database\Seeders;
+namespace AidingApp\Contact\Observers;
 
 use AidingApp\Contact\Models\ContactType;
-use CanyonGBS\Common\Enums\Color;
-use Illuminate\Database\Seeder;
 
-class ContactTypeSeeder extends Seeder
+class ContactTypeObserver
 {
-    public function run(): void
+    public function saving(ContactType $contactType): void
     {
-        // No type is seeded as the default — each institution sets its own.
-        // When none is_default, ContactType::resolveDefault() falls back to the
-        // first (oldest) entry, which will be 'Student'.
-        ContactType::factory()
-            ->createMany(
-                [
-                    [
-                        'name' => 'Student',
-                        'color' => Color::Green->value,
-                        'is_default' => false,
-                    ],
-                    [
-                        'name' => 'Employee',
-                        'color' => Color::Blue->value,
-                        'is_default' => false,
-                    ],
-                ]
-            );
+        if ($contactType->is_default) {
+            ContactType::query()
+                ->where('is_default', true)
+                ->update(['is_default' => false]);
+        }
+    }
+
+    public function deleted(ContactType $contactType): void
+    {
+        if ($contactType->is_default) {
+            $contactType->updateQuietly(['is_default' => false]);
+        }
     }
 }

--- a/app-modules/contact/tests/Tenant/ContactType/ContactTypeDefaultTest.php
+++ b/app-modules/contact/tests/Tenant/ContactType/ContactTypeDefaultTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Contact\Models\ContactType;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function PHPUnit\Framework\assertNull;
+use function PHPUnit\Framework\assertTrue;
+
+test('only one ContactType can be the default at a time', function () {
+    $first = ContactType::factory()->create(['is_default' => true]);
+    $second = ContactType::factory()->create(['is_default' => true]);
+
+    assertTrue($second->fresh()->is_default);
+    expect($first->fresh()->is_default)->toBeFalse();
+
+    assertDatabaseHas(ContactType::class, ['id' => $second->id, 'is_default' => true]);
+    assertDatabaseHas(ContactType::class, ['id' => $first->id, 'is_default' => false]);
+});
+
+test('promoting an existing ContactType to default unsets the previous default', function () {
+    $original = ContactType::factory()->create(['is_default' => true]);
+    $other = ContactType::factory()->create(['is_default' => false]);
+
+    $other->update(['is_default' => true]);
+
+    expect($other->fresh()->is_default)->toBeTrue()
+        ->and($original->fresh()->is_default)->toBeFalse();
+});
+
+test('soft deleting the default ContactType unsets the default flag', function () {
+    $default = ContactType::factory()->create(['is_default' => true]);
+
+    $default->delete();
+
+    expect($default->fresh()->is_default)->toBeFalse()
+        ->and($default->fresh()->trashed())->toBeTrue();
+});
+
+test('resolveDefault returns the configured default when one exists', function () {
+    ContactType::factory()->create(['is_default' => false]);
+    $default = ContactType::factory()->create(['is_default' => true]);
+    ContactType::factory()->create(['is_default' => false]);
+
+    expect(ContactType::resolveDefault()->is($default))->toBeTrue();
+});
+
+test('resolveDefault falls back to the oldest type when no default is set', function () {
+    $oldest = ContactType::factory()->create(['is_default' => false, 'created_at' => now()->subDay()]);
+    ContactType::factory()->create(['is_default' => false, 'created_at' => now()]);
+
+    expect(ContactType::resolveDefault()->is($oldest))->toBeTrue();
+});
+
+test('resolveDefault returns null when no types exist', function () {
+    assertNull(ContactType::resolveDefault());
+});

--- a/app-modules/contact/tests/Tenant/ContactType/EditContactTypeTest.php
+++ b/app-modules/contact/tests/Tenant/ContactType/EditContactTypeTest.php
@@ -65,7 +65,6 @@ test('A successful action on the EditContactType page', function () {
         'record' => $contactType->getRouteKey(),
     ])
         ->assertFormSet([
-            'classification' => $contactType->classification,
             'name' => $contactType->name,
             'color' => $contactType->color,
         ])
@@ -74,7 +73,6 @@ test('A successful action on the EditContactType page', function () {
         ->assertHasNoFormErrors();
 
     assertEquals($editRequest['name'], $contactType->fresh()->name);
-    assertEquals($editRequest['classification'], $contactType->fresh()->classification);
     assertEquals($editRequest['color'], $contactType->fresh()->color);
 });
 
@@ -87,7 +85,6 @@ test('EditContactType requires valid data', function (EditContactTypeRequestFact
         'record' => $contactType->getRouteKey(),
     ])
         ->assertFormSet([
-            'classification' => $contactType->classification,
             'name' => $contactType->name,
             'color' => $contactType->color,
         ])

--- a/app-modules/contact/tests/Tenant/ContactType/ListContactTypesTest.php
+++ b/app-modules/contact/tests/Tenant/ContactType/ListContactTypesTest.php
@@ -74,11 +74,6 @@ test('The correct details are displayed on the ListContactTypes page', function 
                 $contactType
             )
             ->assertTableColumnFormattedStateSet(
-                'classification',
-                $contactType->classification->getLabel(),
-                $contactType
-            )
-            ->assertTableColumnFormattedStateSet(
                 'color',
                 $contactType->color->getLabel(),
                 $contactType

--- a/app-modules/contact/tests/Tenant/ContactType/RequestFactories/CreateContactTypeRequestFactory.php
+++ b/app-modules/contact/tests/Tenant/ContactType/RequestFactories/CreateContactTypeRequestFactory.php
@@ -36,8 +36,7 @@
 
 namespace AidingApp\Contact\Tests\Tenant\ContactType\RequestFactories;
 
-use AidingApp\Contact\Enums\ContactTypeColorOptions;
-use AidingApp\Contact\Enums\SystemContactClassification;
+use CanyonGBS\Common\Enums\Color;
 use Worksome\RequestFactories\RequestFactory;
 
 class CreateContactTypeRequestFactory extends RequestFactory
@@ -45,9 +44,8 @@ class CreateContactTypeRequestFactory extends RequestFactory
     public function definition(): array
     {
         return [
-            'classification' => fake()->randomElement(SystemContactClassification::cases()),
             'name' => fake()->name(),
-            'color' => fake()->randomElement(ContactTypeColorOptions::cases()),
+            'color' => fake()->randomElement(Color::cases()),
         ];
     }
 }

--- a/app-modules/contact/tests/Tenant/ContactType/RequestFactories/EditContactTypeRequestFactory.php
+++ b/app-modules/contact/tests/Tenant/ContactType/RequestFactories/EditContactTypeRequestFactory.php
@@ -36,8 +36,7 @@
 
 namespace AidingApp\Contact\Tests\Tenant\ContactType\RequestFactories;
 
-use AidingApp\Contact\Enums\ContactTypeColorOptions;
-use AidingApp\Contact\Enums\SystemContactClassification;
+use CanyonGBS\Common\Enums\Color;
 use Worksome\RequestFactories\RequestFactory;
 
 class EditContactTypeRequestFactory extends RequestFactory
@@ -45,9 +44,8 @@ class EditContactTypeRequestFactory extends RequestFactory
     public function definition(): array
     {
         return [
-            'classification' => fake()->randomElement(SystemContactClassification::cases()),
             'name' => fake()->name(),
-            'color' => fake()->randomElement(ContactTypeColorOptions::cases()),
+            'color' => fake()->randomElement(Color::cases()),
         ];
     }
 }

--- a/app-modules/contact/tests/Tenant/ContactType/ResolveDefaultContactTypeTest.php
+++ b/app-modules/contact/tests/Tenant/ContactType/ResolveDefaultContactTypeTest.php
@@ -36,39 +36,7 @@
 
 use AidingApp\Contact\Models\ContactType;
 
-use function Pest\Laravel\assertDatabaseHas;
 use function PHPUnit\Framework\assertNull;
-use function PHPUnit\Framework\assertTrue;
-
-test('only one ContactType can be the default at a time', function () {
-    $first = ContactType::factory()->create(['is_default' => true]);
-    $second = ContactType::factory()->create(['is_default' => true]);
-
-    assertTrue($second->fresh()->is_default);
-    expect($first->fresh()->is_default)->toBeFalse();
-
-    assertDatabaseHas(ContactType::class, ['id' => $second->id, 'is_default' => true]);
-    assertDatabaseHas(ContactType::class, ['id' => $first->id, 'is_default' => false]);
-});
-
-test('promoting an existing ContactType to default unsets the previous default', function () {
-    $original = ContactType::factory()->create(['is_default' => true]);
-    $other = ContactType::factory()->create(['is_default' => false]);
-
-    $other->update(['is_default' => true]);
-
-    expect($other->fresh()->is_default)->toBeTrue()
-        ->and($original->fresh()->is_default)->toBeFalse();
-});
-
-test('soft deleting the default ContactType unsets the default flag', function () {
-    $default = ContactType::factory()->create(['is_default' => true]);
-
-    $default->delete();
-
-    expect($default->fresh()->is_default)->toBeFalse()
-        ->and($default->fresh()->trashed())->toBeTrue();
-});
 
 test('resolveDefault returns the configured default when one exists', function () {
     ContactType::factory()->create(['is_default' => false]);

--- a/app-modules/contact/tests/Tenant/ContactType/ViewContactTypeTest.php
+++ b/app-modules/contact/tests/Tenant/ContactType/ViewContactTypeTest.php
@@ -56,10 +56,9 @@ test('The correct details are displayed on the ViewContactType page', function (
             [
                 'Name',
                 $contactType->name,
-                'Classification',
-                $contactType->classification->getLabel(),
                 'Color',
-                $contactType->color,
+                $contactType->color->getLabel(),
+                'Default',
             ]
         );
 });

--- a/app-modules/contact/tests/Tenant/Observers/ContactTypeObserverTest.php
+++ b/app-modules/contact/tests/Tenant/Observers/ContactTypeObserverTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Contact\Models\ContactType;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function PHPUnit\Framework\assertTrue;
+
+test('only one ContactType can be the default at a time', function () {
+    $first = ContactType::factory()->create(['is_default' => true]);
+    $second = ContactType::factory()->create(['is_default' => true]);
+
+    assertTrue($second->fresh()->is_default);
+    expect($first->fresh()->is_default)->toBeFalse();
+
+    assertDatabaseHas(ContactType::class, ['id' => $second->id, 'is_default' => true]);
+    assertDatabaseHas(ContactType::class, ['id' => $first->id, 'is_default' => false]);
+});
+
+test('promoting an existing ContactType to default unsets the previous default', function () {
+    $original = ContactType::factory()->create(['is_default' => true]);
+    $other = ContactType::factory()->create(['is_default' => false]);
+
+    $other->update(['is_default' => true]);
+
+    expect($other->fresh()->is_default)->toBeTrue()
+        ->and($original->fresh()->is_default)->toBeFalse();
+});
+
+test('soft deleting the default ContactType unsets the default flag', function () {
+    $default = ContactType::factory()->create(['is_default' => true]);
+
+    $default->delete();
+
+    expect($default->fresh()->is_default)->toBeFalse()
+        ->and($default->fresh()->trashed())->toBeTrue();
+});

--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -53,6 +53,7 @@ use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\TenantServiceRequestTypeDomain;
+use App\Features\ContactTypeManagementFeature;
 use App\Models\Tenant;
 use Aws\Crypto\KmsMaterialsProviderV3;
 use Aws\Kms\KmsClient;
@@ -595,9 +596,15 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
             'full_name' => $firstName . ' ' . $lastName,
         ]);
 
-        $type = ContactType::query()
-            ->where('classification', SystemContactClassification::New)
-            ->firstOrFail();
+        /*
+         * TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed:
+         * - Keep only the ContactType::resolveDefault() branch and drop the classification query.
+         */
+        $type = ContactTypeManagementFeature::active()
+            ? ContactType::resolveDefault()
+            : ContactType::query()
+                ->where('classification', SystemContactClassification::New)
+                ->firstOrFail();
 
         $contact->type()->associate($type);
 

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalRegisterController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalRegisterController.php
@@ -44,6 +44,7 @@ use AidingApp\Portal\Actions\FindOrganizationByEmailDomain;
 use AidingApp\Portal\Http\Requests\KnowledgeManagementPortalRegisterRequest;
 use AidingApp\Portal\Models\PortalAuthentication;
 use AidingApp\Portal\Settings\PortalSettings;
+use App\Features\ContactTypeManagementFeature;
 use App\Http\Controllers\Controller;
 use App\Settings\LicenseSettings;
 use Illuminate\Http\JsonResponse;
@@ -74,9 +75,15 @@ class KnowledgeManagementPortalRegisterController extends Controller
                 'phone' => $data['phone'] ?? null,
                 'sms_opt_out' => $data['sms_opt_out'],
             ]);
-        $type = ContactType::query()
-            ->where('classification', SystemContactClassification::New)
-            ->first();
+        /*
+         * TODO: ContactTypeManagementFeature cleanup — once the feature flag is removed:
+         * - Keep only the ContactType::resolveDefault() branch and drop the classification query.
+         */
+        $type = ContactTypeManagementFeature::active()
+            ? ContactType::resolveDefault()
+            : ContactType::query()
+                ->where('classification', SystemContactClassification::New)
+                ->first();
 
         $organization = app(FindOrganizationByEmailDomain::class)($data['email']);
 

--- a/app/Features/ContactTypeManagementFeature.php
+++ b/app/Features/ContactTypeManagementFeature.php
@@ -34,33 +34,14 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Contact\Database\Seeders;
+namespace App\Features;
 
-use AidingApp\Contact\Models\ContactType;
-use CanyonGBS\Common\Enums\Color;
-use Illuminate\Database\Seeder;
+use App\Support\AbstractFeatureFlag;
 
-class ContactTypeSeeder extends Seeder
+class ContactTypeManagementFeature extends AbstractFeatureFlag
 {
-    public function run(): void
+    public function resolve(mixed $scope): mixed
     {
-        // No type is seeded as the default — each institution sets its own.
-        // When none is_default, ContactType::resolveDefault() falls back to the
-        // first (oldest) entry, which will be 'Student'.
-        ContactType::factory()
-            ->createMany(
-                [
-                    [
-                        'name' => 'Student',
-                        'color' => Color::Green->value,
-                        'is_default' => false,
-                    ],
-                    [
-                        'name' => 'Employee',
-                        'color' => Color::Blue->value,
-                        'is_default' => false,
-                    ],
-                ]
-            );
+        return false;
     }
 }

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -45,6 +45,7 @@ use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
+use App\Features\ContactTypeManagementFeature;
 use App\Features\ServiceRequestTypeEmailPreferenceFeature;
 use App\Models\User;
 use Illuminate\Support\Facades\Artisan;
@@ -322,6 +323,57 @@ describe('2026_06_05_193725_add_citext_unique_to_service_request_statuses_name',
                     ->and($openBacklog->fresh()->name)->toBe('Backlog-2')
                     ->and($closedBacklog->fresh()->deleted_at)->toBeNull()
                     ->and($openBacklog->fresh()->deleted_at)->toBeNull();
+            }
+        );
+    });
+});
+
+describe('2026_06_11_183351_add_is_default_to_contact_types_table', function () {
+    it('converts legacy semantic contact type colors, adds is_default and activates the feature', function () {
+        isolatedMigration(
+            '2026_06_11_183351_add_is_default_to_contact_types_table',
+            function () {
+                $legacyColors = [
+                    'info' => 'blue',
+                    'warning' => 'amber',
+                    'success' => 'green',
+                    'danger' => 'red',
+                    'primary' => 'gray',
+                    'gray' => 'gray',
+                ];
+
+                $ids = [];
+
+                foreach (array_keys($legacyColors) as $legacyColor) {
+                    $id = (string) Str::orderedUuid();
+                    $ids[$legacyColor] = $id;
+
+                    DB::table('contact_types')->insert([
+                        'id' => $id,
+                        'classification' => 'new',
+                        'name' => "Type {$legacyColor}",
+                        'color' => $legacyColor,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ]);
+                }
+
+                expect(ContactTypeManagementFeature::active())->toBeFalse();
+
+                $migrate = Artisan::call('migrate', [
+                    '--path' => 'app-modules/contact/database/migrations/2026_06_11_183351_add_is_default_to_contact_types_table.php',
+                ]);
+
+                expect($migrate)->toBe(Command::SUCCESS);
+
+                foreach ($legacyColors as $legacyColor => $expectedColor) {
+                    expect(DB::table('contact_types')->where('id', $ids[$legacyColor])->value('color'))
+                        ->toBe($expectedColor)
+                        ->and(DB::table('contact_types')->where('id', $ids[$legacyColor])->value('is_default'))
+                        ->toBeFalsy();
+                }
+
+                expect(ContactTypeManagementFeature::active())->toBeTrue();
             }
         );
     });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1232

### Technical Description

> Implement Contact Type Management feature Introduced a new feature flag for managing contact types. Removed the 'classification' field from the ContactType model and related components. Updated the ContactType model to include an 'is_default' boolean field. Added a migration to handle the addition of the 'is_default' field and the removal of legacy color classifications. Refactored the ContactTypeFactory, Seeder, and Filament resources to align with the new structure. Implemented a ContactTypeObserver to ensure only one contact type can be marked as default. Updated tests to reflect changes in the contact type structure and behavior.
> Also fixes a pre-existing bug where `ContactImporter` wrote to the dropped `assigned_to_id` column, breaking every import.

### Any deployment steps required?

> No

### Cleanup Tasks

> `.cleanup-tasks/2026_06_11_contact_type_management_feature.md`

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
