### PR TITLE
[AIDAPP-1235]: Add failure retry logic to the Support Assistant

### DIFF
--- a/app-modules/ai/routes/widgets.php
+++ b/app-modules/ai/routes/widgets.php
@@ -48,6 +48,7 @@ use AidingApp\Ai\Http\Controllers\AssistantWidget\GetWidgetConfigController;
 use AidingApp\Ai\Http\Controllers\AssistantWidget\ListConversationMessagesController;
 use AidingApp\Ai\Http\Controllers\AssistantWidget\RequestAuthenticationController;
 use AidingApp\Ai\Http\Controllers\AssistantWidget\RequestServiceRequestConversationController;
+use AidingApp\Ai\Http\Controllers\AssistantWidget\RetryMessageController;
 use AidingApp\Ai\Http\Controllers\AssistantWidget\SendConversationMessageController;
 use AidingApp\Ai\Http\Controllers\AssistantWidget\SendMessageController;
 use AidingApp\Ai\Http\Controllers\AssistantWidget\ServeWidgetAssetController;
@@ -91,6 +92,9 @@ Route::middleware([
 
                         Route::post('messages', SendMessageController::class)
                             ->name('messages');
+
+                        Route::post('messages/retry', RetryMessageController::class)
+                            ->name('messages.retry');
 
                         Route::get('service-request-types', GetServiceRequestTypesController::class)
                             ->middleware(['auth:sanctum'])

--- a/app-modules/ai/src/Http/Controllers/AssistantWidget/GetWidgetConfigController.php
+++ b/app-modules/ai/src/Http/Controllers/AssistantWidget/GetWidgetConfigController.php
@@ -67,6 +67,7 @@ class GetWidgetConfigController extends Controller
             'asset_url' => route('widgets.assistant.asset') . '/',
             'js' => route('widgets.assistant.asset', ['file' => $widgetEntry['file']]),
             'send_message_url' => route('widgets.assistant.api.messages'),
+            'retry_message_url' => route('widgets.assistant.api.messages.retry'),
             'websockets_config' => $websocketsConfig,
             'auth_endpoint' => route('widgets.assistant.api.broadcasting.auth'),
             'primary_color' => collect(Color::all()[$settings->knowledge_management_portal_primary_color->value ?? 'blue'])

--- a/app-modules/ai/src/Http/Controllers/AssistantWidget/RetryMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/AssistantWidget/RetryMessageController.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AidingApp\Ai\Http\Controllers\AssistantWidget;
+
+use AidingApp\Ai\Jobs\PortalAssistant\RetryMessage;
+use AidingApp\Ai\Models\PortalAssistantThread;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+
+class RetryMessageController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'content' => ['required', 'string', 'max:25000'],
+            'thread_id' => ['required', 'uuid'],
+            'guest_token' => ['nullable', 'uuid'],
+        ]);
+
+        $author = auth('contact')->user();
+
+        $thread = PortalAssistantThread::query()
+            ->whereKey($data['thread_id'])
+            ->firstOrFail();
+
+        if ($author) {
+            if ($thread->author_type && $thread->author_id && ! $thread->author()->is($author)) {
+                abort(403, 'You do not have access to this thread.');
+            }
+        } else {
+            if ($thread->author_type || $thread->author_id) {
+                abort(403, 'You do not have access to this thread.');
+            }
+
+            if (filled($data['guest_token'] ?? null)) {
+                if ($thread->guest_token !== $data['guest_token']) {
+                    abort(403, 'Invalid guest token.');
+                }
+            } else {
+                abort(403, 'You do not have access to this thread.');
+            }
+        }
+
+        dispatch(new RetryMessage(
+            $thread,
+            $data['content'],
+            request: [
+                'headers' => Arr::only(
+                    request()->headers->all(),
+                    ['host', 'sec-ch-ua', 'user-agent', 'sec-ch-ua-platform', 'origin', 'referer', 'accept-language'],
+                ),
+                'ip' => request()->ip(),
+            ],
+        ))->onConnection('background');
+
+        return response()->json([
+            'message' => 'Message dispatched for processing via websockets.',
+            'thread_id' => $thread->getKey(),
+            'guest_token' => $thread->guest_token,
+        ]);
+    }
+}

--- a/app-modules/ai/src/Jobs/PortalAssistant/RetryMessage.php
+++ b/app-modules/ai/src/Jobs/PortalAssistant/RetryMessage.php
@@ -55,7 +55,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
-use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Prism\Prism\ValueObjects\ToolResult;
 use Throwable;
@@ -110,111 +109,107 @@ class RetryMessage implements ShouldQueue
                 ...(filled($message->internal_content) ? [new DeveloperMessage($message->internal_content)] : []),
             ];
 
-            retry(3, function () use ($aiService, $context, $nextRequestOptions, $messages) {
-                $stream = $aiService->streamRaw(
-                    prompt: $context,
-                    files: KnowledgeBaseItem::query()->tap(app(KnowledgeBasePortalAssistantItem::class))->get(['id'])->all(),
-                    options: $nextRequestOptions,
-                    messages: $messages,
-                    reasoningEffort: AiReasoningEffort::Minimal,
-                );
+            $stream = $aiService->streamRaw(
+                prompt: $context,
+                files: KnowledgeBaseItem::query()->tap(app(KnowledgeBasePortalAssistantItem::class))->get(['id'])->all(),
+                options: $nextRequestOptions,
+                messages: $messages,
+                reasoningEffort: AiReasoningEffort::Minimal,
+            );
 
-                $response = new PortalAssistantMessage();
-                $response->thread()->associate($this->thread);
-                $response->content = '';
-                $response->context = $context;
-                $response->is_assistant = true;
+            $response = new PortalAssistantMessage();
+            $response->thread()->associate($this->thread);
+            $response->content = '';
+            $response->context = $context;
+            $response->is_assistant = true;
 
-                $chunkBuffer = [];
-                $chunkCount = 0;
+            $chunkBuffer = [];
+            $chunkCount = 0;
 
-                $finishChunk = null;
+            $finishChunk = null;
 
-                foreach ($stream() as $chunk) {
-                    if ($chunk instanceof Meta) {
-                        $response->message_id = $chunk->messageId;
-                        $response->next_request_options = $chunk->nextRequestOptions;
+            foreach ($stream() as $chunk) {
+                if ($chunk instanceof Meta) {
+                    $response->message_id = $chunk->messageId;
+                    $response->next_request_options = $chunk->nextRequestOptions;
 
-                        continue;
-                    }
-
-                    if ($chunk instanceof ToolCall) {
-                        continue;
-                    }
-
-                    if ($chunk instanceof ToolResult) {
-                        continue;
-                    }
-
-                    if ($chunk instanceof Finish) {
-                        $finishChunk = $chunk;
-
-                        if ($chunk->error) {
-                            Log::error('Portal Assistant: Stream finished with error', [
-                                'thread_id' => $this->thread->getKey(),
-                                'error' => $chunk->error,
-                                'finishReason' => $chunk->finishReason?->name,
-                            ]);
-                        }
-
-                        continue;
-                    }
-
-                    if ($chunk instanceof Text) {
-                        $chunkBuffer[] = $chunk->content;
-                        $chunkCount++;
-
-                        if ($chunkCount >= 10) {
-                            event(new PortalAssistantMessageChunk(
-                                $this->thread,
-                                content: implode('', $chunkBuffer),
-                            ));
-                            $response->content .= implode('', $chunkBuffer);
-
-                            $chunkBuffer = [];
-                            $chunkCount = 0;
-                        }
-                    }
+                    continue;
                 }
 
-                // When the stream was rate limited or errored, surface that to the client and do
-                // not persist a partial assistant response. The client can then retry the message.
-                if ($finishChunk?->rateLimitResetsAt || $finishChunk?->error) {
-                    event(new PortalAssistantMessageChunk(
-                        $this->thread,
-                        content: '',
-                        isComplete: false,
-                        error: $finishChunk->error,
-                        rateLimitResetsAt: $finishChunk->rateLimitResetsAt,
-                    ));
-
-                    return;
+                if ($chunk instanceof ToolCall) {
+                    continue;
                 }
 
-                if ($finishChunk?->isIncomplete) {
-                    $chunkBuffer[] = '...';
+                if ($chunk instanceof ToolResult) {
+                    continue;
+                }
+
+                if ($chunk instanceof Finish) {
+                    $finishChunk = $chunk;
+
+                    if ($chunk->error) {
+                        Log::error('Portal Assistant: Stream finished with error', [
+                            'thread_id' => $this->thread->getKey(),
+                            'error' => $chunk->error,
+                            'finishReason' => $chunk->finishReason?->name,
+                        ]);
+                    }
+
+                    continue;
+                }
+
+                if ($chunk instanceof Text) {
+                    $chunkBuffer[] = $chunk->content;
                     $chunkCount++;
-                }
 
-                if (! empty($chunkBuffer)) {
-                    event(new PortalAssistantMessageChunk(
-                        $this->thread,
-                        content: implode('', $chunkBuffer),
-                    ));
-                    $response->content .= implode('', $chunkBuffer);
-                }
+                    if ($chunkCount >= 10) {
+                        event(new PortalAssistantMessageChunk(
+                            $this->thread,
+                            content: implode('', $chunkBuffer),
+                        ));
+                        $response->content .= implode('', $chunkBuffer);
 
+                        $chunkBuffer = [];
+                        $chunkCount = 0;
+                    }
+                }
+            }
+
+            // When the stream was rate limited or errored, surface that to the client and do
+            // not persist a partial assistant response. The client can then retry the message.
+            if ($finishChunk?->rateLimitResetsAt || $finishChunk?->error) {
                 event(new PortalAssistantMessageChunk(
                     $this->thread,
                     content: '',
-                    isComplete: true,
+                    isComplete: false,
+                    error: $finishChunk->error,
+                    rateLimitResetsAt: $finishChunk->rateLimitResetsAt,
                 ));
 
-                $response->save();
-                $this->thread->touch();
-            }, sleepMilliseconds: 1000, when: function (Throwable $exception) {
-                return $exception instanceof PrismException;
-            });
+                return;
+            }
+
+            if ($finishChunk?->isIncomplete) {
+                $chunkBuffer[] = '...';
+                $chunkCount++;
+            }
+
+            if (! empty($chunkBuffer)) {
+                event(new PortalAssistantMessageChunk(
+                    $this->thread,
+                    content: implode('', $chunkBuffer),
+                ));
+                $response->content .= implode('', $chunkBuffer);
+            }
+
+            event(new PortalAssistantMessageChunk(
+                $this->thread,
+                content: '',
+                isComplete: true,
+            ));
+
+            $response->save();
+            $this->thread->touch();
         } catch (Throwable $exception) {
             report($exception);
 

--- a/app-modules/ai/src/Jobs/PortalAssistant/RetryMessage.php
+++ b/app-modules/ai/src/Jobs/PortalAssistant/RetryMessage.php
@@ -60,7 +60,7 @@ use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Prism\Prism\ValueObjects\ToolResult;
 use Throwable;
 
-class SendMessage implements ShouldQueue
+class RetryMessage implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
@@ -76,18 +76,23 @@ class SendMessage implements ShouldQueue
         protected PortalAssistantThread $thread,
         protected string $content,
         protected array $request = [],
-        protected ?string $internalContent = null,
     ) {}
 
     public function handle(): void
     {
-        $message = new PortalAssistantMessage();
-        $message->thread()->associate($this->thread);
-        $message->author()->associate($this->thread->author);
-        $message->content = $this->content;
-        $message->internal_content = $this->internalContent;
+        // Reuse the existing last user message when retrying so we don't duplicate it. Only
+        // recreate it if it is missing or its content has changed.
+        $message = $this->thread->messages()->where('is_assistant', false)->latest()->first();
+
+        if ($message?->content !== $this->content) {
+            $message = new PortalAssistantMessage();
+            $message->thread()->associate($this->thread);
+            $message->author()->associate($this->thread->author);
+            $message->content = $this->content;
+            $message->is_assistant = false;
+        }
+
         $message->request = $this->request;
-        $message->is_assistant = false;
         $message->save();
 
         $supportAssistantSettings = app(AiSupportAssistantSettings::class);
@@ -101,8 +106,8 @@ class SendMessage implements ShouldQueue
             $nextRequestOptions = $this->thread->messages()->where('is_assistant', true)->latest()->value('next_request_options') ?? [];
 
             $messages = [
-                new UserMessage($this->content),
-                ...(filled($this->internalContent) ? [new DeveloperMessage($this->internalContent)] : []),
+                new UserMessage($message->content),
+                ...(filled($message->internal_content) ? [new DeveloperMessage($message->internal_content)] : []),
             ];
 
             retry(3, function () use ($aiService, $context, $nextRequestOptions, $messages) {

--- a/app-modules/ai/src/Jobs/PortalAssistant/SendMessage.php
+++ b/app-modules/ai/src/Jobs/PortalAssistant/SendMessage.php
@@ -55,7 +55,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
-use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\ValueObjects\Messages\UserMessage;
 use Prism\Prism\ValueObjects\ToolResult;
 use Throwable;
@@ -105,111 +104,107 @@ class SendMessage implements ShouldQueue
                 ...(filled($this->internalContent) ? [new DeveloperMessage($this->internalContent)] : []),
             ];
 
-            retry(3, function () use ($aiService, $context, $nextRequestOptions, $messages) {
-                $stream = $aiService->streamRaw(
-                    prompt: $context,
-                    files: KnowledgeBaseItem::query()->tap(app(KnowledgeBasePortalAssistantItem::class))->get(['id'])->all(),
-                    options: $nextRequestOptions,
-                    messages: $messages,
-                    reasoningEffort: AiReasoningEffort::Minimal,
-                );
+            $stream = $aiService->streamRaw(
+                prompt: $context,
+                files: KnowledgeBaseItem::query()->tap(app(KnowledgeBasePortalAssistantItem::class))->get(['id'])->all(),
+                options: $nextRequestOptions,
+                messages: $messages,
+                reasoningEffort: AiReasoningEffort::Minimal,
+            );
 
-                $response = new PortalAssistantMessage();
-                $response->thread()->associate($this->thread);
-                $response->content = '';
-                $response->context = $context;
-                $response->is_assistant = true;
+            $response = new PortalAssistantMessage();
+            $response->thread()->associate($this->thread);
+            $response->content = '';
+            $response->context = $context;
+            $response->is_assistant = true;
 
-                $chunkBuffer = [];
-                $chunkCount = 0;
+            $chunkBuffer = [];
+            $chunkCount = 0;
 
-                $finishChunk = null;
+            $finishChunk = null;
 
-                foreach ($stream() as $chunk) {
-                    if ($chunk instanceof Meta) {
-                        $response->message_id = $chunk->messageId;
-                        $response->next_request_options = $chunk->nextRequestOptions;
+            foreach ($stream() as $chunk) {
+                if ($chunk instanceof Meta) {
+                    $response->message_id = $chunk->messageId;
+                    $response->next_request_options = $chunk->nextRequestOptions;
 
-                        continue;
-                    }
-
-                    if ($chunk instanceof ToolCall) {
-                        continue;
-                    }
-
-                    if ($chunk instanceof ToolResult) {
-                        continue;
-                    }
-
-                    if ($chunk instanceof Finish) {
-                        $finishChunk = $chunk;
-
-                        if ($chunk->error) {
-                            Log::error('Portal Assistant: Stream finished with error', [
-                                'thread_id' => $this->thread->getKey(),
-                                'error' => $chunk->error,
-                                'finishReason' => $chunk->finishReason?->name,
-                            ]);
-                        }
-
-                        continue;
-                    }
-
-                    if ($chunk instanceof Text) {
-                        $chunkBuffer[] = $chunk->content;
-                        $chunkCount++;
-
-                        if ($chunkCount >= 10) {
-                            event(new PortalAssistantMessageChunk(
-                                $this->thread,
-                                content: implode('', $chunkBuffer),
-                            ));
-                            $response->content .= implode('', $chunkBuffer);
-
-                            $chunkBuffer = [];
-                            $chunkCount = 0;
-                        }
-                    }
+                    continue;
                 }
 
-                // When the stream was rate limited or errored, surface that to the client and do
-                // not persist a partial assistant response. The client can then retry the message.
-                if ($finishChunk?->rateLimitResetsAt || $finishChunk?->error) {
-                    event(new PortalAssistantMessageChunk(
-                        $this->thread,
-                        content: '',
-                        isComplete: false,
-                        error: $finishChunk->error,
-                        rateLimitResetsAt: $finishChunk->rateLimitResetsAt,
-                    ));
-
-                    return;
+                if ($chunk instanceof ToolCall) {
+                    continue;
                 }
 
-                if ($finishChunk?->isIncomplete) {
-                    $chunkBuffer[] = '...';
+                if ($chunk instanceof ToolResult) {
+                    continue;
+                }
+
+                if ($chunk instanceof Finish) {
+                    $finishChunk = $chunk;
+
+                    if ($chunk->error) {
+                        Log::error('Portal Assistant: Stream finished with error', [
+                            'thread_id' => $this->thread->getKey(),
+                            'error' => $chunk->error,
+                            'finishReason' => $chunk->finishReason?->name,
+                        ]);
+                    }
+
+                    continue;
+                }
+
+                if ($chunk instanceof Text) {
+                    $chunkBuffer[] = $chunk->content;
                     $chunkCount++;
-                }
 
-                if (! empty($chunkBuffer)) {
-                    event(new PortalAssistantMessageChunk(
-                        $this->thread,
-                        content: implode('', $chunkBuffer),
-                    ));
-                    $response->content .= implode('', $chunkBuffer);
-                }
+                    if ($chunkCount >= 10) {
+                        event(new PortalAssistantMessageChunk(
+                            $this->thread,
+                            content: implode('', $chunkBuffer),
+                        ));
+                        $response->content .= implode('', $chunkBuffer);
 
+                        $chunkBuffer = [];
+                        $chunkCount = 0;
+                    }
+                }
+            }
+
+            // When the stream was rate limited or errored, surface that to the client and do
+            // not persist a partial assistant response. The client can then retry the message.
+            if ($finishChunk?->rateLimitResetsAt || $finishChunk?->error) {
                 event(new PortalAssistantMessageChunk(
                     $this->thread,
                     content: '',
-                    isComplete: true,
+                    isComplete: false,
+                    error: $finishChunk->error,
+                    rateLimitResetsAt: $finishChunk->rateLimitResetsAt,
                 ));
 
-                $response->save();
-                $this->thread->touch();
-            }, sleepMilliseconds: 1000, when: function (Throwable $exception) {
-                return $exception instanceof PrismException;
-            });
+                return;
+            }
+
+            if ($finishChunk?->isIncomplete) {
+                $chunkBuffer[] = '...';
+                $chunkCount++;
+            }
+
+            if (! empty($chunkBuffer)) {
+                event(new PortalAssistantMessageChunk(
+                    $this->thread,
+                    content: implode('', $chunkBuffer),
+                ));
+                $response->content .= implode('', $chunkBuffer);
+            }
+
+            event(new PortalAssistantMessageChunk(
+                $this->thread,
+                content: '',
+                isComplete: true,
+            ));
+
+            $response->save();
+            $this->thread->touch();
         } catch (Throwable $exception) {
             report($exception);
 

--- a/app-modules/ai/tests/Tenant/Jobs/PortalAssistant/RetryMessageTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/PortalAssistant/RetryMessageTest.php
@@ -34,54 +34,47 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Ai\Events\PortalAssistant;
-
+use AidingApp\Ai\Enums\AiModel;
+use AidingApp\Ai\Events\PortalAssistant\PortalAssistantMessageChunk;
+use AidingApp\Ai\Jobs\PortalAssistant\RetryMessage;
+use AidingApp\Ai\Models\PortalAssistantMessage;
 use AidingApp\Ai\Models\PortalAssistantThread;
-use Carbon\CarbonInterface;
-use Illuminate\Broadcasting\Channel;
-use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
-use Illuminate\Foundation\Events\Dispatchable;
+use AidingApp\Ai\Services\TestAiService;
+use AidingApp\Ai\Settings\AiIntegratedAssistantSettings;
+use AidingApp\Ai\Support\StreamingChunks\Finish;
+use AidingApp\Ai\Support\StreamingChunks\Text;
+use Illuminate\Support\Facades\Event;
 
-class PortalAssistantMessageChunk implements ShouldBroadcastNow
-{
-    use Dispatchable;
-    use InteractsWithSockets;
+beforeEach(function () {
+    $settings = app(AiIntegratedAssistantSettings::class);
+    $settings->default_model = AiModel::Test;
+    $settings->save();
+});
 
-    public function __construct(
-        public PortalAssistantThread $thread,
-        public string $content,
-        public bool $isComplete = false,
-        public ?string $error = null,
-        public ?CarbonInterface $rateLimitResetsAt = null,
-    ) {}
+it('reuses the existing user message when retrying instead of duplicating it', function () {
+    Event::fake([PortalAssistantMessageChunk::class]);
 
-    public function broadcastAs(): string
-    {
-        return 'portal-assistant-message.chunk';
-    }
+    $thread = PortalAssistantThread::factory()->create();
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function broadcastWith(): array
-    {
-        return [
-            'content' => $this->content,
-            'is_complete' => $this->isComplete,
-            'error' => $this->error,
-            'rate_limit_resets_after_seconds' => $this->rateLimitResetsAt ? (now()->diffInSeconds($this->rateLimitResetsAt) + 1) : null,
-        ];
-    }
+    PortalAssistantMessage::factory()->for($thread, 'thread')->create([
+        'content' => 'What are your office hours?',
+        'is_assistant' => false,
+    ]);
 
-    /**
-     * @return array<int, Channel>
-     */
-    public function broadcastOn(): array
-    {
-        $channelName = "portal-assistant-thread-{$this->thread->getKey()}";
+    $service = Mockery::mock(TestAiService::class)->makePartial();
+    $service->shouldReceive('streamRaw')->andReturn(function () {
+        yield new Text('We are open 9 to 5.');
 
-        return [new PrivateChannel($channelName)];
-    }
-}
+        yield new Finish();
+    });
+    app()->instance(TestAiService::class, $service);
+
+    dispatch_sync(new RetryMessage($thread, 'What are your office hours?'));
+
+    expect(PortalAssistantMessage::query()->where('is_assistant', false)->count())->toBe(1);
+
+    $response = PortalAssistantMessage::query()->where('is_assistant', true)->first();
+
+    expect($response)->not->toBeNull()
+        ->and($response->content)->toBe('We are open 9 to 5.');
+});

--- a/app-modules/ai/tests/Tenant/Jobs/PortalAssistant/SendMessageTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/PortalAssistant/SendMessageTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Ai\Enums\AiModel;
+use AidingApp\Ai\Events\PortalAssistant\PortalAssistantMessageChunk;
+use AidingApp\Ai\Jobs\PortalAssistant\SendMessage;
+use AidingApp\Ai\Models\PortalAssistantMessage;
+use AidingApp\Ai\Models\PortalAssistantThread;
+use AidingApp\Ai\Services\TestAiService;
+use AidingApp\Ai\Settings\AiIntegratedAssistantSettings;
+use AidingApp\Ai\Support\StreamingChunks\Finish;
+use AidingApp\Ai\Support\StreamingChunks\Text;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    $settings = app(AiIntegratedAssistantSettings::class);
+    $settings->default_model = AiModel::Test;
+    $settings->save();
+});
+
+it('surfaces the rate limit reset time and does not persist a partial response when the stream is rate limited', function () {
+    Event::fake([PortalAssistantMessageChunk::class]);
+
+    $thread = PortalAssistantThread::factory()->create();
+
+    $service = Mockery::mock(TestAiService::class)->makePartial();
+    $service->shouldReceive('streamRaw')->andReturn(function () {
+        yield new Text('A partial answer that gets cut off');
+
+        yield new Finish(rateLimitResetsAt: now()->addSeconds(30));
+    });
+    app()->instance(TestAiService::class, $service);
+
+    dispatch_sync(new SendMessage($thread, 'Hello'));
+
+    expect(PortalAssistantMessage::query()->where('is_assistant', false)->count())->toBe(1);
+    expect(PortalAssistantMessage::query()->where('is_assistant', true)->count())->toBe(0);
+
+    Event::assertDispatched(
+        PortalAssistantMessageChunk::class,
+        fn (PortalAssistantMessageChunk $event): bool => $event->thread->is($thread)
+            && $event->isComplete === false
+            && $event->rateLimitResetsAt !== null,
+    );
+});
+
+it('completes and persists the response when the stream finishes normally', function () {
+    Event::fake([PortalAssistantMessageChunk::class]);
+
+    $thread = PortalAssistantThread::factory()->create();
+
+    $service = Mockery::mock(TestAiService::class)->makePartial();
+    $service->shouldReceive('streamRaw')->andReturn(function () {
+        yield new Text('Here is a complete answer.');
+
+        yield new Finish();
+    });
+    app()->instance(TestAiService::class, $service);
+
+    dispatch_sync(new SendMessage($thread, 'Hello'));
+
+    $response = PortalAssistantMessage::query()->where('is_assistant', true)->first();
+
+    expect($response)->not->toBeNull()
+        ->and($response->content)->toBe('Here is a complete answer.');
+
+    Event::assertDispatched(
+        PortalAssistantMessageChunk::class,
+        fn (PortalAssistantMessageChunk $event): bool => $event->isComplete === true,
+    );
+});

--- a/widgets/assistant/src/App.ce.vue
+++ b/widgets/assistant/src/App.ce.vue
@@ -39,6 +39,7 @@
 
     const props = defineProps({
         sendMessageUrl: { type: String, required: true },
+        retryMessageUrl: { type: String, default: null },
         websocketsConfig: { type: Object, required: true },
         primaryColor: { type: Object, required: true },
         rounding: { type: String, default: 'md' },
@@ -153,6 +154,7 @@
         <ChatPanel
             :is-open="isOpen"
             :send-message-url="sendMessageUrl"
+            :retry-message-url="retryMessageUrl"
             :websockets-config="websocketsConfig"
             :is-authenticated="isAuthenticated"
             :portal-service-management="portalServiceManagement"

--- a/widgets/assistant/src/components/ChatMessage.vue
+++ b/widgets/assistant/src/components/ChatMessage.vue
@@ -39,6 +39,8 @@
         message: { type: Object, required: true },
     });
 
+    const emit = defineEmits(['retry']);
+
     const { renderMarkdown } = useMarkdown();
 </script>
 
@@ -71,6 +73,15 @@
                 <div v-if="props.message.error" class="text-xs text-red-500 mt-1">
                     {{ props.message.error }}
                 </div>
+
+                <button
+                    v-if="props.message.canRetry"
+                    type="button"
+                    @click="emit('retry')"
+                    class="text-xs font-semibold text-red-600 underline hover:no-underline mt-1"
+                >
+                    Try again
+                </button>
 
                 <div
                     v-if="props.message.author === 'assistant' && !props.message.content && !props.message.isComplete"

--- a/widgets/assistant/src/components/ChatMessage.vue
+++ b/widgets/assistant/src/components/ChatMessage.vue
@@ -84,7 +84,12 @@
                 </button>
 
                 <div
-                    v-if="props.message.author === 'assistant' && !props.message.content && !props.message.isComplete && !props.message.error"
+                    v-if="
+                        props.message.author === 'assistant' &&
+                        !props.message.content &&
+                        !props.message.isComplete &&
+                        !props.message.error
+                    "
                     class="flex items-center space-x-1"
                 >
                     <div class="w-1.5 h-1.5 bg-brand-400 rounded-full animate-bounce"></div>

--- a/widgets/assistant/src/components/ChatMessage.vue
+++ b/widgets/assistant/src/components/ChatMessage.vue
@@ -84,7 +84,7 @@
                 </button>
 
                 <div
-                    v-if="props.message.author === 'assistant' && !props.message.content && !props.message.isComplete"
+                    v-if="props.message.author === 'assistant' && !props.message.content && !props.message.isComplete && !props.message.error"
                     class="flex items-center space-x-1"
                 >
                     <div class="w-1.5 h-1.5 bg-brand-400 rounded-full animate-bounce"></div>

--- a/widgets/assistant/src/components/ChatMessages.vue
+++ b/widgets/assistant/src/components/ChatMessages.vue
@@ -42,6 +42,8 @@
         isOpen: { type: Boolean, default: false },
     });
 
+    const emit = defineEmits(['retry']);
+
     const messagesContainer = ref(null);
     const autoScroll = ref(true);
 
@@ -121,6 +123,11 @@
             </div>
         </div>
 
-        <ChatMessage v-for="(chatMessage, index) in props.messages" :key="index" :message="chatMessage" />
+        <ChatMessage
+            v-for="(chatMessage, index) in props.messages"
+            :key="index"
+            :message="chatMessage"
+            @retry="emit('retry')"
+        />
     </div>
 </template>

--- a/widgets/assistant/src/components/ChatPanel.vue
+++ b/widgets/assistant/src/components/ChatPanel.vue
@@ -43,6 +43,7 @@
     const props = defineProps({
         isOpen: { type: Boolean, default: false },
         sendMessageUrl: { type: String, required: true },
+        retryMessageUrl: { type: String, default: null },
         websocketsConfig: { type: Object, required: true },
         isAuthenticated: { type: Boolean, default: false },
         portalServiceManagement: { type: Boolean, default: false },
@@ -57,11 +58,8 @@
     const pendingView = ref(null);
     const activeServiceRequestNumber = ref(null);
 
-    const { messages, isSending, isAssistantResponding, sendMessage, setAuthenticated } = useAssistantChat(
-        props.sendMessageUrl,
-        props.websocketsConfig,
-        props.isAuthenticated,
-    );
+    const { messages, isSending, isAssistantResponding, sendMessage, retryMessage, setAuthenticated } =
+        useAssistantChat(props.sendMessageUrl, props.websocketsConfig, props.isAuthenticated, props.retryMessageUrl);
 
     function onOpenServiceRequest() {
         if (props.isAuthenticated) {
@@ -142,7 +140,12 @@
             />
 
             <template v-else>
-                <ChatMessages :messages="messages" :welcome-message="welcomeMessage" :is-open="props.isOpen" />
+                <ChatMessages
+                    :messages="messages"
+                    :welcome-message="welcomeMessage"
+                    :is-open="props.isOpen"
+                    @retry="retryMessage"
+                />
 
                 <ChatInput :disabled="isSending || isAssistantResponding" @send="sendMessage" />
             </template>

--- a/widgets/assistant/src/composables/useAssistantChat.js
+++ b/widgets/assistant/src/composables/useAssistantChat.js
@@ -87,6 +87,13 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
         });
     };
 
+    // Discard any words still queued for the typewriter effect and stop the animation, so
+    // partially-streamed text doesn't linger or bleed into a subsequent (retried) response.
+    const resetWordQueue = () => {
+        wordQueue.value = [];
+        isTyping.value = false;
+    };
+
     const typeNextWord = (messageIndex) => {
         if (wordQueue.value.length === 0) {
             isTyping.value = false;
@@ -179,6 +186,7 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
         isSending.value = true;
 
         clearTransientState();
+        resetWordQueue();
 
         // Reset the most recent assistant message so the retried response streams into it.
         const index = lastAssistantMessageIndex();
@@ -211,10 +219,13 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
     const handleStreamChunk = (chunk, isComplete, error, rateLimitResetsAfterSeconds) => {
         const messageIndex = messages.value.findIndex((m) => m.author === 'assistant' && !m.isComplete);
 
-        // Heavy traffic: the backend hit a rate limit. Wait for the limit to reset, then retry
-        // the message automatically.
+        // Heavy traffic: the backend hit a rate limit. Discard any partially-streamed text, show
+        // the notice, and retry the message automatically once the limit resets.
         if (rateLimitResetsAfterSeconds) {
+            resetWordQueue();
+
             if (messageIndex !== -1) {
+                messages.value[messageIndex].content = '';
                 messages.value[messageIndex].error = 'Heavy traffic, just a few more moments...';
                 messages.value[messageIndex].canRetry = false;
             }
@@ -225,9 +236,12 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
             return;
         }
 
-        // A hard error: stop the loading state and offer a manual retry.
+        // A hard error: discard any partial text, stop the loading state, and offer a manual retry.
         if (error) {
+            resetWordQueue();
+
             if (messageIndex !== -1) {
+                messages.value[messageIndex].content = '';
                 messages.value[messageIndex].error = error;
                 messages.value[messageIndex].isComplete = true;
                 messages.value[messageIndex].canRetry = true;

--- a/widgets/assistant/src/composables/useAssistantChat.js
+++ b/widgets/assistant/src/composables/useAssistantChat.js
@@ -35,7 +35,7 @@ import axios from 'axios';
 import { computed, onUnmounted, ref, watch } from 'vue';
 import { useAssistantConnection } from './useAssistantConnection.js';
 
-export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticated = false) {
+export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticated = false, retryMessageUrl = null) {
     const messages = ref([]);
     const threadId = ref(null);
     const guestToken = ref(null);
@@ -43,6 +43,11 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
     const wordQueue = ref([]);
     const isTyping = ref(false);
     const authEndpoint = ref(websocketsConfig.authEndpoint || '/api/broadcasting/auth');
+
+    // The last message the user sent, so we can resend it when retrying.
+    let lastUserMessage = null;
+    // Pending timer for the automatic retry after a rate limit resets.
+    let rateLimitRetryTimeout = null;
 
     // Guests use a token to identify their session
     if (!isAuthenticated) {
@@ -64,6 +69,22 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
     const addAssistantMessage = () => {
         messages.value.push({ author: 'assistant', content: '', isComplete: false, error: null });
         return messages.value.length - 1;
+    };
+
+    // Cancel any pending auto-retry and clear error/retry state left on earlier messages, so a
+    // stale "Try again" button can never resend the wrong (latest) message.
+    const clearTransientState = () => {
+        if (rateLimitRetryTimeout) {
+            clearTimeout(rateLimitRetryTimeout);
+            rateLimitRetryTimeout = null;
+        }
+
+        messages.value.forEach((message) => {
+            if (message.error || message.canRetry) {
+                message.error = null;
+                message.canRetry = false;
+            }
+        });
     };
 
     const typeNextWord = (messageIndex) => {
@@ -115,6 +136,10 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
 
         isSending.value = true;
 
+        clearTransientState();
+
+        lastUserMessage = content;
+
         addUserMessage(content);
 
         const payload = { content, thread_id: threadId.value };
@@ -141,6 +166,79 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
         }
     };
 
+    const lastAssistantMessageIndex = () => {
+        for (let i = messages.value.length - 1; i >= 0; i--) {
+            if (messages.value[i].author === 'assistant') return i;
+        }
+        return -1;
+    };
+
+    const retryMessage = async () => {
+        if (!retryMessageUrl || !lastUserMessage || !threadId.value || isSending.value) return;
+
+        isSending.value = true;
+
+        clearTransientState();
+
+        // Reset the most recent assistant message so the retried response streams into it.
+        const index = lastAssistantMessageIndex();
+        if (index !== -1) {
+            messages.value[index] = { author: 'assistant', content: '', isComplete: false, error: null };
+        } else {
+            addAssistantMessage();
+        }
+
+        const payload = { content: lastUserMessage, thread_id: threadId.value };
+
+        if (guestToken.value) {
+            payload.guest_token = guestToken.value;
+        }
+
+        try {
+            await axios.post(retryMessageUrl, payload);
+        } catch (error) {
+            const messageIndex = messages.value.findIndex((m) => m.author === 'assistant' && !m.isComplete);
+            if (messageIndex !== -1) {
+                messages.value[messageIndex].error = 'Failed to send message.';
+                messages.value[messageIndex].isComplete = true;
+                messages.value[messageIndex].canRetry = true;
+            }
+        } finally {
+            isSending.value = false;
+        }
+    };
+
+    const handleStreamChunk = (chunk, isComplete, error, rateLimitResetsAfterSeconds) => {
+        const messageIndex = messages.value.findIndex((m) => m.author === 'assistant' && !m.isComplete);
+
+        // Heavy traffic: the backend hit a rate limit. Wait for the limit to reset, then retry
+        // the message automatically.
+        if (rateLimitResetsAfterSeconds) {
+            if (messageIndex !== -1) {
+                messages.value[messageIndex].error = 'Heavy traffic, just a few more moments...';
+                messages.value[messageIndex].canRetry = false;
+            }
+
+            if (rateLimitRetryTimeout) clearTimeout(rateLimitRetryTimeout);
+            rateLimitRetryTimeout = setTimeout(() => retryMessage(), rateLimitResetsAfterSeconds * 1000);
+
+            return;
+        }
+
+        // A hard error: stop the loading state and offer a manual retry.
+        if (error) {
+            if (messageIndex !== -1) {
+                messages.value[messageIndex].error = error;
+                messages.value[messageIndex].isComplete = true;
+                messages.value[messageIndex].canRetry = true;
+            }
+
+            return;
+        }
+
+        updateAssistantMessage(chunk, isComplete, error);
+    };
+
     const getToken = () => {
         return localStorage.getItem('token') || null;
     };
@@ -150,9 +248,7 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
     const connectToThread = async (id) => {
         if (!id) return;
 
-        await connection.connect(id, (chunk, is_complete, err) => {
-            updateAssistantMessage(chunk, is_complete, err);
-        });
+        await connection.connect(id, handleStreamChunk);
     };
 
     watch(threadId, async (newId) => {
@@ -161,6 +257,10 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
     });
 
     onUnmounted(() => {
+        if (rateLimitRetryTimeout) {
+            clearTimeout(rateLimitRetryTimeout);
+            rateLimitRetryTimeout = null;
+        }
         connection.disconnect();
     });
 
@@ -175,6 +275,7 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
         isSending,
         isAssistantResponding,
         sendMessage,
+        retryMessage,
         setAuthenticated,
     };
 }

--- a/widgets/assistant/src/composables/useAssistantChat.js
+++ b/widgets/assistant/src/composables/useAssistantChat.js
@@ -166,8 +166,10 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
             }
             addAssistantMessage();
         } catch (error) {
-            addAssistantMessage();
-            updateAssistantMessage('', true, 'Failed to send message.');
+            const index = addAssistantMessage();
+            messages.value[index].error = 'Failed to send message.';
+            messages.value[index].isComplete = true;
+            messages.value[index].canRetry = true;
         } finally {
             isSending.value = false;
         }
@@ -181,7 +183,7 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
     };
 
     const retryMessage = async () => {
-        if (!retryMessageUrl || !lastUserMessage || !threadId.value || isSending.value) return;
+        if (!lastUserMessage || isSending.value) return;
 
         isSending.value = true;
 
@@ -196,6 +198,8 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
             addAssistantMessage();
         }
 
+        // If we don't have a thread yet (initial send failed), re-attempt via the send endpoint.
+        const url = threadId.value && retryMessageUrl ? retryMessageUrl : sendMessageUrl;
         const payload = { content: lastUserMessage, thread_id: threadId.value };
 
         if (guestToken.value) {
@@ -203,7 +207,14 @@ export function useAssistantChat(sendMessageUrl, websocketsConfig, isAuthenticat
         }
 
         try {
-            await axios.post(retryMessageUrl, payload);
+            const response = await axios.post(url, payload);
+            if (response.data.thread_id) {
+                threadId.value = response.data.thread_id;
+            }
+            if (response.data.guest_token && !isAuthenticated) {
+                guestToken.value = response.data.guest_token;
+                localStorage.setItem('assistantGuestToken', guestToken.value);
+            }
         } catch (error) {
             const messageIndex = messages.value.findIndex((m) => m.author === 'assistant' && !m.isComplete);
             if (messageIndex !== -1) {

--- a/widgets/assistant/src/composables/useAssistantConnection.js
+++ b/widgets/assistant/src/composables/useAssistantConnection.js
@@ -107,7 +107,7 @@ export function useAssistantConnection(
 
         channel.listen('.portal-assistant-message.chunk', (event) => {
             if (onChunk) {
-                onChunk(event.content || '', event.is_complete, event.error);
+                onChunk(event.content || '', event.is_complete, event.error, event.rate_limit_resets_after_seconds);
             }
         });
     };

--- a/widgets/assistant/src/widget.js
+++ b/widgets/assistant/src/widget.js
@@ -61,6 +61,7 @@ if (!config || !config.send_message_url || !config.websockets_config) {
                     h(App, {
                         ...props,
                         sendMessageUrl: config.send_message_url,
+                        retryMessageUrl: config.retry_message_url,
                         websocketsConfig: { ...config.websockets_config, authEndpoint: config.auth_endpoint },
                         primaryColor: config.primary_color,
                         rounding: config.rounding,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1235

### Technical Description

> Add retry message functionality to assistant chat. Introduced `RetryMessageController` and `RetryMessage` job to handle message retries. Updated routes to include a retry endpoint for messages. Enhanced `PortalAssistantMessageChunk` to include rate limit reset information. Modified `useAssistantChat` to manage retry logic and state.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
