### PR TITLE
[AIDAPP-1249]: Enhance email ticket creation for service request types by allowing institutions to forward emails to target type addresses

### DIFF
--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -494,16 +494,30 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                 return;
             }
 
+            /*
+             * When an email is forwarded into the Service Request Type address, the actual sender is
+             * the forwarder, not the person the request is for. Detect the forward and substitute the
+             * original sender, subject, and body so the Service Request is created for the original
+             * sender as if they had emailed in directly.
+             */
+            $forwarded = $this->parseForwardedEmail($parser);
+
+            $effectiveSender = $forwarded['sender'] ?? $sender;
+            $effectiveSenderName = $forwarded['senderName'] ?? ($parser->getAddresses('from')[0]['display'] ?? null);
+            $effectiveSubject = $forwarded['subject'] ?? $parser->getHeader('subject');
+            $effectiveBody = $forwarded['body'] ?? $parser->getMessageBody('text');
+            $effectiveNotificationBody = $forwarded['body'] ?? $parser->getMessageBody('htmlEmbedded');
+
             $contacts = Contact::query()
-                ->where('email', $sender)
+                ->where('email', $effectiveSender)
                 ->get();
 
             if ($contacts->isEmpty()) {
                 if (! $serviceRequestType->is_email_automatic_creation_contact_create_enabled) {
-                    Notification::route('mail', $sender)
+                    Notification::route('mail', $effectiveSender)
                         ->notifyNow(new IneligibleContactSesS3InboundEmailServiceRequestNotification(
                             $serviceRequestTypeDomain,
-                            $parser->getMessageBody('htmlEmbedded')
+                            $effectiveNotificationBody
                         ));
 
                     return;
@@ -512,31 +526,31 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                 $organization = null;
 
                 if ($serviceRequestType->email_automatic_creation_contact_create_condition === EmailAutomaticCreationContactCreateCondition::IfEligible) {
-                    $domain = Str::afterLast($sender, '@');
+                    $domain = Str::afterLast($effectiveSender, '@');
 
                     $organization = Organization::query()
                         ->whereRaw('LOWER(?) = ANY (SELECT LOWER(value) FROM jsonb_array_elements_text(domains))', [mb_strtolower($domain)])
                         ->first();
 
                     if (! $organization) {
-                        Notification::route('mail', $sender)
+                        Notification::route('mail', $effectiveSender)
                             ->notifyNow(new IneligibleContactSesS3InboundEmailServiceRequestNotification(
                                 $serviceRequestTypeDomain,
-                                $parser->getMessageBody('htmlEmbedded')
+                                $effectiveNotificationBody
                             ));
 
                         return;
                     }
                 }
 
-                $contacts = $contacts->add($this->buildContactFromSender($sender, $parser, $organization));
+                $contacts = $contacts->add($this->buildContactFromSender($effectiveSender, $effectiveSenderName, $organization));
             }
 
-            $contacts->each(function (Contact $contact) use ($serviceRequestType, $parser) {
+            $contacts->each(function (Contact $contact) use ($serviceRequestType, $parser, $effectiveSubject, $effectiveBody) {
                 $serviceRequest = $contact->serviceRequests()
                     ->make([
-                        'title' => $parser->getHeader('subject'),
-                        'close_details' => $parser->getMessageBody('text'),
+                        'title' => $effectiveSubject,
+                        'close_details' => $effectiveBody,
                     ]);
 
                 $serviceRequestStatus = ServiceRequestStatus::query()
@@ -582,9 +596,136 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
         });
     }
 
-    protected function buildContactFromSender(string $sender, Parser $parser, ?Organization $organization = null): Contact
+    /**
+     * @return array{sender: string, senderName: ?string, subject: ?string, body: string}|null
+     */
+    protected function parseForwardedEmail(Parser $parser): ?array
     {
-        $senderName = $parser->getAddresses('from')[0]['display'];
+        $outerSubject = (string) $parser->getHeader('subject');
+        $body = (string) $parser->getMessageBody('text');
+
+        if (blank($body)) {
+            return null;
+        }
+
+        $hasForwardSubject = (bool) preg_match('/^\s*(?:fwd?|fw)\s*:/i', $outerSubject);
+
+        $blockOffset = null;
+
+        $markers = [
+            '/^[ \t]*-{2,}[ \t]*Forwarded message[ \t]*-{2,}[ \t]*$/im', // Gmail
+            '/^[ \t]*Begin forwarded message:[ \t]*$/im',                // Apple Mail
+            '/^[ \t]*-{2,}[ \t]*Original Message[ \t]*-{2,}[ \t]*$/im',  // Outlook (older)
+        ];
+
+        foreach ($markers as $marker) {
+            if (preg_match($marker, $body, $m, PREG_OFFSET_CAPTURE)) {
+                // The header block starts on the line after the separator.
+                $blockOffset = $m[0][1] + strlen($m[0][0]);
+
+                break;
+            }
+        }
+
+        if ($blockOffset === null && $hasForwardSubject) {
+            // Outlook inline forward: a "From:" line followed within a few lines by a "Subject:" line.
+            if (preg_match('/^[ \t]*From:[ \t]*.+(?:\r?\n.*){0,5}?\r?\n[ \t]*Subject:[ \t]*.*$/im', $body, $m, PREG_OFFSET_CAPTURE)) {
+                $blockOffset = $m[0][1];
+            }
+        }
+
+        if ($blockOffset === null) {
+            return null;
+        }
+
+        $afterMarker = substr($body, $blockOffset);
+
+        // Original sender from the first "From:" line in the forwarded block.
+        $sender = null;
+        $senderName = null;
+
+        if (preg_match('/^[ \t]*From:[ \t]*(.+)$/im', $afterMarker, $fromMatch)) {
+            $fromLine = trim($fromMatch[1]);
+
+            if (preg_match('/<([^>@\s]+@[^>\s]+)>/', $fromLine, $emailMatch)) {
+                $sender = $emailMatch[1];
+                $senderName = trim(Str::before($fromLine, '<'), " \t\"");
+            } elseif (preg_match('/[\w.+-]+@[\w-]+\.[\w.-]+/', $fromLine, $emailMatch)) {
+                $sender = $emailMatch[0];
+                $senderName = trim(str_replace($sender, '', $fromLine), " \t\"<>");
+            }
+        }
+
+        if (blank($sender)) {
+            return null;
+        }
+
+        // Original subject from the block's "Subject:" line, else the Fwd/FW prefix stripped off the outer subject.
+        if (preg_match('/^[ \t]*Subject:[ \t]*(.+)$/im', $afterMarker, $subjectMatch)) {
+            $subject = $this->stripForwardSubjectPrefix(trim($subjectMatch[1]));
+        } else {
+            $subject = $this->stripForwardSubjectPrefix($outerSubject);
+        }
+
+        return [
+            'sender' => $sender,
+            'senderName' => blank($senderName) ? null : $senderName,
+            'subject' => blank($subject) ? null : $subject,
+            'body' => $this->extractBodyAfterHeaderBlock($afterMarker),
+        ];
+    }
+
+    protected function stripForwardSubjectPrefix(string $subject): string
+    {
+        return trim((string) preg_replace('/^(?:\s*(?:fwd?|fw)\s*:\s*)+/i', '', $subject));
+    }
+
+    protected function extractBodyAfterHeaderBlock(string $afterMarker): string
+    {
+        $lines = preg_split('/\r\n|\r|\n/', $afterMarker) ?: [];
+        $count = count($lines);
+        $headerPattern = '/^[ \t]*(?:From|Sent|Date|To|Cc|Bcc|Subject|Reply-To)[ \t]*:/i';
+
+        $index = 0;
+
+        // Skip blank lines preceding the header block (e.g. after "Begin forwarded message:").
+        while ($index < $count && trim($lines[$index]) === '') {
+            $index++;
+        }
+
+        $seenHeader = false;
+
+        // Consume the contiguous header lines and their folded continuations.
+        while ($index < $count) {
+            $line = $lines[$index];
+
+            if (preg_match($headerPattern, $line)) {
+                $seenHeader = true;
+                $index++;
+
+                continue;
+            }
+
+            if ($seenHeader && preg_match('/^[ \t]+\S/', $line)) {
+                $index++;
+
+                continue;
+            }
+
+            break;
+        }
+
+        // Skip the blank line(s) separating the headers from the body.
+        while ($index < $count && trim($lines[$index]) === '') {
+            $index++;
+        }
+
+        return trim(implode("\n", array_slice($lines, $index)));
+    }
+
+    protected function buildContactFromSender(string $sender, ?string $senderName, ?Organization $organization = null): Contact
+    {
+        $senderName = trim((string) $senderName);
 
         $firstName = Str::before($senderName, ' ') ?: 'Unknown';
         $lastName = Str::after($senderName, ' ') ?: 'Unknown';

--- a/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_apple
+++ b/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_apple
@@ -1,0 +1,39 @@
+Return-Path: <forwarder@school.edu>
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+From: Staff Member <forwarder@school.edu>
+To: test-sr-help@mail.aiding.app
+Subject: Fwd: Library book overdue
+Date: Thu, 20 Feb 2025 20:25:37 +0000
+Message-ID: <apple-fwd-0001@school.edu>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="bnd_apple_fwd"
+
+--bnd_apple_fwd
+Content-Type: text/plain; charset="UTF-8"
+
+FYI -- forwarding to the help desk.
+
+Begin forwarded message:
+
+From: Jordan Student <student@example.com>
+Subject: Library book overdue
+Date: February 20, 2025 at 2:00:00 PM EST
+To: Support Desk <support@school.edu>
+
+My library book is showing overdue but I returned it last week. Please advise.
+
+--bnd_apple_fwd
+Content-Type: text/html; charset="UTF-8"
+
+<html><body>
+<p>FYI -- forwarding to the help desk.</p>
+<br>
+<div>Begin forwarded message:</div>
+<br>
+<div>From: Jordan Student &lt;student@example.com&gt;</div>
+<div>Subject: Library book overdue</div>
+<p>My library book is showing overdue but I returned it last week. Please advise.</p>
+</body></html>
+
+--bnd_apple_fwd--

--- a/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_gmail
+++ b/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_gmail
@@ -1,0 +1,41 @@
+Return-Path: <forwarder@school.edu>
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+From: Staff Member <forwarder@school.edu>
+To: test-sr-help@mail.aiding.app
+Subject: Fwd: Help with my account
+Date: Thu, 20 Feb 2025 20:25:37 +0000
+Message-ID: <gmail-fwd-0001@mail.gmail.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="bnd_gmail_fwd"
+
+--bnd_gmail_fwd
+Content-Type: text/plain; charset="UTF-8"
+
+Hi team, please create a ticket for this student. Thanks!
+
+---------- Forwarded message ---------
+From: Jordan Student <student@example.com>
+Date: Thu, 20 Feb 2025 at 14:00
+Subject: Help with my account
+To: Support Desk <support@school.edu>
+
+Hello, I cannot log into my student portal. Please help me reset my password.
+
+Thanks,
+Jordan
+
+--bnd_gmail_fwd
+Content-Type: text/html; charset="UTF-8"
+
+<html><body>
+<p>Hi team, please create a ticket for this student. Thanks!</p>
+<div class="gmail_quote">
+<div>---------- Forwarded message ---------</div>
+<div>From: Jordan Student &lt;student@example.com&gt;</div>
+<div>Subject: Help with my account</div>
+<p>Hello, I cannot log into my student portal. Please help me reset my password.</p>
+</div>
+</body></html>
+
+--bnd_gmail_fwd--

--- a/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_nested_subject
+++ b/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_nested_subject
@@ -1,0 +1,41 @@
+Return-Path: <forwarder@school.edu>
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+From: Staff Member <forwarder@school.edu>
+To: test-sr-help@mail.aiding.app
+Subject: Fwd: FW: Account help
+Date: Thu, 20 Feb 2025 20:25:37 +0000
+Message-ID: <gmail-nested-0001@mail.gmail.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="bnd_nested_fwd"
+
+--bnd_nested_fwd
+Content-Type: text/plain; charset="UTF-8"
+
+Passing this along to the help desk.
+
+---------- Forwarded message ---------
+From: Jordan Student <student@example.com>
+Date: Thu, 20 Feb 2025 at 14:00
+Subject: FW: Account help
+To: Support Desk <support@school.edu>
+
+I still cannot sign in to my account. Can someone help?
+
+Thanks,
+Jordan
+
+--bnd_nested_fwd
+Content-Type: text/html; charset="UTF-8"
+
+<html><body>
+<p>Passing this along to the help desk.</p>
+<div class="gmail_quote">
+<div>---------- Forwarded message ---------</div>
+<div>From: Jordan Student &lt;student@example.com&gt;</div>
+<div>Subject: FW: Account help</div>
+<p>I still cannot sign in to my account. Can someone help?</p>
+</div>
+</body></html>
+
+--bnd_nested_fwd--

--- a/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_outlook
+++ b/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_outlook
@@ -1,0 +1,41 @@
+Return-Path: <forwarder@school.edu>
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+From: Staff Member <forwarder@school.edu>
+To: test-sr-help@mail.aiding.app
+Subject: FW: Billing question
+Date: Thu, 20 Feb 2025 20:25:37 +0000
+Message-ID: <outlook-fwd-0001@school.edu>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="bnd_outlook_fwd"
+
+--bnd_outlook_fwd
+Content-Type: text/plain; charset="UTF-8"
+
+Please handle this one.
+
+From: Jordan Student <student@example.com>
+Sent: Thursday, February 20, 2025 2:00 PM
+To: Support Desk <support@school.edu>
+Subject: Billing question
+
+I was charged twice for my tuition deposit. Can you please check my account?
+
+Regards,
+Jordan
+
+--bnd_outlook_fwd
+Content-Type: text/html; charset="UTF-8"
+
+<html><body>
+<p>Please handle this one.</p>
+<div>
+<p><b>From:</b> Jordan Student &lt;student@example.com&gt;<br>
+<b>Sent:</b> Thursday, February 20, 2025 2:00 PM<br>
+<b>To:</b> Support Desk &lt;support@school.edu&gt;<br>
+<b>Subject:</b> Billing question</p>
+<p>I was charged twice for my tuition deposit. Can you please check my account?</p>
+</div>
+</body></html>
+
+--bnd_outlook_fwd--

--- a/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_outlook_divider
+++ b/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_outlook_divider
@@ -1,0 +1,42 @@
+Return-Path: <forwarder@school.edu>
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+From: Staff Member <forwarder@school.edu>
+To: test-sr-help@mail.aiding.app
+Subject: FW: Account access
+Date: Thu, 20 Feb 2025 20:25:37 +0000
+Message-ID: <outlook-div-0001@school.edu>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="bnd_outlook_div"
+
+--bnd_outlook_div
+Content-Type: text/plain; charset="UTF-8"
+
+Forwarding to IT.
+
+________________________________
+From: Jordan Student <student@example.com>
+Sent: Thursday, February 20, 2025 2:00 PM
+To: Support Desk <support@school.edu>
+Subject: Account access
+
+I cannot access the portal even after resetting my password.
+
+Regards,
+Jordan
+
+--bnd_outlook_div
+Content-Type: text/html; charset="UTF-8"
+
+<html><body>
+<p>Forwarding to IT.</p>
+<div style="border-top:1px solid #ccc; padding-top:6px">
+<p><b>From:</b> Jordan Student &lt;student@example.com&gt;<br>
+<b>Sent:</b> Thursday, February 20, 2025 2:00 PM<br>
+<b>To:</b> Support Desk &lt;support@school.edu&gt;<br>
+<b>Subject:</b> Account access</p>
+<p>I cannot access the portal even after resetting my password.</p>
+</div>
+</body></html>
+
+--bnd_outlook_div--

--- a/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_quoted_printable
+++ b/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_quoted_printable
@@ -1,0 +1,22 @@
+Return-Path: <forwarder@school.edu>
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+From: Staff Member <forwarder@school.edu>
+To: test-sr-help@mail.aiding.app
+Subject: Fwd: Cafe hours question
+Date: Thu, 20 Feb 2025 20:25:37 +0000
+Message-ID: <gmail-qp-0001@mail.gmail.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+Hi team, please handle.
+
+---------- Forwarded message ---------
+From: Jordan Student <student@example.com>
+Date: Thu, 20 Feb 2025 at 14:00
+Subject: Caf=C3=A9 hours question
+To: Support Desk <support@school.edu>
+
+I have a question about the caf=C3=A9 hours =E2=80=94 are you open on wee=
+kends? Thanks!

--- a/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_unparseable
+++ b/app-modules/engagement/tests/Landlord/Fixtures/s3_email_forwarded_unparseable
@@ -1,0 +1,27 @@
+Return-Path: <forwarder@school.edu>
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+From: Staff Member <forwarder@school.edu>
+To: test-sr-help@mail.aiding.app
+Subject: FW: General inquiry
+Date: Thu, 20 Feb 2025 20:25:37 +0000
+Message-ID: <unparseable-fwd-0001@school.edu>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="bnd_unparseable_fwd"
+
+--bnd_unparseable_fwd
+Content-Type: text/plain; charset="UTF-8"
+
+I'm forwarding this along, but I pasted the content without any headers:
+
+The student said they need help with enrollment and were not sure who to contact.
+
+--bnd_unparseable_fwd
+Content-Type: text/html; charset="UTF-8"
+
+<html><body>
+<p>I'm forwarding this along, but I pasted the content without any headers:</p>
+<p>The student said they need help with enrollment and were not sure who to contact.</p>
+</body></html>
+
+--bnd_unparseable_fwd--

--- a/app-modules/engagement/tests/Landlord/Jobs/ProcessSesS3InboundEmailTest.php
+++ b/app-modules/engagement/tests/Landlord/Jobs/ProcessSesS3InboundEmailTest.php
@@ -1821,6 +1821,422 @@ describe('Service Request Type Service Request creation from inbound email', fun
     });
 });
 
+describe('Forwarded email Service Request creation', function () {
+    it('creates a service request for the original sender when an email is forwarded to the type address', function (string $fixture, string $expectedSubject, string $expectedBodyContains, string $forwarderWrapperContains) {
+        $tenant = Tenant::query()->firstOrFail();
+
+        assert($tenant instanceof Tenant);
+
+        [$originalContact, $serviceRequestType, $assignedPriority] = $tenant->execute(function () {
+            $originalContact = Contact::factory()->create([
+                'email' => 'student@example.com',
+            ]);
+
+            $serviceRequestType = ServiceRequestType::factory()
+                ->has(
+                    TenantServiceRequestTypeDomain::factory()->state([
+                        'domain' => 'help',
+                    ]),
+                    'domain'
+                )
+                ->has(
+                    ServiceRequestPriority::factory()->count(3),
+                    'priorities'
+                )
+                ->create([
+                    'is_email_automatic_creation_enabled' => true,
+                    'is_email_automatic_creation_contact_create_enabled' => false,
+                ]);
+
+            $assignedPriority = $serviceRequestType->priorities->first();
+
+            $serviceRequestType->update([
+                'email_automatic_creation_priority_id' => $assignedPriority->getKey(),
+            ]);
+
+            return [$originalContact, $serviceRequestType, $assignedPriority];
+        });
+
+        Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+
+        assert($filesystem instanceof FilesystemAdapter);
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', "tests/Landlord/Fixtures/{$fixture}"));
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        $mock->handle();
+
+        $tenant->makeCurrent();
+
+        // No contact should be created for the forwarder.
+        expect(Contact::query()->where('email', 'forwarder@school.edu')->exists())->toBeFalse();
+
+        $serviceRequests = ServiceRequest::all();
+
+        expect($serviceRequests)->toHaveCount(1);
+
+        $serviceRequest = $serviceRequests->first();
+
+        assert($serviceRequest instanceof ServiceRequest);
+
+        expect($serviceRequest->title)->toBe($expectedSubject)
+            ->and($serviceRequest->close_details)->toContain($expectedBodyContains)
+            ->and($serviceRequest->close_details)->not->toContain($forwarderWrapperContains)
+            ->and($serviceRequest->respondent->is($originalContact))->toBeTrue()
+            ->and($serviceRequest->priority->is($assignedPriority))->toBeTrue();
+
+        $filesystem->assertMissing('s3_email');
+    })->with([
+        'gmail' => ['s3_email_forwarded_gmail', 'Help with my account', 'I cannot log into my student portal', 'Hi team, please create a ticket'],
+        'outlook' => ['s3_email_forwarded_outlook', 'Billing question', 'charged twice for my tuition deposit', 'Please handle this one.'],
+        'apple' => ['s3_email_forwarded_apple', 'Library book overdue', 'library book is showing overdue', 'forwarding to the help desk'],
+        'outlook with underscore divider' => ['s3_email_forwarded_outlook_divider', 'Account access', 'I cannot access the portal', 'Forwarding to IT'],
+        'quoted-printable encoded' => ['s3_email_forwarded_quoted_printable', 'Café hours question', 'open on weekends', 'Hi team, please handle'],
+        'nested Fwd/FW subject' => ['s3_email_forwarded_nested_subject', 'Account help', 'cannot sign in to my account', 'Passing this along'],
+    ]);
+
+    it('creates a new contact for the original sender, not the forwarder, when contact creation is enabled', function () {
+        $tenant = Tenant::query()->firstOrFail();
+
+        assert($tenant instanceof Tenant);
+
+        $assignedPriority = $tenant->execute(function () {
+            seed(ContactTypeSeeder::class);
+
+            $serviceRequestType = ServiceRequestType::factory()
+                ->has(
+                    TenantServiceRequestTypeDomain::factory()->state([
+                        'domain' => 'help',
+                    ]),
+                    'domain'
+                )
+                ->has(
+                    ServiceRequestPriority::factory()->count(3),
+                    'priorities'
+                )
+                ->create([
+                    'is_email_automatic_creation_enabled' => true,
+                    'is_email_automatic_creation_contact_create_enabled' => true,
+                    'email_automatic_creation_contact_create_condition' => EmailAutomaticCreationContactCreateCondition::None,
+                ]);
+
+            $assignedPriority = $serviceRequestType->priorities->first();
+
+            $serviceRequestType->update([
+                'email_automatic_creation_priority_id' => $assignedPriority->getKey(),
+            ]);
+
+            return $assignedPriority;
+        });
+
+        Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+
+        assert($filesystem instanceof FilesystemAdapter);
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', 'tests/Landlord/Fixtures/s3_email_forwarded_gmail'));
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        assertDatabaseEmpty(Contact::class);
+
+        $mock->handle();
+
+        $tenant->makeCurrent();
+
+        $contacts = Contact::all();
+
+        expect($contacts)->toHaveCount(1);
+
+        $contact = $contacts->first();
+
+        assert($contact instanceof Contact);
+
+        expect($contact->email)->toBe('student@example.com')
+            ->and($contact->first_name)->toBe('Jordan')
+            ->and($contact->last_name)->toBe('Student')
+            ->and($contact->full_name)->toBe('Jordan Student');
+
+        $serviceRequest = ServiceRequest::query()->firstOrFail();
+
+        expect($serviceRequest->title)->toBe('Help with my account')
+            ->and($serviceRequest->respondent->is($contact))->toBeTrue()
+            ->and($serviceRequest->priority->is($assignedPriority))->toBeTrue();
+
+        $filesystem->assertMissing('s3_email');
+    });
+
+    it('evaluates organization eligibility against the original sender domain, not the forwarder domain', function () {
+        $tenant = Tenant::query()->firstOrFail();
+
+        assert($tenant instanceof Tenant);
+
+        $organization = $tenant->execute(function () {
+            seed(ContactTypeSeeder::class);
+
+            // Organization matches the ORIGINAL sender's domain (example.com), not the forwarder's (school.edu).
+            $organization = Organization::factory()->create([
+                'domains' => ['example.com'],
+            ]);
+
+            $serviceRequestType = ServiceRequestType::factory()
+                ->has(
+                    TenantServiceRequestTypeDomain::factory()->state([
+                        'domain' => 'help',
+                    ]),
+                    'domain'
+                )
+                ->has(
+                    ServiceRequestPriority::factory()->count(3),
+                    'priorities'
+                )
+                ->create([
+                    'is_email_automatic_creation_enabled' => true,
+                    'is_email_automatic_creation_contact_create_enabled' => true,
+                    'email_automatic_creation_contact_create_condition' => EmailAutomaticCreationContactCreateCondition::IfEligible,
+                ]);
+
+            $assignedPriority = $serviceRequestType->priorities->first();
+
+            $serviceRequestType->update([
+                'email_automatic_creation_priority_id' => $assignedPriority->getKey(),
+            ]);
+
+            return $organization;
+        });
+
+        Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+
+        assert($filesystem instanceof FilesystemAdapter);
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', 'tests/Landlord/Fixtures/s3_email_forwarded_gmail'));
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        $mock->handle();
+
+        $tenant->makeCurrent();
+
+        $contact = Contact::query()->where('email', 'student@example.com')->firstOrFail();
+
+        expect($contact->organization->is($organization))->toBeTrue();
+
+        $serviceRequest = ServiceRequest::query()->firstOrFail();
+
+        expect($serviceRequest->respondent->is($contact))->toBeTrue()
+            ->and($serviceRequest->title)->toBe('Help with my account');
+
+        $filesystem->assertMissing('s3_email');
+    });
+
+    it('sends the ineligible notification to the original sender when their domain is not eligible', function () {
+        $notificationFake = Notification::fake();
+
+        Event::listen(
+            MadeTenantCurrentEvent::class,
+            function (MadeTenantCurrentEvent $event) use ($notificationFake) {
+                Notification::swap($notificationFake);
+            }
+        );
+
+        $tenant = Tenant::query()->firstOrFail();
+
+        assert($tenant instanceof Tenant);
+
+        $tenant->execute(function () {
+            // Organization matches only the forwarder's domain, so the original sender is ineligible.
+            Organization::factory()->create([
+                'domains' => ['school.edu'],
+            ]);
+
+            $serviceRequestType = ServiceRequestType::factory()
+                ->has(
+                    TenantServiceRequestTypeDomain::factory()->state([
+                        'domain' => 'help',
+                    ]),
+                    'domain'
+                )
+                ->has(
+                    ServiceRequestPriority::factory()->count(3),
+                    'priorities'
+                )
+                ->create([
+                    'is_email_automatic_creation_enabled' => true,
+                    'is_email_automatic_creation_contact_create_enabled' => true,
+                    'email_automatic_creation_contact_create_condition' => EmailAutomaticCreationContactCreateCondition::IfEligible,
+                ]);
+
+            $assignedPriority = $serviceRequestType->priorities->first();
+
+            $serviceRequestType->update([
+                'email_automatic_creation_priority_id' => $assignedPriority->getKey(),
+            ]);
+        });
+
+        Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+
+        assert($filesystem instanceof FilesystemAdapter);
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', 'tests/Landlord/Fixtures/s3_email_forwarded_gmail'));
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        $mock->handle();
+
+        $tenant->makeCurrent();
+
+        assertDatabaseEmpty(ServiceRequest::class);
+        assertDatabaseEmpty(Contact::class);
+
+        $notificationFake->assertSentOnDemand(
+            IneligibleContactSesS3InboundEmailServiceRequestNotification::class,
+            function (IneligibleContactSesS3InboundEmailServiceRequestNotification $notification, array $channels, object $notifiable) {
+                return $notifiable->routes['mail'] === 'student@example.com';
+            }
+        );
+
+        $filesystem->assertMissing('s3_email');
+    });
+
+    it('falls back to the forwarder when a forward cannot be confidently parsed', function () {
+        $tenant = Tenant::query()->firstOrFail();
+
+        assert($tenant instanceof Tenant);
+
+        $forwarderContact = $tenant->execute(function () {
+            $forwarderContact = Contact::factory()->create([
+                'email' => 'forwarder@school.edu',
+            ]);
+
+            $serviceRequestType = ServiceRequestType::factory()
+                ->has(
+                    TenantServiceRequestTypeDomain::factory()->state([
+                        'domain' => 'help',
+                    ]),
+                    'domain'
+                )
+                ->has(
+                    ServiceRequestPriority::factory()->count(3),
+                    'priorities'
+                )
+                ->create([
+                    'is_email_automatic_creation_enabled' => true,
+                    'is_email_automatic_creation_contact_create_enabled' => false,
+                ]);
+
+            $assignedPriority = $serviceRequestType->priorities->first();
+
+            $serviceRequestType->update([
+                'email_automatic_creation_priority_id' => $assignedPriority->getKey(),
+            ]);
+
+            return $forwarderContact;
+        });
+
+        Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+
+        assert($filesystem instanceof FilesystemAdapter);
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', 'tests/Landlord/Fixtures/s3_email_forwarded_unparseable'));
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        $mock->handle();
+
+        $tenant->makeCurrent();
+
+        expect(Contact::query()->where('email', 'student@example.com')->exists())->toBeFalse();
+
+        $serviceRequest = ServiceRequest::query()->firstOrFail();
+
+        expect($serviceRequest->respondent->is($forwarderContact))->toBeTrue()
+            ->and($serviceRequest->title)->toBe('FW: General inquiry')
+            ->and($serviceRequest->close_details)->toContain('need help with enrollment');
+
+        $filesystem->assertMissing('s3_email');
+    });
+});
+
 describe('Legacy inbound email handling', function () {
     it('creates an UnmatchedInboundCommunication for a legacy bare-tenant address', function () {
         Storage::fake('s3');


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1249

### Technical Description

> Implement handling for forwarded emails in service request creation.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
