### PR TITLE
[AIDAPP-1245]: Engagement files should have an allowlist of file types

### DIFF
--- a/app-modules/engagement/src/Filament/Resources/EngagementFiles/EngagementFileResource.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementFiles/EngagementFileResource.php
@@ -89,7 +89,28 @@ class EngagementFileResource extends Resource
                     ->label('File')
                     ->disk('s3')
                     ->collection('file')
-                    ->required(),
+                    ->required()
+                    ->acceptedFileTypes([
+                        'image/png',
+                        'image/jpeg',
+                        'image/gif',
+                        'application/pdf',
+                        'application/msword',
+                        'text/csv',
+                        'application/vnd.ms-excel',
+                        'application/msexcel',
+                        'application/ms-excel',
+                        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                        'application/vnd.ms-powerpoint',
+                        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+                        'text/plain',
+                        'audio/mpeg',
+                        'video/mp4',
+                        'application/x-zip-compressed',
+                        'application/zip',
+                        'application/x-zip',
+                    ]),
             ]);
     }
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1245

### Technical Description

> Engagement files should have an allowlist of file types

### Any deployment steps required?

> NO

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
