### PR TITLE
[AIDAPP-1197]: Ensure Audit Logging Captures Programmatic User as Change Author

### DIFF
--- a/app-modules/audit/src/Filament/Resources/Audits/Pages/ListAudits.php
+++ b/app-modules/audit/src/Filament/Resources/Audits/Pages/ListAudits.php
@@ -39,6 +39,7 @@ namespace AidingApp\Audit\Filament\Resources\Audits\Pages;
 use AidingApp\Audit\Actions\Finders\AuditableModels;
 use AidingApp\Audit\Filament\Resources\Audits\AuditResource;
 use App\Filament\Tables\Columns\IdColumn;
+use App\Models\SystemUser;
 use App\Models\User;
 use Filament\Actions\ViewAction;
 use Filament\Resources\Pages\ListRecords;
@@ -54,14 +55,31 @@ class ListAudits extends ListRecords
     public function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query->with(['changeAgent']))
             ->columns([
                 IdColumn::make(),
                 TextColumn::make('auditable_type')
                     ->label('Auditable')
                     ->sortable(),
-                TextColumn::make('user.name')
-                    ->label('Change Agent (User)')
-                    ->sortable(query: fn (Builder $query, string $direction): Builder => $query->orderBy(User::select('name')->whereColumn('users.id', 'audits.change_agent_id'), $direction)),
+                TextColumn::make('changeAgent.name')
+                    ->label('Change Agent')
+                    ->sortable(
+                        query: fn (Builder $query, string $direction): Builder => $query->orderByRaw(
+                            'COALESCE((' .
+                                User::query()
+                                    ->select('name')
+                                    ->whereColumn('users.id', 'audits.change_agent_id')
+                                    ->where('audits.change_agent_type', 'user')
+                                    ->toRawSql() .
+                                '), (' .
+                                SystemUser::query()
+                                    ->select('name')
+                                    ->whereColumn('system_users.id', 'audits.change_agent_id')
+                                    ->where('audits.change_agent_type', 'system_user')
+                                    ->toRawSql() .
+                                ')) ' . $direction
+                        )
+                    ),
                 TextColumn::make('event')
                     ->label('Event')
                     ->sortable(),

--- a/app-modules/audit/src/Filament/Resources/Audits/Pages/ListAudits.php
+++ b/app-modules/audit/src/Filament/Resources/Audits/Pages/ListAudits.php
@@ -61,7 +61,7 @@ class ListAudits extends ListRecords
                     ->sortable(),
                 TextColumn::make('user.name')
                     ->label('Change Agent (User)')
-                    ->sortable(),
+                    ->sortable(query: fn (Builder $query, string $direction): Builder => $query->orderBy(User::select('name')->whereColumn('users.id', 'audits.change_agent_id'), $direction)),
                 TextColumn::make('event')
                     ->label('Event')
                     ->sortable(),

--- a/app-modules/audit/src/Filament/Resources/Audits/Pages/ListAudits.php
+++ b/app-modules/audit/src/Filament/Resources/Audits/Pages/ListAudits.php
@@ -65,19 +65,18 @@ class ListAudits extends ListRecords
                     ->label('Change Agent')
                     ->sortable(
                         query: fn (Builder $query, string $direction): Builder => $query->orderByRaw(
-                            'COALESCE((' .
+                            'CASE audits.change_agent_type ' .
+                                "WHEN 'user' THEN (" .
                                 User::query()
                                     ->select('name')
                                     ->whereColumn('users.id', 'audits.change_agent_id')
-                                    ->where('audits.change_agent_type', 'user')
                                     ->toRawSql() .
-                                '), (' .
+                                ") WHEN 'system_user' THEN (" .
                                 SystemUser::query()
                                     ->select('name')
                                     ->whereColumn('system_users.id', 'audits.change_agent_id')
-                                    ->where('audits.change_agent_type', 'system_user')
                                     ->toRawSql() .
-                                ')) ' . $direction
+                                ') END ' . $direction
                         )
                     ),
                 TextColumn::make('event')
@@ -86,10 +85,25 @@ class ListAudits extends ListRecords
             ])
             ->filters([
                 SelectFilter::make('change_agent_user')
-                    ->label('Change Agent (User)')
-                    ->options(fn (): array => User::query()->pluck('name', 'id')->all())
+                    ->label('Change Agent')
+                    ->options(fn (): array => [
+                        'Users' => User::query()->pluck('name', 'id')
+                            ->mapWithKeys(fn (string $name, string $id) => ["user:{$id}" => $name])
+                            ->all(),
+                        'System Users' => SystemUser::query()->pluck('name', 'id')
+                            ->mapWithKeys(fn (string $name, string $id) => ["system_user:{$id}" => $name])
+                            ->all(),
+                    ])
                     ->searchable()
-                    ->query(fn (Builder $query, array $data) => $data['value'] ? $query->where('change_agent_type', 'user')->where('change_agent_id', $data['value']) : null),
+                    ->query(function (Builder $query, array $data) {
+                        if (! $data['value']) {
+                            return null;
+                        }
+
+                        [$type, $id] = explode(':', $data['value'], 2);
+
+                        return $query->where('change_agent_type', $type)->where('change_agent_id', $id);
+                    }),
                 SelectFilter::make('auditable')
                     ->label('Auditable')
                     ->options(AuditableModels::all())

--- a/app-modules/audit/src/Models/Audit.php
+++ b/app-modules/audit/src/Models/Audit.php
@@ -42,6 +42,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use OwenIt\Auditing\Models\Audit as BaseAudit;
 use Spatie\Multitenancy\Models\Concerns\UsesTenantConnection;
@@ -73,6 +74,9 @@ class Audit extends BaseAudit
         );
     }
 
+    /**
+     * @return MorphTo<Model, $this>
+     */
     public function changeAgent(): MorphTo
     {
         return $this->morphTo();

--- a/app-modules/audit/src/Models/Audit.php
+++ b/app-modules/audit/src/Models/Audit.php
@@ -42,6 +42,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use OwenIt\Auditing\Models\Audit as BaseAudit;
 use Spatie\Multitenancy\Models\Concerns\UsesTenantConnection;
 
@@ -70,5 +71,10 @@ class Audit extends BaseAudit
                     ->retention_duration_in_days
             ),
         );
+    }
+
+    public function changeAgent(): MorphTo
+    {
+        return $this->morphTo();
     }
 }

--- a/app-modules/audit/tests/Tenant/Audit/ApiAuditAttributionTest.php
+++ b/app-modules/audit/tests/Tenant/Audit/ApiAuditAttributionTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app-modules/audit/tests/Tenant/Audit/ApiAuditAttributionTest.php
+++ b/app-modules/audit/tests/Tenant/Audit/ApiAuditAttributionTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Audit\Models\Audit;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
+use App\Models\SystemUser;
+use Laravel\Sanctum\Sanctum;
+
+use function Pest\Laravel\patchJson;
+
+beforeEach(function () {
+    config()->set('audit.queue.enable', false);
+});
+
+it('attributes audit change_agent to the authenticated SystemUser for API-initiated changes', function () {
+    $systemUser = SystemUser::factory()->create(['name' => 'Test System User']);
+    $systemUser->givePermissionTo(['service_request.view-any', 'service_request.*.update']);
+    Sanctum::actingAs($systemUser, ['api']);
+
+    $serviceRequest = ServiceRequest::factory()->create([
+        'status_id' => ServiceRequestStatus::factory()->state(['classification' => SystemServiceRequestClassification::Open]),
+    ]);
+
+    $newPriority = ServiceRequestPriority::factory()->create();
+
+    patchJson(
+        route('api.v1.service-requests.update', ['serviceRequest' => $serviceRequest], false),
+        ['priority_id' => $newPriority->id]
+    )->assertOk();
+
+    $audit = Audit::query()
+        ->where('auditable_type', $serviceRequest->getMorphClass())
+        ->where('auditable_id', $serviceRequest->id)
+        ->where('event', 'updated')
+        ->first();
+
+    expect($audit)->not->toBeNull();
+    expect($audit->change_agent_type)->toBe('system_user');
+    expect($audit->change_agent_id)->toBe($systemUser->id);
+});
+
+it('resolves the SystemUser name via the audit user() relationship', function () {
+    $systemUser = SystemUser::factory()->create(['name' => 'Test System User']);
+    $systemUser->givePermissionTo(['service_request.view-any', 'service_request.*.update']);
+    Sanctum::actingAs($systemUser, ['api']);
+
+    $serviceRequest = ServiceRequest::factory()->create([
+        'status_id' => ServiceRequestStatus::factory()->state(['classification' => SystemServiceRequestClassification::Open]),
+    ]);
+
+    $newPriority = ServiceRequestPriority::factory()->create();
+
+    patchJson(
+        route('api.v1.service-requests.update', ['serviceRequest' => $serviceRequest], false),
+        ['priority_id' => $newPriority->id]
+    )->assertOk();
+
+    $audit = Audit::query()
+        ->where('auditable_type', $serviceRequest->getMorphClass())
+        ->where('auditable_id', $serviceRequest->id)
+        ->where('event', 'updated')
+        ->first();
+
+    expect($audit->user)->toBeInstanceOf(SystemUser::class);
+    expect($audit->user->name)->toBe('Test System User');
+});
+
+it('records null change_agent when no user is authenticated', function () {
+    $serviceRequest = ServiceRequest::factory()->create([
+        'status_id' => ServiceRequestStatus::factory()->state(['classification' => SystemServiceRequestClassification::Open]),
+    ]);
+
+    $newPriority = ServiceRequestPriority::factory()->create();
+    $serviceRequest->update(['priority_id' => $newPriority->id]);
+
+    $audit = Audit::query()
+        ->where('auditable_type', $serviceRequest->getMorphClass())
+        ->where('auditable_id', $serviceRequest->id)
+        ->where('event', 'updated')
+        ->first();
+
+    expect($audit)->not->toBeNull();
+    expect($audit->change_agent_type)->toBeNull();
+    expect($audit->change_agent_id)->toBeNull();
+});

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -41,6 +41,7 @@ use AidingApp\Notification\Enums\NotificationChannel;
 use App\Models\Media;
 use App\Models\SystemUser;
 use App\Models\Tenant;
+use App\Models\User;
 use App\Overrides\Filament\Actions\Imports\Jobs\ImportCsvOverride;
 use App\Overrides\Filament\Actions\Imports\Jobs\PrepareCsvExportOverride;
 use App\Overrides\Laravel\PermissionMigrationCreator;
@@ -101,6 +102,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Relation::morphMap([
+            'user' => User::class,
             'system_user' => SystemUser::class,
             'tenant' => Tenant::class,
             'email_settings_property' => EmailSettingsProperty::class,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -41,7 +41,6 @@ use AidingApp\Notification\Enums\NotificationChannel;
 use App\Models\Media;
 use App\Models\SystemUser;
 use App\Models\Tenant;
-use App\Models\User;
 use App\Overrides\Filament\Actions\Imports\Jobs\ImportCsvOverride;
 use App\Overrides\Filament\Actions\Imports\Jobs\PrepareCsvExportOverride;
 use App\Overrides\Laravel\PermissionMigrationCreator;
@@ -102,7 +101,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Relation::morphMap([
-            'user' => User::class,
             'system_user' => SystemUser::class,
             'tenant' => Tenant::class,
             'email_settings_property' => EmailSettingsProperty::class,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1197

### Technical Description

> Ensure Audit Logging Captures Programmatic User as Change Author
> Add test to check system user audits are stored properly.

### Any deployment steps required?

> No

### Cleanup Tasks

> No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
