### PR TITLE
[AIDAPP-1248]: Some users have reported that when they select edit in the knowledge base, it does not take into account what tab they are on

### DIFF
--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/EditKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/EditKnowledgeBaseItem.php
@@ -238,6 +238,17 @@ class EditKnowledgeBaseItem extends EditRecord
             ]);
     }
 
+    public function getRedirectUrl(): ?string
+    {
+        $parameters = ['record' => $this->record];
+
+        if ($this->tab) {
+            $parameters['tab'] = $this->tab;
+        }
+
+        return KnowledgeBaseItemResource::getUrl('view', $parameters);
+    }
+
     protected function getSavedNotificationTitle(): ?string
     {
         return 'Article details successfully saved';
@@ -259,16 +270,5 @@ class EditKnowledgeBaseItem extends EditRecord
                 ->color('primary')
                 ->label('Save'),
         ];
-    }
-
-    public function getRedirectUrl(): ?string
-    {
-        $parameters = ['record' => $this->record];
-
-        if ($this->tab) {
-            $parameters['tab'] = $this->tab;
-        }
-
-        return KnowledgeBaseItemResource::getUrl('view', $parameters);
     }
 }

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/EditKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/EditKnowledgeBaseItem.php
@@ -64,6 +64,7 @@ use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Illuminate\Database\Eloquent\Builder;
+use Livewire\Attributes\Url;
 
 class EditKnowledgeBaseItem extends EditRecord
 {
@@ -72,13 +73,25 @@ class EditKnowledgeBaseItem extends EditRecord
 
     protected static string $resource = KnowledgeBaseItemResource::class;
 
+    #[Url]
+    public ?string $tab = null;
+
+    public function mount(int | string $record): void
+    {
+        parent::mount($record);
+
+        if (! in_array($this->tab, ['resource', 'properties'])) {
+            $this->tab = 'resource';
+        }
+    }
+
     public function form(Schema $schema): Schema
     {
         return $schema
             ->components([
                 Tabs::make()
                     ->tabs([
-                        Tab::make('Content')
+                        'resource' => Tab::make('Content')
                             ->label('Resource')
                             ->schema([
                                 RichEditor::make('article_details')
@@ -104,7 +117,7 @@ class EditKnowledgeBaseItem extends EditRecord
                                     DraftKnowledgeBaseItemWithAiAction::make(),
                                 ]),
                             ]),
-                        Tab::make('Properties')
+                        'properties' => Tab::make('Properties')
                             ->schema([
                                 TextInput::make('title')
                                     ->label('Article Title')
@@ -220,7 +233,8 @@ class EditKnowledgeBaseItem extends EditRecord
                             ])
                             ->columns(2),
                     ])
-                    ->columnSpanFull(),
+                    ->columnSpanFull()
+                    ->livewireProperty('tab'),
             ]);
     }
 
@@ -245,5 +259,16 @@ class EditKnowledgeBaseItem extends EditRecord
                 ->color('primary')
                 ->label('Save'),
         ];
+    }
+
+    public function getRedirectUrl(): ?string
+    {
+        $parameters = ['record' => $this->record];
+
+        if ($this->tab) {
+            $parameters['tab'] = $this->tab;
+        }
+
+        return KnowledgeBaseItemResource::getUrl('view', $parameters);
     }
 }

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItem.php
@@ -53,10 +53,23 @@ use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Components\View;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\Support\Htmlable;
+use Livewire\Attributes\Url;
 
 class ViewKnowledgeBaseItem extends ViewRecord
 {
     protected static string $resource = KnowledgeBaseItemResource::class;
+
+    #[Url]
+    public ?string $tab = null;
+
+    public function mount(int | string $record): void
+    {
+        parent::mount($record);
+
+        if (! in_array($this->tab, ['resource', 'properties', 'concerns', 'health'])) {
+            $this->tab = 'resource';
+        }
+    }
 
     public function getTitle(): string|Htmlable
     {
@@ -77,16 +90,15 @@ class ViewKnowledgeBaseItem extends ViewRecord
                 View::make('knowledge-base::filament.pages.badges'),
                 Tabs::make()
                     ->tabs([
-                        Tab::make('Content')
+                        'resource' => Tab::make('Content')
                             ->label('Resource')
                             ->schema([
                                 TextEntry::make('article_details')
                                     ->columnSpanFull()
                                     ->hiddenLabel()
                                     ->html(),
-                            ])
-                            ->id('content'),
-                        Tab::make('Properties')
+                            ]),
+                        'properties' => Tab::make('Properties')
                             ->schema([
                                 Grid::make(Division::count() > 1 ? 4 : 3)
                                     ->schema([
@@ -132,14 +144,12 @@ class ViewKnowledgeBaseItem extends ViewRecord
                                         return (int) round(($record->getAttribute('helpful_votes_count') / $totalVotes) * 100) . '%';
                                     }),
                             ])
-                            ->id('properties')
                             ->columns(2),
-                        Tab::make('Concerns')
+                        'concerns' => Tab::make('Concerns')
                             ->schema([
                                 Livewire::make(KnowledgeBaseItemConcernsTable::class, ['record' => $this->getRecord()]),
-                            ])
-                            ->id('concerns'),
-                        Tab::make('Health')
+                            ]),
+                        'health' => Tab::make('Health')
                             ->schema([
                                 IconEntry::make('title_filled')
                                     ->label('Title Filled')
@@ -166,11 +176,10 @@ class ViewKnowledgeBaseItem extends ViewRecord
                                         ? implode("\n", $record->broken_images ?? [])
                                         : 'No broken images were detected in this article.'),
                             ])
-                            ->columns(2)
-                            ->id('health'),
+                            ->columns(2),
                     ])
                     ->columnSpanFull()
-                    ->persistTabInQueryString(),
+                    ->livewireProperty('tab'),
             ]);
     }
 
@@ -178,7 +187,16 @@ class ViewKnowledgeBaseItem extends ViewRecord
     {
         return [
             CreateConcernAction::make(),
-            EditAction::make(),
+            EditAction::make()
+                ->url(function (): string {
+                    $parameters = ['record' => $this->getRecord()];
+
+                    if ($this->tab) {
+                        $parameters['tab'] = $this->tab;
+                    }
+
+                    return KnowledgeBaseItemResource::getUrl('edit', $parameters);
+                }),
             DeleteAction::make(),
         ];
     }

--- a/app-modules/knowledge-base/tests/Tenant/Filament/Resources/KnowledgeBaseItems/Pages/EditKnowledgeBaseItemTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/Filament/Resources/KnowledgeBaseItems/Pages/EditKnowledgeBaseItemTest.php
@@ -144,7 +144,7 @@ test('managers UserSelect does not show admin users in options by default', func
 
     livewire(EditKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
         ->assertSuccessful()
-        ->assertFormFieldExists('manager_ids', function (UserSelect $field) use ($regularUser, $adminUser): bool {
+        ->assertFormFieldExists('properties.manager_ids', function (UserSelect $field) use ($regularUser, $adminUser): bool {
             $options = $field->getSearchResults($regularUser->name);
             $adminOptions = $field->getSearchResults($adminUser->name);
 
@@ -170,7 +170,7 @@ test('managers UserSelect shows a pre-selected admin user so they can be deselec
 
     livewire(EditKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
         ->assertSuccessful()
-        ->assertFormFieldExists('manager_ids', function (UserSelect $field) use ($adminUser): bool {
+        ->assertFormFieldExists('properties.manager_ids', function (UserSelect $field) use ($adminUser): bool {
             $options = $field->getSearchResults($adminUser->name);
 
             return ! empty($options);
@@ -196,7 +196,7 @@ test('managers UserSelect shows all users including admins when filter_admins_fr
 
     livewire(EditKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
         ->assertSuccessful()
-        ->assertFormFieldExists('manager_ids', function (UserSelect $field) use ($adminUser): bool {
+        ->assertFormFieldExists('properties.manager_ids', function (UserSelect $field) use ($adminUser): bool {
             $options = $field->getSearchResults($adminUser->name);
 
             return ! empty($options);

--- a/app-modules/knowledge-base/tests/Tenant/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItemTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItemTest.php
@@ -43,6 +43,7 @@ use AidingApp\KnowledgeBase\Models\KnowledgeBaseItemConcern;
 use AidingApp\Portal\Models\KnowledgeBaseArticleVote;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
 use function Pest\Livewire\livewire;

--- a/app-modules/knowledge-base/tests/Tenant/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItemTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/Filament/Resources/KnowledgeBaseItems/Pages/ViewKnowledgeBaseItemTest.php
@@ -43,7 +43,6 @@ use AidingApp\KnowledgeBase\Models\KnowledgeBaseItemConcern;
 use AidingApp\Portal\Models\KnowledgeBaseArticleVote;
 use App\Models\User;
 use App\Settings\LicenseSettings;
-
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
 use function Pest\Livewire\livewire;
@@ -121,7 +120,7 @@ test('rating displays Unrated when article has no votes', function () {
     $knowledgeBaseItem = KnowledgeBaseItem::factory()->create();
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSeeText('Unrated');
+        ->assertSchemaComponentStateSet('properties.rating', 'Unrated', 'infolist');
 });
 
 test('rating displays correct percentage when article has votes', function () {
@@ -150,7 +149,7 @@ test('rating displays correct percentage when article has votes', function () {
         ->create();
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSeeText('67%');
+        ->assertSchemaComponentStateSet('properties.rating', '67%', 'infolist');
 });
 
 test('rating displays 100 percent when all votes are helpful', function () {
@@ -170,7 +169,7 @@ test('rating displays 100 percent when all votes are helpful', function () {
         ->create();
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSeeText('100%');
+        ->assertSchemaComponentStateSet('properties.rating', '100%', 'infolist');
 });
 
 test('rating displays 0 percent when no votes are helpful', function () {
@@ -190,7 +189,7 @@ test('rating displays 0 percent when no votes are helpful', function () {
         ->create();
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSeeText('0%');
+        ->assertSchemaComponentStateSet('properties.rating', '0%', 'infolist');
 });
 
 // Health Tab Tests
@@ -203,12 +202,12 @@ test('Health tab title_filled shows correct state', function () {
         ->create();
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('title_filled', false, 'infolist');
+        ->assertSchemaComponentStateSet('health.title_filled', false, 'infolist');
 
     $knowledgeBaseItem->update(['title' => 'Test Article']);
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('title_filled', true, 'infolist');
+        ->assertSchemaComponentStateSet('health.title_filled', true, 'infolist');
 });
 
 test('Health tab article_filled shows correct state', function () {
@@ -219,7 +218,7 @@ test('Health tab article_filled shows correct state', function () {
         ->create();
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('article_filled', false, 'infolist');
+        ->assertSchemaComponentStateSet('health.article_filled', false, 'infolist');
 
     $knowledgeBaseItem->update([
         'article_details' => [
@@ -231,7 +230,7 @@ test('Health tab article_filled shows correct state', function () {
     ]);
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('article_filled', false, 'infolist');
+        ->assertSchemaComponentStateSet('health.article_filled', false, 'infolist');
 
     $knowledgeBaseItem->update([
         'article_details' => [
@@ -243,7 +242,7 @@ test('Health tab article_filled shows correct state', function () {
     ]);
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('article_filled', false, 'infolist');
+        ->assertSchemaComponentStateSet('health.article_filled', false, 'infolist');
 
     $knowledgeBaseItem->update([
         'article_details' => [
@@ -255,7 +254,7 @@ test('Health tab article_filled shows correct state', function () {
     ]);
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('article_filled', true, 'infolist');
+        ->assertSchemaComponentStateSet('health.article_filled', true, 'infolist');
 });
 
 test('Health tab manager_assigned shows correct state', function () {
@@ -265,12 +264,12 @@ test('Health tab manager_assigned shows correct state', function () {
     $knowledgeBaseItem = KnowledgeBaseItem::factory()->create();
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('manager_assigned', false, 'infolist');
+        ->assertSchemaComponentStateSet('health.manager_assigned', false, 'infolist');
 
     $knowledgeBaseItem->managers()->attach($user);
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('manager_assigned', true, 'infolist');
+        ->assertSchemaComponentStateSet('health.manager_assigned', true, 'infolist');
 });
 
 test('Health tab no_unresolved_concerns shows correct state', function () {
@@ -284,12 +283,12 @@ test('Health tab no_unresolved_concerns shows correct state', function () {
         ->create();
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('no_unresolved_concerns', false, 'infolist');
+        ->assertSchemaComponentStateSet('health.no_unresolved_concerns', false, 'infolist');
 
     $concern->update(['status' => ConcernStatus::Resolved]);
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('no_unresolved_concerns', true, 'infolist');
+        ->assertSchemaComponentStateSet('health.no_unresolved_concerns', true, 'infolist');
 });
 
 test('Health tab no_broken_links shows correct state', function () {
@@ -303,7 +302,7 @@ test('Health tab no_broken_links shows correct state', function () {
         ->create();
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('no_broken_links', false, 'infolist');
+        ->assertSchemaComponentStateSet('health.no_broken_links', false, 'infolist');
 
     $knowledgeBaseItem->update([
         'are_broken_links_detected' => false,
@@ -311,7 +310,7 @@ test('Health tab no_broken_links shows correct state', function () {
     ]);
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('no_broken_links', true, 'infolist');
+        ->assertSchemaComponentStateSet('health.no_broken_links', true, 'infolist');
 });
 
 test('Health tab no_broken_images shows correct state', function () {
@@ -325,7 +324,7 @@ test('Health tab no_broken_images shows correct state', function () {
         ->create();
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('no_broken_images', false, 'infolist');
+        ->assertSchemaComponentStateSet('health.no_broken_images', false, 'infolist');
 
     $knowledgeBaseItem->update([
         'are_broken_images_detected' => false,
@@ -333,5 +332,5 @@ test('Health tab no_broken_images shows correct state', function () {
     ]);
 
     livewire(ViewKnowledgeBaseItem::class, ['record' => $knowledgeBaseItem->getRouteKey()])
-        ->assertSchemaComponentStateSet('no_broken_images', true, 'infolist');
+        ->assertSchemaComponentStateSet('health.no_broken_images', true, 'infolist');
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1248

### Technical Description

Syncs tabs with a Livewire prop, and uses that prop in the URL to preserve the active tab when clicking "Edit" or saving the edit form.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
