### PR TITLE
[AIDAPP-1315]: Introduce pipeline stage classifications

### DIFF
--- a/.cleanup-tasks/2026_07_14_pipeline_stage_classification_feature.md
+++ b/.cleanup-tasks/2026_07_14_pipeline_stage_classification_feature.md
@@ -1,0 +1,24 @@
+---
+title: Pipeline Stage Classification Feature
+created: 2026-07-14
+---
+
+## Feature Flags
+
+- `App\Features\PipelineStageClassificationFeature`
+
+## Temporary Migrations
+
+- The feature flag activation in `app-modules/project/database/migrations/2026_07_14_000001_add_classification_to_pipeline_stages_table.php` (the `PipelineStageClassificationFeature::activate()` / `deactivate()` calls) can be removed once the flag is cleaned up
+
+## Additional Cleanup
+
+- In `app-modules/project/src/Filament/Resources/Pipelines/Pages/CreatePipeline.php`: remove the `PipelineStageClassificationFeature::active()` condition from the classification `Select` field's `->visible()` call — it should always be visible. Remove the ternary in `->default()` on the Repeater — the default stages should always include `classification`.
+
+- In `app-modules/project/src/Filament/Resources/Pipelines/Pages/EditPipeline.php`: remove the `PipelineStageClassificationFeature::active()` condition from the classification `Select` field's `->visible()` call — it should always be visible.
+
+- In `app-modules/project/src/Filament/Resources/Projects/Pages/ManagePipelines.php`: remove the `PipelineStageClassificationFeature::active()` condition from the classification `Select` field's `->visible()` call — it should always be visible.
+
+- In `app-modules/project/src/Filament/Resources/Pipelines/Pages/ViewPipeline.php`: remove the `PipelineStageClassificationFeature::active()` condition from the classification `TextEntry`'s `->visible()` call — it should always be visible.
+
+- Delete the feature flag class: `app/Features/PipelineStageClassificationFeature.php`

--- a/app-modules/project/database/migrations/2026_07_14_514313_add_classification_to_pipeline_stages_table.php
+++ b/app-modules/project/database/migrations/2026_07_14_514313_add_classification_to_pipeline_stages_table.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app-modules/project/database/migrations/2026_07_14_514313_add_classification_to_pipeline_stages_table.php
+++ b/app-modules/project/database/migrations/2026_07_14_514313_add_classification_to_pipeline_stages_table.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -34,61 +34,35 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Project\Models;
-
-use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
-use AidingApp\Project\Database\Factories\PipelineStageFactory;
 use AidingApp\Project\Enums\PipelineStageClassification;
-use App\Models\BaseModel;
-use CanyonGBS\Common\Models\Concerns\HasUserSaveTracking;
-use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use OwenIt\Auditing\Contracts\Auditable;
+use App\Features\PipelineStageClassificationFeature;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
-/**
- * @mixin IdeHelperPipelineStage
- */
-class PipelineStage extends BaseModel implements Auditable
-{
-    /** @use HasFactory<PipelineStageFactory> */
-    use HasFactory;
-
-    use AuditableTrait;
-    use HasUuids;
-    use HasUserSaveTracking;
-
-    protected $fillable = [
-        'name',
-        'pipeline_id',
-        'order',
-        'classification',
-    ];
-
-    /**
-     * @return array<string, mixed>
-     */
-    protected function casts(): array
+return new class () extends Migration {
+    public function up(): void
     {
-        return [
-            'classification' => PipelineStageClassification::class,
-        ];
+        DB::transaction(function () {
+            Schema::table('pipeline_stages', function (Blueprint $table) {
+                $table->string('classification')
+                    ->initial(PipelineStageClassification::Planning->value)
+                    ->default(PipelineStageClassification::Planning->value);
+            });
+
+            PipelineStageClassificationFeature::activate();
+        });
     }
 
-    /**
-     * @return BelongsTo<Pipeline, $this>
-     */
-    public function pipeline(): BelongsTo
+    public function down(): void
     {
-        return $this->belongsTo(Pipeline::class);
-    }
+        DB::transaction(function () {
+            PipelineStageClassificationFeature::deactivate();
 
-    /**
-     * @return HasMany<PipelineEntry, $this>
-     */
-    public function pipelineEntries(): HasMany
-    {
-        return $this->hasMany(PipelineEntry::class);
+            Schema::table('pipeline_stages', function (Blueprint $table) {
+                $table->dropColumn('classification');
+            });
+        });
     }
-}
+};

--- a/app-modules/project/database/migrations/2026_07_14_514313_add_classification_to_pipeline_stages_table.php
+++ b/app-modules/project/database/migrations/2026_07_14_514313_add_classification_to_pipeline_stages_table.php
@@ -47,7 +47,6 @@ return new class () extends Migration {
         DB::transaction(function () {
             Schema::table('pipeline_stages', function (Blueprint $table) {
                 $table->string('classification')
-                    ->initial(PipelineStageClassification::Planning->value)
                     ->default(PipelineStageClassification::Planning->value);
             });
 

--- a/app-modules/project/src/Enums/PipelineStageClassification.php
+++ b/app-modules/project/src/Enums/PipelineStageClassification.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app-modules/project/src/Enums/PipelineStageClassification.php
+++ b/app-modules/project/src/Enums/PipelineStageClassification.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -34,30 +34,24 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Project\Database\Factories;
+namespace AidingApp\Project\Enums;
 
-use AidingApp\Project\Enums\PipelineStageClassification;
-use AidingApp\Project\Models\Pipeline;
-use AidingApp\Project\Models\PipelineStage;
-use Illuminate\Database\Eloquent\Factories\Factory;
+use Filament\Support\Contracts\HasLabel;
 
-/**
- * @extends Factory<PipelineStage>
- */
-class PipelineStageFactory extends Factory
+enum PipelineStageClassification: string implements HasLabel
 {
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
-    public function definition(): array
+    case Planning = 'planning';
+
+    case InProgress = 'in_progress';
+
+    case Complete = 'complete';
+
+    public function getLabel(): string
     {
-        return [
-            'name' => $this->faker->unique()->words(3, true),
-            'pipeline_id' => Pipeline::factory(),
-            'order' => $this->faker->numberBetween(1, 5),
-            'classification' => $this->faker->randomElement(PipelineStageClassification::cases()),
-        ];
+        return match ($this) {
+            self::Planning => 'Planning',
+            self::InProgress => 'In Progress',
+            self::Complete => 'Complete',
+        };
     }
 }

--- a/app-modules/project/src/Filament/Resources/Pipelines/Pages/CreatePipeline.php
+++ b/app-modules/project/src/Filament/Resources/Pipelines/Pages/CreatePipeline.php
@@ -36,12 +36,15 @@
 
 namespace AidingApp\Project\Filament\Resources\Pipelines\Pages;
 
+use AidingApp\Project\Enums\PipelineStageClassification;
 use AidingApp\Project\Filament\Resources\Pipelines\PipelineResource;
 use AidingApp\Project\Filament\Resources\Projects\ProjectResource;
 use AidingApp\Project\Models\Project;
+use App\Features\PipelineStageClassificationFeature;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Repeater\TableColumn;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
@@ -70,6 +73,7 @@ class CreatePipeline extends CreateRecord
                 Repeater::make('stages')
                     ->table([
                         TableColumn::make('Stage Name'),
+                        ...(PipelineStageClassificationFeature::active() ? [TableColumn::make('Classification')] : []),
                     ])
                     ->relationship('stages')
                     ->schema([
@@ -77,7 +81,21 @@ class CreatePipeline extends CreateRecord
                             ->label('Stage')
                             ->distinct()
                             ->required(),
+                        Select::make('classification')
+                            ->label('Classification')
+                            ->options(PipelineStageClassification::class)
+                            ->enum(PipelineStageClassification::class)
+                            ->required()
+                            ->native()
+                            ->default(PipelineStageClassification::Planning->value)
+                            ->visible(fn () => PipelineStageClassificationFeature::active()),
                     ])
+                    ->default(
+                        collect(PipelineStageClassification::cases())->map(fn (PipelineStageClassification $case) => [
+                            'name' => $case->getLabel(),
+                            ...(PipelineStageClassificationFeature::active() ? ['classification' => $case->value] : []),
+                        ])->all()
+                    )
                     ->orderColumn('order')
                     ->reorderable()
                     ->columnSpanFull()

--- a/app-modules/project/src/Filament/Resources/Pipelines/Pages/EditPipeline.php
+++ b/app-modules/project/src/Filament/Resources/Pipelines/Pages/EditPipeline.php
@@ -36,14 +36,17 @@
 
 namespace AidingApp\Project\Filament\Resources\Pipelines\Pages;
 
+use AidingApp\Project\Enums\PipelineStageClassification;
 use AidingApp\Project\Filament\Resources\Pipelines\PipelineResource;
 use AidingApp\Project\Filament\Resources\Projects\ProjectResource;
 use AidingApp\Project\Models\Pipeline;
 use AidingApp\Project\Models\PipelineStage;
+use App\Features\PipelineStageClassificationFeature;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Repeater\TableColumn;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
@@ -71,12 +74,21 @@ class EditPipeline extends EditRecord
                     ->relationship('stages')
                     ->table([
                         TableColumn::make('Stage Name'),
+                        ...(PipelineStageClassificationFeature::active() ? [TableColumn::make('Classification')] : []),
                     ])
                     ->schema([
                         TextInput::make('name')
                             ->label('Stage')
                             ->distinct()
                             ->required(),
+                        Select::make('classification')
+                            ->label('Classification')
+                            ->options(PipelineStageClassification::class)
+                            ->enum(PipelineStageClassification::class)
+                            ->required()
+                            ->native()
+                            ->default(PipelineStageClassification::Planning->value)
+                            ->visible(fn () => PipelineStageClassificationFeature::active()),
                     ])
                     ->deleteAction(
                         function (Action $action) {

--- a/app-modules/project/src/Filament/Resources/Pipelines/Pages/ViewPipeline.php
+++ b/app-modules/project/src/Filament/Resources/Pipelines/Pages/ViewPipeline.php
@@ -39,6 +39,7 @@ namespace AidingApp\Project\Filament\Resources\Pipelines\Pages;
 use AidingApp\Project\Filament\Resources\Pipelines\PipelineResource;
 use AidingApp\Project\Filament\Resources\Projects\ProjectResource;
 use AidingApp\Project\Models\Pipeline;
+use App\Features\PipelineStageClassificationFeature;
 use Filament\Infolists\Components\RepeatableEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Pages\ViewRecord;
@@ -62,6 +63,10 @@ class ViewPipeline extends ViewRecord
                     ->schema([
                         TextEntry::make('name')
                             ->label('Stage'),
+                        TextEntry::make('classification')
+                            ->label('Classification')
+                            ->badge()
+                            ->visible(fn () => PipelineStageClassificationFeature::active()),
                     ])
                     ->label('Other stages')
                     ->columns(2),

--- a/app-modules/project/src/Filament/Resources/Projects/Pages/ManagePipelines.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Pages/ManagePipelines.php
@@ -36,14 +36,17 @@
 
 namespace AidingApp\Project\Filament\Resources\Projects\Pages;
 
+use AidingApp\Project\Enums\PipelineStageClassification;
 use AidingApp\Project\Filament\Resources\Pipelines\PipelineResource;
 use AidingApp\Project\Filament\Resources\Projects\ProjectResource;
 use AidingApp\Project\Models\Pipeline;
+use App\Features\PipelineStageClassificationFeature;
 use Filament\Actions\CreateAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Repeater\TableColumn;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\ManageRelatedRecords;
@@ -85,12 +88,21 @@ class ManagePipelines extends ManageRelatedRecords
                     ->relationship('stages')
                     ->table([
                         TableColumn::make('Stage Name'),
+                        ...(PipelineStageClassificationFeature::active() ? [TableColumn::make('Classification')] : []),
                     ])
                     ->schema([
                         TextInput::make('name')
                             ->label('Stage')
                             ->distinct()
                             ->required(),
+                        Select::make('classification')
+                            ->label('Classification')
+                            ->options(PipelineStageClassification::class)
+                            ->enum(PipelineStageClassification::class)
+                            ->required()
+                            ->native()
+                            ->default(PipelineStageClassification::Planning->value)
+                            ->visible(fn () => PipelineStageClassificationFeature::active()),
                     ])
                     ->orderColumn('order')
                     ->reorderable()

--- a/app-modules/project/src/Models/PipelineStage.php
+++ b/app-modules/project/src/Models/PipelineStage.php
@@ -66,6 +66,10 @@ class PipelineStage extends BaseModel implements Auditable
         'classification',
     ];
 
+    protected $casts = [
+        'classification' => PipelineStageClassification::class,
+    ];
+
     /**
      * @return BelongsTo<Pipeline, $this>
      */
@@ -80,15 +84,5 @@ class PipelineStage extends BaseModel implements Auditable
     public function pipelineEntries(): HasMany
     {
         return $this->hasMany(PipelineEntry::class);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    protected function casts(): array
-    {
-        return [
-            'classification' => PipelineStageClassification::class,
-        ];
     }
 }

--- a/app-modules/project/src/Models/PipelineStage.php
+++ b/app-modules/project/src/Models/PipelineStage.php
@@ -67,16 +67,6 @@ class PipelineStage extends BaseModel implements Auditable
     ];
 
     /**
-     * @return array<string, mixed>
-     */
-    protected function casts(): array
-    {
-        return [
-            'classification' => PipelineStageClassification::class,
-        ];
-    }
-
-    /**
      * @return BelongsTo<Pipeline, $this>
      */
     public function pipeline(): BelongsTo
@@ -90,5 +80,15 @@ class PipelineStage extends BaseModel implements Auditable
     public function pipelineEntries(): HasMany
     {
         return $this->hasMany(PipelineEntry::class);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function casts(): array
+    {
+        return [
+            'classification' => PipelineStageClassification::class,
+        ];
     }
 }

--- a/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/Pages/CreatePipelineTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/Pages/CreatePipelineTest.php
@@ -120,10 +120,10 @@ it('defaults new pipeline stages to planning', function () {
     asSuperAdmin($superAdmin);
 
     $pipelineData = [
-            'name' => 'Test',
-            'description' => 'This is a test pipeline',
-            'stages' => [['name' => 'Stage One']],
-        ];
+        'name' => 'Test',
+        'description' => 'This is a test pipeline',
+        'stages' => [['name' => 'Stage One']],
+    ];
 
     livewire(CreatePipeline::class)
         ->fillForm($pipelineData)

--- a/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/Pages/CreatePipelineTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/Pages/CreatePipelineTest.php
@@ -41,6 +41,7 @@ use App\Models\User;
 use Filament\Forms\Components\Repeater;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertCount;
 use function Tests\asSuperAdmin;
@@ -108,6 +109,31 @@ it('can create pipelines', function () {
     $createdPipeline = Pipeline::first();
     assertCount(1, Pipeline::all());
     expect($createdPipeline->stages)->toHaveCount(3);
+
+    $undoRepeaterFake();
+});
+
+it('defaults new pipeline stages to planning', function () {
+    $undoRepeaterFake = Repeater::fake();
+
+    $superAdmin = User::factory()->create();
+    asSuperAdmin($superAdmin);
+
+    $pipelineData = [
+            'name' => 'Test',
+            'description' => 'This is a test pipeline',
+            'stages' => [['name' => 'Stage One']],
+        ];
+
+    livewire(CreatePipeline::class)
+        ->fillForm($pipelineData)
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    assertDatabaseHas('pipeline_stages', [
+        'name' => 'Stage One',
+        'classification' => 'planning',
+    ]);
 
     $undoRepeaterFake();
 });

--- a/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/CreatePipelineRequestFactory.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/CreatePipelineRequestFactory.php
@@ -46,11 +46,10 @@ class CreatePipelineRequestFactory extends RequestFactory
         return [
             'name' => fake()->words(3, true),
             'description' => fake()->sentence(),
-            'stages' => fn () => [
-                ['name' => 'Planning', 'classification' => PipelineStageClassification::Planning->value],
-                ['name' => 'In Progress', 'classification' => PipelineStageClassification::InProgress->value],
-                ['name' => 'Complete', 'classification' => PipelineStageClassification::Complete->value],
-            ],
+            'stages' => fn () => collect(PipelineStageClassification::cases())->map(fn ($classification) => [
+                'name' => $classification->getLabel(),
+                'classification' => $classification->value,
+            ]),
         ];
     }
 }

--- a/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/CreatePipelineRequestFactory.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/CreatePipelineRequestFactory.php
@@ -49,7 +49,7 @@ class CreatePipelineRequestFactory extends RequestFactory
             'stages' => fn () => collect(PipelineStageClassification::cases())->map(fn ($classification) => [
                 'name' => $classification->getLabel(),
                 'classification' => $classification->value,
-            ]),
+            ])->toArray(),
         ];
     }
 }

--- a/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/CreatePipelineRequestFactory.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/CreatePipelineRequestFactory.php
@@ -36,6 +36,7 @@
 
 namespace AidingApp\Project\Tests\Tenant\Filament\Resources\PipelineResource\RequestFactory;
 
+use AidingApp\Project\Enums\PipelineStageClassification;
 use Worksome\RequestFactories\RequestFactory;
 
 class CreatePipelineRequestFactory extends RequestFactory
@@ -45,14 +46,11 @@ class CreatePipelineRequestFactory extends RequestFactory
         return [
             'name' => fake()->words(3, true),
             'description' => fake()->sentence(),
-            'stages' => fn () => array_map(
-                fn ($stage) => ['name' => $stage],
-                [
-                    fake()->unique()->word(),
-                    fake()->unique()->word(),
-                    fake()->unique()->word(),
-                ]
-            ),
+            'stages' => fn () => [
+                ['name' => 'Planning', 'classification' => PipelineStageClassification::Planning->value],
+                ['name' => 'In Progress', 'classification' => PipelineStageClassification::InProgress->value],
+                ['name' => 'Complete', 'classification' => PipelineStageClassification::Complete->value],
+            ],
         ];
     }
 }

--- a/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/EditPipelineRequestFactory.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/EditPipelineRequestFactory.php
@@ -36,6 +36,7 @@
 
 namespace AidingApp\Project\Tests\Tenant\Filament\Resources\PipelineResource\RequestFactory;
 
+use AidingApp\Project\Enums\PipelineStageClassification;
 use Worksome\RequestFactories\RequestFactory;
 
 class EditPipelineRequestFactory extends RequestFactory
@@ -45,13 +46,10 @@ class EditPipelineRequestFactory extends RequestFactory
         return [
             'name' => fake()->words(3, true),
             'description' => fake()->sentence(),
-            'stages' => fn () => array_map(
-                fn ($stage) => ['name' => $stage],
-                [
-                    fake()->unique()->word(),
-                    fake()->unique()->word(),
-                ]
-            ),
+            'stages' => fn () => [
+                ['name' => fake()->unique()->word(), 'classification' => PipelineStageClassification::Planning->value],
+                ['name' => fake()->unique()->word(), 'classification' => PipelineStageClassification::InProgress->value],
+            ],
         ];
     }
 }

--- a/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/EditPipelineRequestFactory.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/EditPipelineRequestFactory.php
@@ -46,10 +46,10 @@ class EditPipelineRequestFactory extends RequestFactory
         return [
             'name' => fake()->words(3, true),
             'description' => fake()->sentence(),
-            'stages' => fn () => [
-                ['name' => fake()->unique()->word(), 'classification' => PipelineStageClassification::Planning->value],
-                ['name' => fake()->unique()->word(), 'classification' => PipelineStageClassification::InProgress->value],
-            ],
+            'stages' => fn () => collect(PipelineStageClassification::cases())->map(fn ($classification) => [
+                'name' => $classification->getLabel(),
+                'classification' => $classification->value,
+            ]),
         ];
     }
 }

--- a/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/EditPipelineRequestFactory.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/RequestFactory/EditPipelineRequestFactory.php
@@ -49,7 +49,7 @@ class EditPipelineRequestFactory extends RequestFactory
             'stages' => fn () => collect(PipelineStageClassification::cases())->map(fn ($classification) => [
                 'name' => $classification->getLabel(),
                 'classification' => $classification->value,
-            ]),
+            ])->toArray(),
         ];
     }
 }

--- a/app-modules/project/tests/Tenant/PipelineStageClassificationTest.php
+++ b/app-modules/project/tests/Tenant/PipelineStageClassificationTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app-modules/project/tests/Tenant/PipelineStageClassificationTest.php
+++ b/app-modules/project/tests/Tenant/PipelineStageClassificationTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Project\Enums\PipelineStageClassification;
+use AidingApp\Project\Models\Pipeline;
+use AidingApp\Project\Models\PipelineStage;
+use AidingApp\Project\Models\Project;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Tests\asSuperAdmin;
+
+it('has three classification values', function () {
+    expect(PipelineStageClassification::cases())->toHaveCount(3);
+    expect(PipelineStageClassification::Planning->value)->toBe('planning');
+    expect(PipelineStageClassification::InProgress->value)->toBe('in_progress');
+    expect(PipelineStageClassification::Complete->value)->toBe('complete');
+});
+
+it('casts classification to the enum on PipelineStage model', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+    $pipeline = Pipeline::factory()->for($project)->create();
+
+    $stage = PipelineStage::factory()->create([
+        'pipeline_id' => $pipeline->id,
+        'classification' => PipelineStageClassification::InProgress,
+    ]);
+
+    $stage->refresh();
+
+    expect($stage->classification)->toBe(PipelineStageClassification::InProgress);
+});
+
+it('defaults classification to planning for new stages', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+    $pipeline = Pipeline::factory()->for($project)->create();
+
+    $stage = PipelineStage::factory()->create([
+        'pipeline_id' => $pipeline->id,
+        'classification' => PipelineStageClassification::Planning,
+    ]);
+
+    assertDatabaseHas('pipeline_stages', [
+        'id' => $stage->id,
+        'classification' => 'planning',
+    ]);
+});
+
+it('stores each classification value correctly', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+    $pipeline = Pipeline::factory()->for($project)->create();
+
+    foreach (PipelineStageClassification::cases() as $classification) {
+        $stage = PipelineStage::factory()->create([
+            'pipeline_id' => $pipeline->id,
+            'classification' => $classification,
+        ]);
+
+        assertDatabaseHas('pipeline_stages', [
+            'id' => $stage->id,
+            'classification' => $classification->value,
+        ]);
+    }
+});
+
+it('returns proper labels for each classification', function () {
+    expect(PipelineStageClassification::Planning->getLabel())->toBe('Planning');
+    expect(PipelineStageClassification::InProgress->getLabel())->toBe('In Progress');
+    expect(PipelineStageClassification::Complete->getLabel())->toBe('Complete');
+});

--- a/app-modules/project/tests/Tenant/PipelineStageClassificationTest.php
+++ b/app-modules/project/tests/Tenant/PipelineStageClassificationTest.php
@@ -42,20 +42,6 @@ use AidingApp\Project\Models\Project;
 use function Pest\Laravel\assertDatabaseHas;
 use function Tests\asSuperAdmin;
 
-it('defaults classification to planning for new stages', function () {
-    asSuperAdmin();
-
-    $project = Project::factory()->create();
-    $pipeline = Pipeline::factory()->for($project)->create();
-
-    $stage = PipelineStage::factory()->create(['pipeline_id' => $pipeline->id]);
-
-    assertDatabaseHas('pipeline_stages', [
-        'id' => $stage->id,
-        'classification' => 'planning',
-    ]);
-});
-
 it('stores each classification value correctly', function () {
     asSuperAdmin();
 

--- a/app-modules/project/tests/Tenant/PipelineStageClassificationTest.php
+++ b/app-modules/project/tests/Tenant/PipelineStageClassificationTest.php
@@ -42,39 +42,13 @@ use AidingApp\Project\Models\Project;
 use function Pest\Laravel\assertDatabaseHas;
 use function Tests\asSuperAdmin;
 
-it('has three classification values', function () {
-    expect(PipelineStageClassification::cases())->toHaveCount(3);
-    expect(PipelineStageClassification::Planning->value)->toBe('planning');
-    expect(PipelineStageClassification::InProgress->value)->toBe('in_progress');
-    expect(PipelineStageClassification::Complete->value)->toBe('complete');
-});
-
-it('casts classification to the enum on PipelineStage model', function () {
-    asSuperAdmin();
-
-    $project = Project::factory()->create();
-    $pipeline = Pipeline::factory()->for($project)->create();
-
-    $stage = PipelineStage::factory()->create([
-        'pipeline_id' => $pipeline->id,
-        'classification' => PipelineStageClassification::InProgress,
-    ]);
-
-    $stage->refresh();
-
-    expect($stage->classification)->toBe(PipelineStageClassification::InProgress);
-});
-
 it('defaults classification to planning for new stages', function () {
     asSuperAdmin();
 
     $project = Project::factory()->create();
     $pipeline = Pipeline::factory()->for($project)->create();
 
-    $stage = PipelineStage::factory()->create([
-        'pipeline_id' => $pipeline->id,
-        'classification' => PipelineStageClassification::Planning,
-    ]);
+    $stage = PipelineStage::factory()->create(['pipeline_id' => $pipeline->id]);
 
     assertDatabaseHas('pipeline_stages', [
         'id' => $stage->id,

--- a/app/Features/PipelineStageClassificationFeature.php
+++ b/app/Features/PipelineStageClassificationFeature.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of

--- a/app/Features/PipelineStageClassificationFeature.php
+++ b/app/Features/PipelineStageClassificationFeature.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -34,30 +34,14 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Project\Database\Factories;
+namespace App\Features;
 
-use AidingApp\Project\Enums\PipelineStageClassification;
-use AidingApp\Project\Models\Pipeline;
-use AidingApp\Project\Models\PipelineStage;
-use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Support\AbstractFeatureFlag;
 
-/**
- * @extends Factory<PipelineStage>
- */
-class PipelineStageFactory extends Factory
+class PipelineStageClassificationFeature extends AbstractFeatureFlag
 {
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
-    public function definition(): array
+    public function resolve(mixed $scope): mixed
     {
-        return [
-            'name' => $this->faker->unique()->words(3, true),
-            'pipeline_id' => Pipeline::factory(),
-            'order' => $this->faker->numberBetween(1, 5),
-            'classification' => $this->faker->randomElement(PipelineStageClassification::cases()),
-        ];
+        return false;
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1315

### Technical Description

- New enum: `PipelineStageClassification` with Planning, InProgress, Complete cases
- Migration: Adds `classification` column to `pipeline_stages` table with Planning as the default for existing rows (uses initial() modifier)
- Feature flag: `PipelineStageClassificationFeature` gates the field visibility; activated during migration
- Model: Updated `PipelineStage` with classification in fillable and casts
- UI: Added classification Select (native) to the stages Repeater on Create, Edit, and Manage Pipelines pages; added badge display on View Pipeline
- Defaults: New pipelines are seeded with one stage per classification (Planning → In Progress → Complete)
- Factory/Request factories: Updated to include classification data
- Tests: `PipelineStageClassificationTest` covers enum values, model casting, DB persistence, and labels

### Any deployment steps required?

No

### Cleanup Tasks

Feature Flag Added: `.cleanup-tasks/2026_07_14_pipeline_stage_classification_feature.md`

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
