### PR TITLE
[AIDAPP-1333]: The related to manager field in the Service Request list is not displaying the correct users

### DIFF
--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
@@ -81,7 +81,7 @@ class ListServiceRequests extends ListRecords
                 'latestInboundServiceRequestUpdate',
                 'latestOutboundServiceRequestUpdate',
                 'priority.sla',
-                'priority.type.managerUsers',
+                'assignedTo.user',
                 'respondent.organization',
                 'feedback',
                 'status',

--- a/resources/views/filament/tables/columns/service-request/related-to.blade.php
+++ b/resources/views/filament/tables/columns/service-request/related-to.blade.php
@@ -1,13 +1,13 @@
 {{--
     <COPYRIGHT>
-
+    
     Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
-
+    
     Aiding App® is licensed under the Elastic License 2.0. For more details,
     see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
-
+    
     Notice:
-
+    
     - You may not provide the software to third parties as a hosted or managed
     service, where the service provides users with access to any substantial set of
     the features or functionality of the software.
@@ -25,10 +25,10 @@
     Software as a Service (SaaS) by Canyon GBS Inc.
     - Use of this software implies agreement to the license terms and conditions as stated
     in the Elastic License 2.0.
-
+    
     For more information or inquiries please visit our website at
     <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
-
+    
     </COPYRIGHT>
 --}}
 @php

--- a/resources/views/filament/tables/columns/service-request/related-to.blade.php
+++ b/resources/views/filament/tables/columns/service-request/related-to.blade.php
@@ -1,13 +1,13 @@
 {{--
     <COPYRIGHT>
-    
+
     Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
-    
+
     Aiding App® is licensed under the Elastic License 2.0. For more details,
     see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
-    
+
     Notice:
-    
+
     - You may not provide the software to third parties as a hosted or managed
     service, where the service provides users with access to any substantial set of
     the features or functionality of the software.
@@ -25,10 +25,10 @@
     Software as a Service (SaaS) by Canyon GBS Inc.
     - Use of this software implies agreement to the license terms and conditions as stated
     in the Elastic License 2.0.
-    
+
     For more information or inquiries please visit our website at
     <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
-    
+
     </COPYRIGHT>
 --}}
 @php
@@ -36,7 +36,7 @@
 
     $record = $getRecord();
 
-    $managers = $record->priority?->type?->managerUsers ?? collect();
+    $assignedUser = $record->assignedTo?->user;
 
     $respondent = $record->respondent;
     $customerName = $respondent?->{Contact::displayNameKey()};
@@ -46,10 +46,10 @@
 <div class="fi-ta-text grid w-full gap-y-1 text-sm text-gray-950 dark:text-white">
     <div class="flex flex-wrap items-center gap-x-2">
         <span class="font-medium">Manager:</span>
-        @if ($managers->isEmpty())
+        @if (! $assignedUser)
             <x-filament::badge color="gray">Unassigned</x-filament::badge>
         @else
-            <span>{{ $managers->pluck("name")->join(", ") }}</span>
+            <span>{{ $assignedUser->name }}</span>
         @endif
     </div>
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1333

### Technical Description

This pull request updates how the "Manager" field is displayed in the Service Requests table, switching from showing all manager users associated with a priority type to displaying only the assigned user's name. The changes also update the data relationships used to retrieve this information.

**Display logic and data source updates:**

* The table now loads the `assignedTo.user` relationship instead of `priority.type.managerUsers`, ensuring the assigned user's information is available for display.
* In the related Blade view, the variable previously holding manager users has been replaced with the assigned user, and the display logic now shows the assigned user's name or "Unassigned" if none is set. [[1]](diffhunk://#diff-6bc30779a299c269d1e0475741a28ba0e31b8f8ecf09a21898f54d35ff613a6dL39-R39) [[2]](diffhunk://#diff-6bc30779a299c269d1e0475741a28ba0e31b8f8ecf09a21898f54d35ff613a6dL49-R52)

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
