### PR TITLE
[AIDAPP-1339]: Some users have reported not seeing the service request open button in the portal widget

### DIFF
--- a/app-modules/ai/src/Http/Controllers/AssistantWidget/GetWidgetConfigController.php
+++ b/app-modules/ai/src/Http/Controllers/AssistantWidget/GetWidgetConfigController.php
@@ -37,13 +37,12 @@
 namespace AidingApp\Ai\Http\Controllers\AssistantWidget;
 
 use AidingApp\Portal\Settings\PortalSettings;
-use App\Enums\Feature;
 use App\Http\Controllers\Controller;
+use App\Settings\LicenseSettings;
 use Filament\Support\Colors\Color;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL;
 
 class GetWidgetConfigController extends Controller
@@ -59,7 +58,7 @@ class GetWidgetConfigController extends Controller
         $settings = app(PortalSettings::class);
 
         $serviceManagementEnabled = $settings->knowledge_management_portal_service_management
-            && Gate::check(Feature::ServiceManagement->getGateName());
+            && (bool) app(LicenseSettings::class)->data?->addons?->serviceManagement;
 
         $websocketsConfig = config('filament.broadcasting.echo');
 

--- a/app-modules/ai/tests/Tenant/Http/Controllers/AssistantWidget/GetWidgetConfigControllerTest.php
+++ b/app-modules/ai/tests/Tenant/Http/Controllers/AssistantWidget/GetWidgetConfigControllerTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Contact\Models\Contact;
+use AidingApp\Portal\Settings\PortalSettings;
+use App\Settings\LicenseSettings;
+use Illuminate\Support\Facades\File;
+use Illuminate\Testing\TestResponse;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\getJson;
+
+beforeEach(function () {
+    $portalSettings = app(PortalSettings::class);
+    $portalSettings->knowledge_management_portal_enabled = true;
+    $portalSettings->ai_support_assistant = true;
+    $portalSettings->save();
+
+    $manifestPath = public_path('storage/widgets/assistant/.vite/manifest.json');
+
+    $this->manifestPath = $manifestPath;
+    $this->manifestOriginalContents = File::exists($manifestPath) ? File::get($manifestPath) : null;
+
+    File::ensureDirectoryExists(dirname($manifestPath));
+    File::put($manifestPath, json_encode([
+        'src/widget.js' => [
+            'file' => 'assets/widget-test.js',
+            'name' => 'widget',
+            'src' => 'src/widget.js',
+            'isEntry' => true,
+        ],
+    ]));
+});
+
+afterEach(function () {
+    if ($this->manifestOriginalContents === null) {
+        File::delete($this->manifestPath);
+
+        return;
+    }
+
+    File::put($this->manifestPath, $this->manifestOriginalContents);
+});
+
+function getWidgetConfig(): TestResponse
+{
+    return getJson(route('widgets.assistant.api.config'), ['Origin' => config('app.url')]);
+}
+
+it('exposes service management when the license addon and portal setting are enabled', function () {
+    $portalSettings = app(PortalSettings::class);
+    $portalSettings->knowledge_management_portal_service_management = true;
+    $portalSettings->save();
+
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->serviceManagement = true;
+    $settings->save();
+
+    $response = getWidgetConfig();
+
+    $response->assertOk()
+        ->assertJson(['portal_service_management' => true]);
+
+    expect($response->json('service_request_types_url'))->not->toBeNull();
+});
+
+it('does not expose service management when the license addon is disabled', function () {
+    $portalSettings = app(PortalSettings::class);
+    $portalSettings->knowledge_management_portal_service_management = true;
+    $portalSettings->save();
+
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->serviceManagement = false;
+    $settings->save();
+
+    $response = getWidgetConfig();
+
+    $response->assertOk()
+        ->assertJson([
+            'portal_service_management' => false,
+            'service_request_types_url' => null,
+        ]);
+});
+
+it('does not expose service management when the portal setting is disabled', function () {
+    $portalSettings = app(PortalSettings::class);
+    $portalSettings->knowledge_management_portal_service_management = false;
+    $portalSettings->save();
+
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->serviceManagement = true;
+    $settings->save();
+
+    $response = getWidgetConfig();
+
+    $response->assertOk()
+        ->assertJson([
+            'portal_service_management' => false,
+            'service_request_types_url' => null,
+        ]);
+});
+
+it('exposes service management for an authenticated contact when the license addon and portal setting are enabled', function () {
+    $portalSettings = app(PortalSettings::class);
+    $portalSettings->knowledge_management_portal_service_management = true;
+    $portalSettings->save();
+
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->serviceManagement = true;
+    $settings->save();
+
+    $contact = Contact::factory()->create();
+    $contact->createToken('assistant-widget-access-token');
+
+    actingAs($contact, 'contact');
+
+    $response = getWidgetConfig();
+
+    $response->assertOk()
+        ->assertJson(['portal_service_management' => true]);
+
+    expect($response->json('service_request_types_url'))->not->toBeNull();
+});

--- a/widgets/assistant/src/components/ChatPanel.vue
+++ b/widgets/assistant/src/components/ChatPanel.vue
@@ -115,7 +115,7 @@
             class="mb-4 w-[400px] max-w-full h-[650px] max-h-full bg-white rounded-lg shadow-2xl flex flex-col overflow-hidden ring-1 ring-brand-950/5 backdrop-blur-sm origin-bottom-right"
         >
             <ChatHeader
-                :service-request-enabled="!!serviceRequestTypesUrl && portalServiceManagement"
+                :service-request-enabled="!!serviceRequestTypesUrl && portalServiceManagement && isAuthenticated"
                 :current-view="currentView"
                 :active-service-request-number="activeServiceRequestNumber"
                 @close="emit('close')"

--- a/widgets/assistant/src/components/ChatPanel.vue
+++ b/widgets/assistant/src/components/ChatPanel.vue
@@ -115,7 +115,7 @@
             class="mb-4 w-[400px] max-w-full h-[650px] max-h-full bg-white rounded-lg shadow-2xl flex flex-col overflow-hidden ring-1 ring-brand-950/5 backdrop-blur-sm origin-bottom-right"
         >
             <ChatHeader
-                :service-request-enabled="!!serviceRequestTypesUrl && portalServiceManagement && isAuthenticated"
+                :service-request-enabled="!!serviceRequestTypesUrl && portalServiceManagement"
                 :current-view="currentView"
                 :active-service-request-number="activeServiceRequestNumber"
                 @close="emit('close')"


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1339

### Technical Description

Fixes an issue where the "Open Service Request" button would NEVER display in the portal support widget if you were not ALSO logged into the Filament dashboard at the same time. The old Guard way of checking would check the web guard by default, be null, and fail. Checks it directly like other places in the portal controllers.

Also makes sure that it only displays if they are logged in.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
