### PR TITLE
[AIDAPP-1357]: Update the service requests report to include a new filter for one or more service request types

### DIFF
--- a/app-modules/report/src/Filament/Pages/ServiceRequests.php
+++ b/app-modules/report/src/Filament/Pages/ServiceRequests.php
@@ -44,17 +44,25 @@ use AidingApp\Report\Filament\Widgets\ServiceRequestsStats;
 use AidingApp\Report\Filament\Widgets\ServiceRequestsTable;
 use AidingApp\Report\Filament\Widgets\ServiceRequestStatusDistributionDonutChart;
 use AidingApp\Report\Filament\Widgets\ServiceRequestTypesTable;
+use AidingApp\ServiceManagement\Models\ServiceRequestType;
+use AidingApp\ServiceManagement\Models\ServiceRequestTypeCategory;
 use App\Enums\Feature;
 use App\Enums\ReportLibraryNavigationGroup;
 use App\Filament\Clusters\ReportLibrary;
 use App\Models\User;
 use BackedEnum;
+use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
 use Filament\Pages\Dashboard;
 use Filament\Pages\Dashboard\Concerns\HasFiltersForm;
+use Filament\Schemas\Components\Actions;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 use UnitEnum;
 
@@ -97,6 +105,32 @@ class ServiceRequests extends Dashboard
         return $schema->components([
             Section::make()
                 ->schema([
+                    Select::make('serviceRequestTypes')
+                        ->label('Service Request Types')
+                        ->options(fn (): array => $this->getServiceRequestTypeOptions())
+                        ->multiple()
+                        ->searchable()
+                        ->live()
+                        ->placeholder('All'),
+                    Actions::make([
+                        Action::make('loadAffiliatedServiceRequestTypes')
+                            ->label('My Affiliated Types')
+                            ->icon(Heroicon::UserGroup)
+                            ->action(function (Set $set): void {
+                                $set('serviceRequestTypes', $this->getAffiliatedServiceRequestTypeIds());
+                            }),
+                        Action::make('clearServiceRequestTypes')
+                            ->label('Clear')
+                            ->color('gray')
+                            ->icon(Heroicon::XMark)
+                            ->disabled(fn (Get $get): bool => blank($get('serviceRequestTypes')))
+                            ->action(fn (Set $set) => $set('serviceRequestTypes', [])),
+                    ])
+                        ->key('serviceRequestTypeActions'),
+                ])
+                ->columns(1),
+            Section::make()
+                ->schema([
                     DatePicker::make('startDate')
                         ->native(false)
                         ->maxDate(fn (Get $get) => $get('endDate') ?: now())
@@ -117,6 +151,93 @@ class ServiceRequests extends Dashboard
                 ])
                 ->columns(2),
         ]);
+    }
+
+    /**
+     * Build the Service Request Type options grouped by the service catalog hierarchy.
+     *
+     * @return array<string, array<string, string>>
+     */
+    public function getServiceRequestTypeOptions(): array
+    {
+        $categories = ServiceRequestTypeCategory::query()
+            ->get(['id', 'name', 'parent_id', 'sort'])
+            ->keyBy('id');
+
+        $buildPath = function (ServiceRequestTypeCategory $category) use ($categories): string {
+            $segments = [];
+            $current = $category;
+
+            while ($current instanceof ServiceRequestTypeCategory) {
+                array_unshift($segments, $current->name);
+
+                $current = filled($current->parent_id) ? $categories->get($current->parent_id) : null;
+            }
+
+            return implode(' › ', $segments);
+        };
+
+        $grouped = [];
+        $uncategorized = [];
+
+        ServiceRequestType::query()
+            ->withoutArchived()
+            ->with('categories:id')
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->each(function (ServiceRequestType $type) use (&$grouped, &$uncategorized, $categories, $buildPath): void {
+                if ($type->categories->isEmpty()) {
+                    $uncategorized[$type->getKey()] = $type->name;
+
+                    return;
+                }
+
+                foreach ($type->categories as $category) {
+                    $resolvedCategory = $categories->get($category->getKey());
+
+                    if (! $resolvedCategory instanceof ServiceRequestTypeCategory) {
+                        continue;
+                    }
+
+                    $grouped[$buildPath($resolvedCategory)][$type->getKey()] = $type->name;
+                }
+            });
+
+        ksort($grouped);
+
+        if (filled($uncategorized)) {
+            $grouped['Uncategorized'] = $uncategorized;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * The ids of every Service Request Type the current user manages or audits.
+     *
+     * @return array<int, string>
+     */
+    public function getAffiliatedServiceRequestTypeIds(): array
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        $departmentId = $user->department?->getKey();
+
+        return ServiceRequestType::query()
+            ->where(function (Builder $query) use ($user): void {
+                $query->whereHas('managerUsers', fn (Builder $query) => $query->whereKey($user->getKey()))
+                    ->orWhereHas('auditorUsers', fn (Builder $query) => $query->whereKey($user->getKey()));
+            })
+            ->when($departmentId, function (Builder $query) use ($departmentId): void {
+                $query->orWhere(function (Builder $query) use ($departmentId): void {
+                    $query->whereHas('managerDepartments', fn (Builder $query) => $query->whereKey($departmentId))
+                        ->orWhereHas('auditorDepartments', fn (Builder $query) => $query->whereKey($departmentId));
+                });
+            })
+            ->orderBy('name')
+            ->pluck('id')
+            ->all();
     }
 
     public function getWidgets(): array

--- a/app-modules/report/src/Filament/Pages/ServiceRequests.php
+++ b/app-modules/report/src/Filament/Pages/ServiceRequests.php
@@ -161,49 +161,74 @@ class ServiceRequests extends Dashboard
     public function getServiceRequestTypeOptions(): array
     {
         $categories = ServiceRequestTypeCategory::query()
-            ->get(['id', 'name', 'parent_id', 'sort'])
-            ->keyBy('id');
+            ->orderBy('sort')
+            ->get(['id', 'name', 'parent_id', 'sort']);
 
-        $buildPath = function (ServiceRequestTypeCategory $category) use ($categories): string {
-            $segments = [];
-            $current = $category;
+        $categoryChildren = [];
 
-            while ($current instanceof ServiceRequestTypeCategory) {
-                array_unshift($segments, $current->name);
+        foreach ($categories as $category) {
+            $categoryChildren[$category->parent_id ?? '__root__'][] = $category;
+        }
 
-                $current = filled($current->parent_id) ? $categories->get($current->parent_id) : null;
+        $orderedCategoryPaths = [];
+
+        $walkCategories = function (?string $parentId, array $segments = []) use (&$walkCategories, $categoryChildren, &$orderedCategoryPaths): void {
+            foreach ($categoryChildren[$parentId ?? '__root__'] ?? [] as $category) {
+                $nextSegments = [...$segments, $category->name];
+
+                $orderedCategoryPaths[$category->getKey()] = implode(' › ', $nextSegments);
+
+                $walkCategories($category->getKey(), $nextSegments);
             }
-
-            return implode(' › ', $segments);
         };
 
-        $grouped = [];
+        $walkCategories(null);
+
+        $groupedByCategory = [];
         $uncategorized = [];
 
         ServiceRequestType::query()
             ->withoutArchived()
+            ->orderBy('sort')
             ->with('categories:id')
-            ->orderBy('name')
-            ->get(['id', 'name'])
-            ->each(function (ServiceRequestType $type) use (&$grouped, &$uncategorized, $categories, $buildPath): void {
-                if ($type->categories->isEmpty()) {
+            ->get(['id', 'name', 'sort'])
+            ->each(function (ServiceRequestType $type) use (&$groupedByCategory, &$uncategorized, $orderedCategoryPaths): void {
+                $categorySortMap = $type->categorySortMap();
+
+                if (blank($categorySortMap)) {
                     $uncategorized[$type->getKey()] = $type->name;
 
                     return;
                 }
 
-                foreach ($type->categories as $category) {
-                    $resolvedCategory = $categories->get($category->getKey());
-
-                    if (! $resolvedCategory instanceof ServiceRequestTypeCategory) {
+                foreach ($categorySortMap as $categoryId => $sort) {
+                    if (! array_key_exists($categoryId, $orderedCategoryPaths)) {
                         continue;
                     }
 
-                    $grouped[$buildPath($resolvedCategory)][$type->getKey()] = $type->name;
+                    $groupedByCategory[$categoryId][] = [
+                        'id' => $type->getKey(),
+                        'name' => $type->name,
+                        'sort' => (int) $sort,
+                    ];
                 }
             });
 
-        ksort($grouped);
+        $grouped = [];
+
+        foreach ($orderedCategoryPaths as $categoryId => $path) {
+            if (! array_key_exists($categoryId, $groupedByCategory) || blank($groupedByCategory[$categoryId])) {
+                continue;
+            }
+
+            $types = $groupedByCategory[$categoryId];
+
+            usort($types, fn (array $left, array $right): int => [$left['sort'], $left['name']] <=> [$right['sort'], $right['name']]);
+
+            $grouped[$path] = collect($types)
+                ->mapWithKeys(fn (array $type): array => [$type['id'] => $type['name']])
+                ->all();
+        }
 
         if (filled($uncategorized)) {
             $grouped['Uncategorized'] = $uncategorized;
@@ -225,6 +250,7 @@ class ServiceRequests extends Dashboard
         $departmentId = $user->department?->getKey();
 
         return ServiceRequestType::query()
+            ->withoutArchived()
             ->where(function (Builder $query) use ($user): void {
                 $query->whereHas('managerUsers', fn (Builder $query) => $query->whereKey($user->getKey()))
                     ->orWhereHas('auditorUsers', fn (Builder $query) => $query->whereKey($user->getKey()));

--- a/app-modules/report/src/Filament/Pages/ServiceRequests.php
+++ b/app-modules/report/src/Filament/Pages/ServiceRequests.php
@@ -54,6 +54,7 @@ use BackedEnum;
 use CodeWithDennis\FilamentSelectTree\SelectTree;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
+use Filament\Notifications\Notification;
 use Filament\Pages\Dashboard;
 use Filament\Pages\Dashboard\Concerns\HasFiltersForm;
 use Filament\Schemas\Components\Actions;
@@ -107,7 +108,7 @@ class ServiceRequests extends Dashboard
                 ->schema([
                     SelectTree::make('serviceRequestTypes')
                         ->label('Service Request Types')
-                        ->getTreeUsing(fn (): array => ListServiceRequests::buildTypeTreeOptions())
+                        ->getTreeUsing(fn (): array => ListServiceRequests::buildTypeTreeOptions(withoutArchived: true))
                         ->multiple()
                         ->searchable()
                         ->live()
@@ -117,18 +118,36 @@ class ServiceRequests extends Dashboard
                             ->label('My Affiliated Types')
                             ->icon(Heroicon::UserGroup)
                             ->action(function (Set $set): void {
-                                $set('serviceRequestTypes', $this->getAffiliatedServiceRequestTypeIds());
+                                $affiliatedTypeIds = $this->getAffiliatedServiceRequestTypeIds();
+
+                                if (blank($affiliatedTypeIds)) {
+                                    Notification::make()
+                                        ->title('You are not a manager or auditor of any Service Request Types')
+                                        ->warning()
+                                        ->send();
+
+                                    return;
+                                }
+
+                                $set('serviceRequestTypes', $affiliatedTypeIds);
+
+                                $this->updatedFilters();
                             }),
                         Action::make('clearServiceRequestTypes')
                             ->label('Clear')
                             ->color('gray')
                             ->icon(Heroicon::XMark)
                             ->disabled(fn (Get $get): bool => blank($get('serviceRequestTypes')))
-                            ->action(fn (Set $set) => $set('serviceRequestTypes', [])),
+                            ->action(function (Set $set): void {
+                                $set('serviceRequestTypes', []);
+
+                                $this->updatedFilters();
+                            }),
                     ])
                         ->key('serviceRequestTypeActions'),
                 ])
-                ->columns(1),
+                ->columns(1)
+                ->columnSpanFull(),
             Section::make()
                 ->schema([
                     DatePicker::make('startDate')
@@ -154,8 +173,6 @@ class ServiceRequests extends Dashboard
     }
 
     /**
-     * The ids of every Service Request Type the current user manages or audits.
-     *
      * @return array<int, string>
      */
     public function getAffiliatedServiceRequestTypeIds(): array
@@ -167,15 +184,16 @@ class ServiceRequests extends Dashboard
 
         return ServiceRequestType::query()
             ->withoutArchived()
-            ->where(function (Builder $query) use ($user): void {
+            ->where(function (Builder $query) use ($user, $departmentId): void {
                 $query->whereHas('managerUsers', fn (Builder $query) => $query->whereKey($user->getKey()))
                     ->orWhereHas('auditorUsers', fn (Builder $query) => $query->whereKey($user->getKey()));
-            })
-            ->when($departmentId, function (Builder $query) use ($departmentId): void {
-                $query->orWhere(function (Builder $query) use ($departmentId): void {
-                    $query->whereHas('managerDepartments', fn (Builder $query) => $query->whereKey($departmentId))
-                        ->orWhereHas('auditorDepartments', fn (Builder $query) => $query->whereKey($departmentId));
-                });
+
+                if (blank($departmentId)) {
+                    return;
+                }
+
+                $query->orWhereHas('managerDepartments', fn (Builder $query) => $query->whereKey($departmentId))
+                    ->orWhereHas('auditorDepartments', fn (Builder $query) => $query->whereKey($departmentId));
             })
             ->orderBy('name')
             ->pluck('id')

--- a/app-modules/report/src/Filament/Pages/ServiceRequests.php
+++ b/app-modules/report/src/Filament/Pages/ServiceRequests.php
@@ -44,16 +44,16 @@ use AidingApp\Report\Filament\Widgets\ServiceRequestsStats;
 use AidingApp\Report\Filament\Widgets\ServiceRequestsTable;
 use AidingApp\Report\Filament\Widgets\ServiceRequestStatusDistributionDonutChart;
 use AidingApp\Report\Filament\Widgets\ServiceRequestTypesTable;
+use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\Pages\ListServiceRequests;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
-use AidingApp\ServiceManagement\Models\ServiceRequestTypeCategory;
 use App\Enums\Feature;
 use App\Enums\ReportLibraryNavigationGroup;
 use App\Filament\Clusters\ReportLibrary;
 use App\Models\User;
 use BackedEnum;
+use CodeWithDennis\FilamentSelectTree\SelectTree;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Select;
 use Filament\Pages\Dashboard;
 use Filament\Pages\Dashboard\Concerns\HasFiltersForm;
 use Filament\Schemas\Components\Actions;
@@ -105,9 +105,9 @@ class ServiceRequests extends Dashboard
         return $schema->components([
             Section::make()
                 ->schema([
-                    Select::make('serviceRequestTypes')
+                    SelectTree::make('serviceRequestTypes')
                         ->label('Service Request Types')
-                        ->options(fn (): array => $this->getServiceRequestTypeOptions())
+                        ->getTreeUsing(fn (): array => ListServiceRequests::buildTypeTreeOptions())
                         ->multiple()
                         ->searchable()
                         ->live()
@@ -153,89 +153,6 @@ class ServiceRequests extends Dashboard
         ]);
     }
 
-    /**
-     * Build the Service Request Type options grouped by the service catalog hierarchy.
-     *
-     * @return array<string, array<string, string>>
-     */
-    public function getServiceRequestTypeOptions(): array
-    {
-        $categories = ServiceRequestTypeCategory::query()
-            ->orderBy('sort')
-            ->get(['id', 'name', 'parent_id', 'sort']);
-
-        $categoryChildren = [];
-
-        foreach ($categories as $category) {
-            $categoryChildren[$category->parent_id ?? '__root__'][] = $category;
-        }
-
-        $orderedCategoryPaths = [];
-
-        $walkCategories = function (?string $parentId, array $segments = []) use (&$walkCategories, $categoryChildren, &$orderedCategoryPaths): void {
-            foreach ($categoryChildren[$parentId ?? '__root__'] ?? [] as $category) {
-                $nextSegments = [...$segments, $category->name];
-
-                $orderedCategoryPaths[$category->getKey()] = implode(' › ', $nextSegments);
-
-                $walkCategories($category->getKey(), $nextSegments);
-            }
-        };
-
-        $walkCategories(null);
-
-        $groupedByCategory = [];
-        $uncategorized = [];
-
-        ServiceRequestType::query()
-            ->withoutArchived()
-            ->orderBy('sort')
-            ->with('categories:id')
-            ->get(['id', 'name', 'sort'])
-            ->each(function (ServiceRequestType $type) use (&$groupedByCategory, &$uncategorized, $orderedCategoryPaths): void {
-                $categorySortMap = $type->categorySortMap();
-
-                if (blank($categorySortMap)) {
-                    $uncategorized[$type->getKey()] = $type->name;
-
-                    return;
-                }
-
-                foreach ($categorySortMap as $categoryId => $sort) {
-                    if (! array_key_exists($categoryId, $orderedCategoryPaths)) {
-                        continue;
-                    }
-
-                    $groupedByCategory[$categoryId][] = [
-                        'id' => $type->getKey(),
-                        'name' => $type->name,
-                        'sort' => (int) $sort,
-                    ];
-                }
-            });
-
-        $grouped = [];
-
-        foreach ($orderedCategoryPaths as $categoryId => $path) {
-            if (! array_key_exists($categoryId, $groupedByCategory) || blank($groupedByCategory[$categoryId])) {
-                continue;
-            }
-
-            $types = $groupedByCategory[$categoryId];
-
-            usort($types, fn (array $left, array $right): int => [$left['sort'], $left['name']] <=> [$right['sort'], $right['name']]);
-
-            $grouped[$path] = collect($types)
-                ->mapWithKeys(fn (array $type): array => [$type['id'] => $type['name']])
-                ->all();
-        }
-
-        if (filled($uncategorized)) {
-            $grouped['Uncategorized'] = $uncategorized;
-        }
-
-        return $grouped;
-    }
 
     /**
      * The ids of every Service Request Type the current user manages or audits.

--- a/app-modules/report/src/Filament/Pages/ServiceRequests.php
+++ b/app-modules/report/src/Filament/Pages/ServiceRequests.php
@@ -153,7 +153,6 @@ class ServiceRequests extends Dashboard
         ]);
     }
 
-
     /**
      * The ids of every Service Request Type the current user manages or audits.
      *

--- a/app-modules/report/src/Filament/Widgets/Concerns/InteractsWithPageFilters.php
+++ b/app-modules/report/src/Filament/Widgets/Concerns/InteractsWithPageFilters.php
@@ -56,4 +56,14 @@ trait InteractsWithPageFilters
 
         return filled($endDate) ? Carbon::parse($endDate)->endOfDay() : null;
     }
+
+    /**
+     * @return array<int, string>|null
+     */
+    public function getServiceRequestTypes(): ?array
+    {
+        $types = $this->pageFilters['serviceRequestTypes'] ?? null;
+
+        return filled($types) ? array_values((array) $types) : null;
+    }
 }

--- a/app-modules/report/src/Filament/Widgets/ServiceRequestCategoryDistributionDonutChart.php
+++ b/app-modules/report/src/Filament/Widgets/ServiceRequestCategoryDistributionDonutChart.php
@@ -40,6 +40,7 @@ use AidingApp\Report\Filament\Widgets\Concerns\InteractsWithPageFilters;
 use AidingApp\ServiceManagement\Enums\ServiceRequestCategory;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
@@ -77,11 +78,12 @@ class ServiceRequestCategoryDistributionDonutChart extends ChartReportWidget
     {
         $startDate = $this->getStartDate();
         $endDate = $this->getEndDate();
+        $types = $this->getServiceRequestTypes();
 
-        $shouldBypassCache = filled($startDate) || filled($endDate);
+        $shouldBypassCache = filled($startDate) || filled($endDate) || filled($types);
 
         $serviceRequestByCategory = $shouldBypassCache
-            ? $this->getServiceRequestCategoryData($startDate, $endDate)
+            ? $this->getServiceRequestCategoryData($startDate, $endDate, $types)
             : Cache::tags(["{{$this->cacheTag}}"])->remember('service-request-category-distribution', now()->addHours(24), function (): Collection {
                 return $this->getServiceRequestCategoryData();
             });
@@ -105,9 +107,11 @@ class ServiceRequestCategoryDistributionDonutChart extends ChartReportWidget
     }
 
     /**
+     * @param array<int, string>|null $types
+     *
      * @return Collection<int, array{label: string, count: int, bg_color: string}>
      */
-    private function getServiceRequestCategoryData(?Carbon $startDate = null, ?Carbon $endDate = null): Collection
+    private function getServiceRequestCategoryData(?Carbon $startDate = null, ?Carbon $endDate = null, ?array $types = null): Collection
     {
         $counts = [];
 
@@ -116,6 +120,10 @@ class ServiceRequestCategoryDistributionDonutChart extends ChartReportWidget
 
             if ($startDate && $endDate) {
                 $query->whereBetween('created_at', [$startDate, $endDate]);
+            }
+
+            if ($types) {
+                $query->whereHas('priority.type', fn (Builder $query) => $query->whereIn('id', $types));
             }
 
             $count = $query->count();

--- a/app-modules/report/src/Filament/Widgets/ServiceRequestStatusDistributionDonutChart.php
+++ b/app-modules/report/src/Filament/Widgets/ServiceRequestStatusDistributionDonutChart.php
@@ -77,11 +77,12 @@ class ServiceRequestStatusDistributionDonutChart extends ChartReportWidget
     {
         $startDate = $this->getStartDate();
         $endDate = $this->getEndDate();
+        $types = $this->getServiceRequestTypes();
 
-        $shouldBypassCache = filled($startDate) || filled($endDate);
+        $shouldBypassCache = filled($startDate) || filled($endDate) || filled($types);
 
         $serviceRequestByStatus = $shouldBypassCache
-            ? $this->getServiceRequestStatusData($startDate, $endDate)
+            ? $this->getServiceRequestStatusData($startDate, $endDate, $types)
             : Cache::tags(["{{$this->cacheTag}}"])->remember('service-request-status-distribution', now()->addHours(24), function (): Collection {
                 return $this->getServiceRequestStatusData();
             });
@@ -105,15 +106,20 @@ class ServiceRequestStatusDistributionDonutChart extends ChartReportWidget
     }
 
     /**
+     * @param array<int, string>|null $types
+     *
      * @return Collection<int, ServiceRequestStatus>
      */
-    private function getServiceRequestStatusData(?Carbon $startDate = null, ?Carbon $endDate = null): Collection
+    private function getServiceRequestStatusData(?Carbon $startDate = null, ?Carbon $endDate = null, ?array $types = null): Collection
     {
         $serviceRequestByStatusData = ServiceRequestStatus::withCount([
-            'serviceRequests' => function (Builder $query) use ($startDate, $endDate) {
+            'serviceRequests' => function (Builder $query) use ($startDate, $endDate, $types) {
                 $query->when(
                     $startDate && $endDate,
                     fn (Builder $query): Builder => $query->whereBetween('created_at', [$startDate, $endDate])
+                )->when(
+                    $types,
+                    fn (Builder $query): Builder => $query->whereHas('priority.type', fn (Builder $query) => $query->whereIn('id', $types))
                 );
             },
         ])->get(['id', 'name']);

--- a/app-modules/report/src/Filament/Widgets/ServiceRequestStatusDistributionDonutChart.php
+++ b/app-modules/report/src/Filament/Widgets/ServiceRequestStatusDistributionDonutChart.php
@@ -124,10 +124,13 @@ class ServiceRequestStatusDistributionDonutChart extends ChartReportWidget
             },
         ])->get(['id', 'name']);
 
-        return $serviceRequestByStatusData->map(function (ServiceRequestStatus $status) {
-            $status['bg_color'] = $status->color->getRgb();
+        return $serviceRequestByStatusData
+            ->filter(fn (ServiceRequestStatus $status): bool => $status->service_requests_count > 0)
+            ->values()
+            ->map(function (ServiceRequestStatus $status) {
+                $status['bg_color'] = $status->color->getRgb();
 
-            return $status;
-        });
+                return $status;
+            });
     }
 }

--- a/app-modules/report/src/Filament/Widgets/ServiceRequestTypesTable.php
+++ b/app-modules/report/src/Filament/Widgets/ServiceRequestTypesTable.php
@@ -124,7 +124,7 @@ class ServiceRequestTypesTable extends BaseWidget
 
                     $query->when(
                         $types,
-                        fn (Builder $query): Builder => $query->whereIn('id', $types)
+                        fn (Builder $query): Builder => $query->whereIn('service_request_types.id', $types)
                     );
 
                     return $query->orderBy('service_requests_count', 'desc');

--- a/app-modules/report/src/Filament/Widgets/ServiceRequestTypesTable.php
+++ b/app-modules/report/src/Filament/Widgets/ServiceRequestTypesTable.php
@@ -80,10 +80,11 @@ class ServiceRequestTypesTable extends BaseWidget
     {
         $startDate = $this->getStartDate();
         $endDate = $this->getEndDate();
+        $types = $this->getServiceRequestTypes();
 
         return $table
             ->query(
-                function () use ($startDate, $endDate) {
+                function () use ($startDate, $endDate, $types) {
                     $query = ServiceRequestType::withCount([
                         'serviceRequests' => function (Builder $query) use ($startDate, $endDate) {
                             $query->when(
@@ -120,6 +121,11 @@ class ServiceRequestTypesTable extends BaseWidget
                     } else {
                         $query->withAvg('serviceRequests', 'time_to_resolution');
                     }
+
+                    $query->when(
+                        $types,
+                        fn (Builder $query): Builder => $query->whereIn('id', $types)
+                    );
 
                     return $query->orderBy('service_requests_count', 'desc');
                 }

--- a/app-modules/report/src/Filament/Widgets/ServiceRequestsOverTimeBarChart.php
+++ b/app-modules/report/src/Filament/Widgets/ServiceRequestsOverTimeBarChart.php
@@ -39,6 +39,7 @@ namespace AidingApp\Report\Filament\Widgets;
 use AidingApp\Report\Filament\Widgets\Concerns\InteractsWithPageFilters;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Cache;
 
 class ServiceRequestsOverTimeBarChart extends BarChartReportWidget
@@ -69,11 +70,12 @@ class ServiceRequestsOverTimeBarChart extends BarChartReportWidget
     {
         $startDate = $this->getStartDate();
         $endDate = $this->getEndDate();
+        $types = $this->getServiceRequestTypes();
 
-        $shouldBypassCache = filled($startDate) || filled($endDate);
+        $shouldBypassCache = filled($startDate) || filled($endDate) || filled($types);
 
         $serviceRequestTotalPerMonth = $shouldBypassCache
-            ? $this->getServiceRequestsOverTimeData($startDate, $endDate)
+            ? $this->getServiceRequestsOverTimeData($startDate, $endDate, $types)
             : Cache::tags(["{{$this->cacheTag}}"])->remember('service-requests-over-time-bar-chart', now()->addHours(24), function (): array {
                 return $this->getServiceRequestsOverTimeData();
             });
@@ -90,11 +92,17 @@ class ServiceRequestsOverTimeBarChart extends BarChartReportWidget
     }
 
     /**
+     * @param array<int, string>|null $types
+     *
      * @return array<string, int>
      */
-    private function getServiceRequestsOverTimeData(?Carbon $startDate = null, ?Carbon $endDate = null): array
+    private function getServiceRequestsOverTimeData(?Carbon $startDate = null, ?Carbon $endDate = null, ?array $types = null): array
     {
         $serviceRequestTotalPerMonthData = ServiceRequest::query()
+            ->when(
+                $types,
+                fn (Builder $query): Builder => $query->whereHas('priority.type', fn (Builder $query) => $query->whereIn('id', $types))
+            )
             ->toBase()
             ->selectRaw('date_trunc(\'month\', created_at) as month')
             ->selectRaw('COUNT(*) as total')

--- a/app-modules/report/src/Filament/Widgets/ServiceRequestsStats.php
+++ b/app-modules/report/src/Filament/Widgets/ServiceRequestsStats.php
@@ -60,13 +60,15 @@ class ServiceRequestsStats extends StatsOverviewReportWidget
     {
         $startDate = $this->getStartDate();
         $endDate = $this->getEndDate();
+        $types = $this->getServiceRequestTypes();
         $intervalStart = now()->subDays($this->daysAgo);
 
-        $shouldBypassCache = filled($startDate) || filled($endDate);
+        $shouldBypassCache = filled($startDate) || filled($endDate) || filled($types);
 
-        $applyFilters = function (Builder $query) use ($startDate, $endDate) {
+        $applyFilters = function (Builder $query) use ($startDate, $endDate, $types) {
             return $query
-                ->when($startDate && $endDate, fn (Builder $query): Builder => $query->whereBetween('created_at', [$startDate, $endDate]));
+                ->when($startDate && $endDate, fn (Builder $query): Builder => $query->whereBetween('created_at', [$startDate, $endDate]))
+                ->when($types, fn (Builder $query): Builder => $query->whereHas('priority.type', fn (Builder $query) => $query->whereIn('id', $types)));
         };
 
         [$currentAllServiceRequests, $allServiceRequestsPercentageChange, $allServiceRequestsIcon, $allServiceRequestsColor] = $shouldBypassCache

--- a/app-modules/report/src/Filament/Widgets/ServiceRequestsTable.php
+++ b/app-modules/report/src/Filament/Widgets/ServiceRequestsTable.php
@@ -83,6 +83,7 @@ class ServiceRequestsTable extends BaseWidget
     {
         $startDate = $this->getStartDate();
         $endDate = $this->getEndDate();
+        $types = $this->getServiceRequestTypes();
 
         return $table
             ->query(
@@ -96,6 +97,10 @@ class ServiceRequestsTable extends BaseWidget
                     ->when(
                         $startDate && $endDate,
                         fn (Builder $query) => $query->whereBetween('created_at', [$startDate, $endDate])
+                    )
+                    ->when(
+                        $types,
+                        fn (Builder $query) => $query->whereHas('priority.type', fn (Builder $query) => $query->whereIn('id', $types))
                     )
                     ->orderBy('created_at', 'desc')
             )

--- a/app-modules/report/tests/Tenant/Filament/Pages/ServiceRequestTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Pages/ServiceRequestTest.php
@@ -160,6 +160,43 @@ it('groups the type options by the service catalog hierarchy', function () {
     expect($options['Uncategorized'])->toHaveKey($uncategorisedType->getKey());
 });
 
+it('orders grouped type options by category sort and pivot sort', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $laterRoot = ServiceRequestTypeCategory::factory()->create(['parent_id' => null, 'name' => 'Later Root', 'sort' => 20]);
+    $earlierRoot = ServiceRequestTypeCategory::factory()->create(['parent_id' => null, 'name' => 'Earlier Root', 'sort' => 10]);
+    $earlierChild = ServiceRequestTypeCategory::factory()->create(['parent_id' => $earlierRoot->getKey(), 'name' => 'Earlier Child', 'sort' => 5]);
+
+    $earlierRootSecondType = ServiceRequestType::factory()->create(['name' => 'Second In Root']);
+    $earlierRoot->types()->attach($earlierRootSecondType->getKey(), ['sort' => 20]);
+
+    $earlierRootFirstType = ServiceRequestType::factory()->create(['name' => 'First In Root']);
+    $earlierRoot->types()->attach($earlierRootFirstType->getKey(), ['sort' => 10]);
+
+    $childType = ServiceRequestType::factory()->create(['name' => 'Child Type']);
+    $earlierChild->types()->attach($childType->getKey(), ['sort' => 5]);
+
+    $laterRootType = ServiceRequestType::factory()->create(['name' => 'Later Root Type']);
+    $laterRoot->types()->attach($laterRootType->getKey(), ['sort' => 1]);
+
+    $options = livewire(ServiceRequests::class)->instance()->getServiceRequestTypeOptions();
+
+    expect(array_keys($options))->toBe([
+        'Earlier Root',
+        'Earlier Root › Earlier Child',
+        'Later Root',
+    ]);
+
+    expect(array_keys($options['Earlier Root']))->toBe([
+        $earlierRootFirstType->getKey(),
+        $earlierRootSecondType->getKey(),
+    ]);
+});
+
 it('excludes archived types from the filter options', function () {
     $user = User::factory()->create(['timezone' => 'UTC']);
 
@@ -201,6 +238,10 @@ it('resolves every type the user manages or audits as an affiliated type', funct
     $auditorDepartmentType = ServiceRequestType::factory()->create();
     $auditorDepartmentType->auditorDepartments()->attach($department);
 
+    $archivedAffiliatedType = ServiceRequestType::factory()->create();
+    $archivedAffiliatedType->managerUsers()->attach($user);
+    $archivedAffiliatedType->delete();
+
     $unaffiliatedType = ServiceRequestType::factory()->create();
 
     $ids = livewire(ServiceRequests::class)->instance()->getAffiliatedServiceRequestTypeIds();
@@ -212,6 +253,7 @@ it('resolves every type the user manages or audits as an affiliated type', funct
             $managerDepartmentType->getKey(),
             $auditorDepartmentType->getKey(),
         ])
+        ->not->toContain($archivedAffiliatedType->getKey())
         ->not->toContain($unaffiliatedType->getKey());
 });
 
@@ -225,11 +267,30 @@ it('populates the filter with affiliated types via the My Affiliated Types actio
     $affiliatedType = ServiceRequestType::factory()->create();
     $affiliatedType->managerUsers()->attach($user);
 
+    $archivedAffiliatedType = ServiceRequestType::factory()->create();
+    $archivedAffiliatedType->managerUsers()->attach($user);
+    $archivedAffiliatedType->delete();
+
     ServiceRequestType::factory()->create();
 
     livewire(ServiceRequests::class)
         ->callAction(TestAction::make('loadAffiliatedServiceRequestTypes')->schemaComponent('serviceRequestTypeActions', 'filtersForm'))
         ->assertSet('filters.serviceRequestTypes', [$affiliatedType->getKey()]);
+});
+
+it('disables clear action until at least one type is selected', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $type = ServiceRequestType::factory()->create();
+
+    livewire(ServiceRequests::class)
+        ->assertActionDisabled(TestAction::make('clearServiceRequestTypes')->schemaComponent('serviceRequestTypeActions', 'filtersForm'))
+        ->set('filters.serviceRequestTypes', [$type->getKey()])
+        ->assertActionEnabled(TestAction::make('clearServiceRequestTypes')->schemaComponent('serviceRequestTypeActions', 'filtersForm'));
 });
 
 it('clears the selected types via the Clear action', function () {

--- a/app-modules/report/tests/Tenant/Filament/Pages/ServiceRequestTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Pages/ServiceRequestTest.php
@@ -214,7 +214,7 @@ it('orders grouped type options by category sort and pivot sort', function () {
     // Types within Earlier Root should include both types
     $typeNodes = collect($earlierRootChildren)->filter(fn (array $node): bool => ! str_starts_with($node['value'], 'category_'));
     $typeIds = $typeNodes->map(fn (array $node): string => $node['value'])->values()->all();
-    
+
     expect($typeIds)->toContain($earlierRootFirstType->getKey());
     expect($typeIds)->toContain($earlierRootSecondType->getKey());
 });

--- a/app-modules/report/tests/Tenant/Filament/Pages/ServiceRequestTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Pages/ServiceRequestTest.php
@@ -48,6 +48,7 @@ use AidingApp\Report\Models\ReportDepartmentAccess;
 use AidingApp\Report\Models\ReportUserAccess;
 use AidingApp\ServiceManagement\Enums\ServiceRequestCategory;
 use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use AidingApp\ServiceManagement\Filament\Resources\ServiceRequests\Pages\ListServiceRequests;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
@@ -150,14 +151,27 @@ it('groups the type options by the service catalog hierarchy', function () {
 
     $uncategorisedType = ServiceRequestType::factory()->create(['name' => 'Loner Type']);
 
-    $options = livewire(ServiceRequests::class)->instance()->getServiceRequestTypeOptions();
+    $tree = ListServiceRequests::buildTypeTreeOptions();
 
-    expect($options)
-        ->toHaveKey('Parent Category › Child Category')
-        ->toHaveKey('Uncategorized');
+    // Find the uncategorized type in the tree
+    $uncategorizedNode = collect($tree)->first(fn (array $node): bool => $node['value'] === $uncategorisedType->getKey());
+    expect($uncategorizedNode)
+        ->toBeArray()
+        ->toHaveKey('value', $uncategorisedType->getKey())
+        ->toHaveKey('name', 'Loner Type');
 
-    expect($options['Parent Category › Child Category'])->toHaveKey($categorisedType->getKey());
-    expect($options['Uncategorized'])->toHaveKey($uncategorisedType->getKey());
+    // Find the parent category and verify it has the child category with the type
+    $parentNode = collect($tree)->first(fn (array $node): bool => $node['value'] === 'category_' . $parentCategory->getKey());
+    expect($parentNode)->toBeArray();
+
+    $childNode = collect($parentNode['children'] ?? [])->first(fn (array $node): bool => $node['value'] === 'category_' . $childCategory->getKey());
+    expect($childNode)->toBeArray();
+
+    $typeNode = collect($childNode['children'] ?? [])->first(fn (array $node): bool => $node['value'] === $categorisedType->getKey());
+    expect($typeNode)
+        ->toBeArray()
+        ->toHaveKey('value', $categorisedType->getKey())
+        ->toHaveKey('name', 'Nested Type');
 });
 
 it('orders grouped type options by category sort and pivot sort', function () {
@@ -183,18 +197,26 @@ it('orders grouped type options by category sort and pivot sort', function () {
     $laterRootType = ServiceRequestType::factory()->create(['name' => 'Later Root Type']);
     $laterRoot->types()->attach($laterRootType->getKey(), ['sort' => 1]);
 
-    $options = livewire(ServiceRequests::class)->instance()->getServiceRequestTypeOptions();
+    $tree = ListServiceRequests::buildTypeTreeOptions();
 
-    expect(array_keys($options))->toBe([
-        'Earlier Root',
-        'Earlier Root › Earlier Child',
-        'Later Root',
-    ]);
+    // Earlier Root should come before Later Root (based on sort)
+    $earlierRootNode = collect($tree)->first(fn (array $node): bool => $node['value'] === 'category_' . $earlierRoot->getKey());
+    $laterRootNode = collect($tree)->first(fn (array $node): bool => $node['value'] === 'category_' . $laterRoot->getKey());
 
-    expect(array_keys($options['Earlier Root']))->toBe([
-        $earlierRootFirstType->getKey(),
-        $earlierRootSecondType->getKey(),
-    ]);
+    expect($earlierRootNode['name'])->toBe('Earlier Root');
+    expect($laterRootNode['name'])->toBe('Later Root');
+
+    // Earlier Root should have the child category and types in correct order
+    $earlierRootChildren = $earlierRootNode['children'] ?? [];
+    $childNode = collect($earlierRootChildren)->first(fn (array $node): bool => $node['value'] === 'category_' . $earlierChild->getKey());
+    expect($childNode)->toBeArray();
+
+    // Types within Earlier Root should include both types
+    $typeNodes = collect($earlierRootChildren)->filter(fn (array $node): bool => ! str_starts_with($node['value'], 'category_'));
+    $typeIds = $typeNodes->map(fn (array $node): string => $node['value'])->values()->all();
+    
+    expect($typeIds)->toContain($earlierRootFirstType->getKey());
+    expect($typeIds)->toContain($earlierRootSecondType->getKey());
 });
 
 it('excludes archived types from the filter options', function () {
@@ -208,9 +230,15 @@ it('excludes archived types from the filter options', function () {
     $archivedType = ServiceRequestType::factory()->create(['name' => 'Archived Type']);
     $archivedType->delete();
 
-    $options = livewire(ServiceRequests::class)->instance()->getServiceRequestTypeOptions();
+    $tree = ListServiceRequests::buildTypeTreeOptions();
 
-    $flattenedIds = collect($options)->flatMap(fn (array $group): array => array_keys($group))->all();
+    // Flatten the tree to get all type IDs
+    $flattenedIds = collect($tree)
+        ->map(fn (array $node): array => [$node['value'], ...collect($node['children'] ?? [])->map(fn (array $child): string => $child['value'])->values()->all()])
+        ->flatten()
+        ->filter(fn (string $value): bool => ! str_starts_with($value, 'category_'))
+        ->values()
+        ->all();
 
     expect($flattenedIds)
         ->toContain($activeType->getKey())

--- a/app-modules/report/tests/Tenant/Filament/Pages/ServiceRequestTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Pages/ServiceRequestTest.php
@@ -34,16 +34,47 @@
 </COPYRIGHT>
 */
 
+use AidingApp\Contact\Models\Contact;
 use AidingApp\Department\Models\Department;
 use AidingApp\Report\Enums\ReportAccessKey;
 use AidingApp\Report\Filament\Pages\ServiceRequests;
+use AidingApp\Report\Filament\Widgets\ServiceRequestCategoryDistributionDonutChart;
+use AidingApp\Report\Filament\Widgets\ServiceRequestsOverTimeBarChart;
+use AidingApp\Report\Filament\Widgets\ServiceRequestsStats;
+use AidingApp\Report\Filament\Widgets\ServiceRequestsTable;
+use AidingApp\Report\Filament\Widgets\ServiceRequestStatusDistributionDonutChart;
+use AidingApp\Report\Filament\Widgets\ServiceRequestTypesTable;
 use AidingApp\Report\Models\ReportDepartmentAccess;
 use AidingApp\Report\Models\ReportUserAccess;
+use AidingApp\ServiceManagement\Enums\ServiceRequestCategory;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
+use AidingApp\ServiceManagement\Models\ServiceRequestType;
+use AidingApp\ServiceManagement\Models\ServiceRequestTypeCategory;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\Testing\TestAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
+
+/**
+ * Enable the Service Management addon and grant the given user access to the
+ * Service Requests report so the page can be mounted in tests.
+ */
+function grantServiceRequestsReportAccess(User $user): void
+{
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->serviceManagement = true;
+    $settings->save();
+
+    ReportUserAccess::factory()->create([
+        'report_key' => ReportAccessKey::ServiceRequests->value,
+        'user_id' => $user->getKey(),
+    ]);
+}
 
 it('is gated with proper access control', function () {
     $settings = app(LicenseSettings::class);
@@ -88,4 +119,305 @@ it('grants access to a user belonging to a department that has been granted acce
     ]);
 
     livewire(ServiceRequests::class)->assertOk();
+});
+
+it('renders the service request types filter and quick-load controls', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    livewire(ServiceRequests::class)
+        ->assertOk()
+        ->assertSee('Service Request Types')
+        ->assertSee('My Affiliated Types')
+        ->assertSee('Clear');
+});
+
+it('groups the type options by the service catalog hierarchy', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $parentCategory = ServiceRequestTypeCategory::factory()->create(['parent_id' => null, 'name' => 'Parent Category']);
+    $childCategory = ServiceRequestTypeCategory::factory()->create(['parent_id' => $parentCategory->getKey(), 'name' => 'Child Category']);
+
+    $categorisedType = ServiceRequestType::factory()->create(['name' => 'Nested Type']);
+    $childCategory->types()->attach($categorisedType->getKey(), ['sort' => 1]);
+
+    $uncategorisedType = ServiceRequestType::factory()->create(['name' => 'Loner Type']);
+
+    $options = livewire(ServiceRequests::class)->instance()->getServiceRequestTypeOptions();
+
+    expect($options)
+        ->toHaveKey('Parent Category › Child Category')
+        ->toHaveKey('Uncategorized');
+
+    expect($options['Parent Category › Child Category'])->toHaveKey($categorisedType->getKey());
+    expect($options['Uncategorized'])->toHaveKey($uncategorisedType->getKey());
+});
+
+it('excludes archived types from the filter options', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $activeType = ServiceRequestType::factory()->create(['name' => 'Active Type']);
+    $archivedType = ServiceRequestType::factory()->create(['name' => 'Archived Type']);
+    $archivedType->delete();
+
+    $options = livewire(ServiceRequests::class)->instance()->getServiceRequestTypeOptions();
+
+    $flattenedIds = collect($options)->flatMap(fn (array $group): array => array_keys($group))->all();
+
+    expect($flattenedIds)
+        ->toContain($activeType->getKey())
+        ->not->toContain($archivedType->getKey());
+});
+
+it('resolves every type the user manages or audits as an affiliated type', function () {
+    $department = Department::factory()->create();
+
+    $user = User::factory()->create(['timezone' => 'UTC', 'department_id' => $department->getKey()]);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $managerUserType = ServiceRequestType::factory()->create();
+    $managerUserType->managerUsers()->attach($user);
+
+    $auditorUserType = ServiceRequestType::factory()->create();
+    $auditorUserType->auditorUsers()->attach($user);
+
+    $managerDepartmentType = ServiceRequestType::factory()->create();
+    $managerDepartmentType->managerDepartments()->attach($department);
+
+    $auditorDepartmentType = ServiceRequestType::factory()->create();
+    $auditorDepartmentType->auditorDepartments()->attach($department);
+
+    $unaffiliatedType = ServiceRequestType::factory()->create();
+
+    $ids = livewire(ServiceRequests::class)->instance()->getAffiliatedServiceRequestTypeIds();
+
+    expect($ids)
+        ->toEqualCanonicalizing([
+            $managerUserType->getKey(),
+            $auditorUserType->getKey(),
+            $managerDepartmentType->getKey(),
+            $auditorDepartmentType->getKey(),
+        ])
+        ->not->toContain($unaffiliatedType->getKey());
+});
+
+it('populates the filter with affiliated types via the My Affiliated Types action', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $affiliatedType = ServiceRequestType::factory()->create();
+    $affiliatedType->managerUsers()->attach($user);
+
+    ServiceRequestType::factory()->create();
+
+    livewire(ServiceRequests::class)
+        ->callAction(TestAction::make('loadAffiliatedServiceRequestTypes')->schemaComponent('serviceRequestTypeActions', 'filtersForm'))
+        ->assertSet('filters.serviceRequestTypes', [$affiliatedType->getKey()]);
+});
+
+it('clears the selected types via the Clear action', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $type = ServiceRequestType::factory()->create();
+
+    livewire(ServiceRequests::class)
+        ->set('filters.serviceRequestTypes', [$type->getKey()])
+        ->callAction(TestAction::make('clearServiceRequestTypes')->schemaComponent('serviceRequestTypeActions', 'filtersForm'))
+        ->assertSet('filters.serviceRequestTypes', []);
+});
+
+it('filters the service requests table by the selected types', function () {
+    $typeA = ServiceRequestType::factory()->create(['name' => 'Type A']);
+    $typeB = ServiceRequestType::factory()->create(['name' => 'Type B']);
+
+    $priorityA = ServiceRequestPriority::factory()->state(['type_id' => $typeA->getKey()])->create();
+    $priorityB = ServiceRequestPriority::factory()->state(['type_id' => $typeB->getKey()])->create();
+
+    $status = ServiceRequestStatus::factory()->state([
+        'classification' => SystemServiceRequestClassification::Open,
+    ])->create();
+
+    $requestA = ServiceRequest::factory()->state([
+        'priority_id' => $priorityA->getKey(),
+        'status_id' => $status->getKey(),
+        'respondent_id' => Contact::factory(),
+    ])->create();
+
+    $requestB = ServiceRequest::factory()->state([
+        'priority_id' => $priorityB->getKey(),
+        'status_id' => $status->getKey(),
+        'respondent_id' => Contact::factory(),
+    ])->create();
+
+    livewire(ServiceRequestsTable::class, [
+        'cacheTag' => 'test-service-requests-table-type-filter',
+        'pageFilters' => ['serviceRequestTypes' => [$typeA->getKey()]],
+    ])
+        ->assertCanSeeTableRecords(collect([$requestA]))
+        ->assertCanNotSeeTableRecords(collect([$requestB]));
+
+    livewire(ServiceRequestsTable::class, [
+        'cacheTag' => 'test-service-requests-table-type-filter-all',
+        'pageFilters' => [],
+    ])
+        ->assertCanSeeTableRecords(collect([$requestA, $requestB]));
+});
+
+it('filters the request types table by the selected types', function () {
+    $typeA = ServiceRequestType::factory()->create(['name' => 'Type A']);
+    $typeB = ServiceRequestType::factory()->create(['name' => 'Type B']);
+
+    livewire(ServiceRequestTypesTable::class, [
+        'cacheTag' => 'test-service-request-types-table-type-filter',
+        'pageFilters' => ['serviceRequestTypes' => [$typeA->getKey()]],
+    ])
+        ->assertCanSeeTableRecords(collect([$typeA]))
+        ->assertCanNotSeeTableRecords(collect([$typeB]));
+});
+
+it('respects the selected types in the service requests stats', function () {
+    $typeA = ServiceRequestType::factory()->create();
+    $typeB = ServiceRequestType::factory()->create();
+
+    $priorityA = ServiceRequestPriority::factory()->state(['type_id' => $typeA->getKey()])->create();
+    $priorityB = ServiceRequestPriority::factory()->state(['type_id' => $typeB->getKey()])->create();
+
+    $status = ServiceRequestStatus::factory()->state([
+        'classification' => SystemServiceRequestClassification::Open,
+    ])->create();
+
+    ServiceRequest::factory()->count(2)->state([
+        'priority_id' => $priorityA->getKey(),
+        'status_id' => $status->getKey(),
+    ])->create();
+
+    ServiceRequest::factory()->count(3)->state([
+        'priority_id' => $priorityB->getKey(),
+        'status_id' => $status->getKey(),
+    ])->create();
+
+    $widget = new ServiceRequestsStats();
+    $widget->cacheTag = 'test-service-requests-stats-type-filter';
+    $widget->pageFilters = ['serviceRequestTypes' => [$typeA->getKey()]];
+
+    $stats = $widget->getStats();
+
+    expect($stats[0]->getValue())->toEqual('2');
+});
+
+it('respects the selected types in the status distribution chart', function () {
+    $typeA = ServiceRequestType::factory()->create();
+    $typeB = ServiceRequestType::factory()->create();
+
+    $priorityA = ServiceRequestPriority::factory()->state(['type_id' => $typeA->getKey()])->create();
+    $priorityB = ServiceRequestPriority::factory()->state(['type_id' => $typeB->getKey()])->create();
+
+    $status = ServiceRequestStatus::factory()->state([
+        'name' => 'Open',
+        'classification' => SystemServiceRequestClassification::Open,
+    ])->create();
+
+    ServiceRequest::factory()->count(2)->state([
+        'priority_id' => $priorityA->getKey(),
+        'status_id' => $status->getKey(),
+    ])->create();
+
+    ServiceRequest::factory()->count(3)->state([
+        'priority_id' => $priorityB->getKey(),
+        'status_id' => $status->getKey(),
+    ])->create();
+
+    $widget = new ServiceRequestStatusDistributionDonutChart();
+    $widget->cacheTag = 'test-service-request-status-type-filter';
+    $widget->pageFilters = ['serviceRequestTypes' => [$typeA->getKey()]];
+
+    $data = $widget->getData();
+
+    expect(array_sum($data['datasets'][0]['data']->all()))->toBe(2);
+});
+
+it('respects the selected types in the category distribution chart', function () {
+    $typeA = ServiceRequestType::factory()->create();
+    $typeB = ServiceRequestType::factory()->create();
+
+    $priorityA = ServiceRequestPriority::factory()->state(['type_id' => $typeA->getKey()])->create();
+    $priorityB = ServiceRequestPriority::factory()->state(['type_id' => $typeB->getKey()])->create();
+
+    $status = ServiceRequestStatus::factory()->state([
+        'classification' => SystemServiceRequestClassification::Open,
+    ])->create();
+
+    ServiceRequest::factory()->count(2)->state([
+        'priority_id' => $priorityA->getKey(),
+        'status_id' => $status->getKey(),
+        'category' => ServiceRequestCategory::Incident,
+    ])->create();
+
+    ServiceRequest::factory()->count(3)->state([
+        'priority_id' => $priorityB->getKey(),
+        'status_id' => $status->getKey(),
+        'category' => ServiceRequestCategory::Request,
+    ])->create();
+
+    $widget = new ServiceRequestCategoryDistributionDonutChart();
+    $widget->cacheTag = 'test-service-request-category-type-filter';
+    $widget->pageFilters = ['serviceRequestTypes' => [$typeA->getKey()]];
+
+    $data = $widget->getData();
+
+    expect($data['labels']->all())->toBe([(string) ServiceRequestCategory::Incident->getLabel()])
+        ->and(array_sum($data['datasets'][0]['data']->all()))->toBe(2);
+});
+
+it('respects the selected types in the requests over time chart', function () {
+    $typeA = ServiceRequestType::factory()->create();
+    $typeB = ServiceRequestType::factory()->create();
+
+    $priorityA = ServiceRequestPriority::factory()->state(['type_id' => $typeA->getKey()])->create();
+    $priorityB = ServiceRequestPriority::factory()->state(['type_id' => $typeB->getKey()])->create();
+
+    $status = ServiceRequestStatus::factory()->state([
+        'classification' => SystemServiceRequestClassification::Open,
+    ])->create();
+
+    ServiceRequest::factory()->count(2)->state([
+        'priority_id' => $priorityA->getKey(),
+        'status_id' => $status->getKey(),
+        'created_at' => now()->subMonth(),
+    ])->create();
+
+    ServiceRequest::factory()->count(3)->state([
+        'priority_id' => $priorityB->getKey(),
+        'status_id' => $status->getKey(),
+        'created_at' => now()->subMonth(),
+    ])->create();
+
+    $widget = new ServiceRequestsOverTimeBarChart();
+    $widget->cacheTag = 'test-service-requests-over-time-type-filter';
+    $widget->pageFilters = ['serviceRequestTypes' => [$typeA->getKey()]];
+
+    $data = $widget->getData();
+
+    expect(array_sum($data['datasets'][0]['data']))->toBe(2);
 });

--- a/app-modules/report/tests/Tenant/Filament/Pages/ServiceRequestTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Pages/ServiceRequestTest.php
@@ -199,24 +199,57 @@ it('orders grouped type options by category sort and pivot sort', function () {
 
     $tree = ListServiceRequests::buildTypeTreeOptions();
 
-    // Earlier Root should come before Later Root (based on sort)
+    $rootCategoryOrder = collect($tree)
+        ->filter(fn (array $node): bool => str_starts_with($node['value'], 'category_'))
+        ->map(fn (array $node): string => $node['name'])
+        ->values()
+        ->all();
+
+    expect($rootCategoryOrder)->toBe(['Earlier Root', 'Later Root']);
+
     $earlierRootNode = collect($tree)->first(fn (array $node): bool => $node['value'] === 'category_' . $earlierRoot->getKey());
-    $laterRootNode = collect($tree)->first(fn (array $node): bool => $node['value'] === 'category_' . $laterRoot->getKey());
 
-    expect($earlierRootNode['name'])->toBe('Earlier Root');
-    expect($laterRootNode['name'])->toBe('Later Root');
-
-    // Earlier Root should have the child category and types in correct order
-    $earlierRootChildren = $earlierRootNode['children'] ?? [];
-    $childNode = collect($earlierRootChildren)->first(fn (array $node): bool => $node['value'] === 'category_' . $earlierChild->getKey());
+    $childNode = collect($earlierRootNode['children'])->first(fn (array $node): bool => $node['value'] === 'category_' . $earlierChild->getKey());
     expect($childNode)->toBeArray();
 
-    // Types within Earlier Root should include both types
-    $typeNodes = collect($earlierRootChildren)->filter(fn (array $node): bool => ! str_starts_with($node['value'], 'category_'));
-    $typeIds = $typeNodes->map(fn (array $node): string => $node['value'])->values()->all();
+    $typeIds = collect($earlierRootNode['children'])
+        ->reject(fn (array $node): bool => str_starts_with($node['value'], 'category_'))
+        ->map(fn (array $node): string => $node['value'])
+        ->values()
+        ->all();
 
-    expect($typeIds)->toContain($earlierRootFirstType->getKey());
-    expect($typeIds)->toContain($earlierRootSecondType->getKey());
+    expect($typeIds)->toBe([
+        $earlierRootFirstType->getKey(),
+        $earlierRootSecondType->getKey(),
+    ]);
+});
+
+it('orders types within a category by pivot sort rather than the global sort', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $category = ServiceRequestTypeCategory::factory()->create(['parent_id' => null, 'name' => 'Area', 'sort' => 1]);
+
+    $globalFirst = ServiceRequestType::factory()->create(['name' => 'Global First', 'sort' => 1]);
+    $globalSecond = ServiceRequestType::factory()->create(['name' => 'Global Second', 'sort' => 2]);
+
+    $category->types()->attach($globalFirst->getKey(), ['sort' => 20]);
+    $category->types()->attach($globalSecond->getKey(), ['sort' => 10]);
+
+    $tree = ListServiceRequests::buildTypeTreeOptions();
+
+    $areaNode = collect($tree)->first(fn (array $node): bool => $node['value'] === 'category_' . $category->getKey());
+
+    $typeNames = collect($areaNode['children'])
+        ->reject(fn (array $node): bool => str_starts_with($node['value'], 'category_'))
+        ->map(fn (array $node): string => $node['name'])
+        ->values()
+        ->all();
+
+    expect($typeNames)->toBe(['Global Second', 'Global First']);
 });
 
 it('excludes archived types from the filter options', function () {
@@ -227,10 +260,14 @@ it('excludes archived types from the filter options', function () {
     actingAs($user);
 
     $activeType = ServiceRequestType::factory()->create(['name' => 'Active Type']);
-    $archivedType = ServiceRequestType::factory()->create(['name' => 'Archived Type']);
-    $archivedType->delete();
 
-    $tree = ListServiceRequests::buildTypeTreeOptions();
+    $archivedType = ServiceRequestType::factory()->create(['name' => 'Archived Type']);
+    $archivedType->archive();
+
+    $deletedType = ServiceRequestType::factory()->create(['name' => 'Deleted Type']);
+    $deletedType->delete();
+
+    $tree = ListServiceRequests::buildTypeTreeOptions(withoutArchived: true);
 
     // Flatten the tree to get all type IDs
     $flattenedIds = collect($tree)
@@ -242,7 +279,26 @@ it('excludes archived types from the filter options', function () {
 
     expect($flattenedIds)
         ->toContain($activeType->getKey())
-        ->not->toContain($archivedType->getKey());
+        ->not->toContain($archivedType->getKey())
+        ->not->toContain($deletedType->getKey());
+});
+
+it('keeps archived types available to the service requests list filter', function () {
+    $activeType = ServiceRequestType::factory()->create(['name' => 'Active Type']);
+
+    $archivedType = ServiceRequestType::factory()->create(['name' => 'Archived Type']);
+    $archivedType->archive();
+
+    $flattenedIds = collect(ListServiceRequests::buildTypeTreeOptions())
+        ->map(fn (array $node): array => [$node['value'], ...collect($node['children'] ?? [])->map(fn (array $child): string => $child['value'])->values()->all()])
+        ->flatten()
+        ->reject(fn (string $value): bool => str_starts_with($value, 'category_'))
+        ->values()
+        ->all();
+
+    expect($flattenedIds)
+        ->toContain($activeType->getKey())
+        ->toContain($archivedType->getKey());
 });
 
 it('resolves every type the user manages or audits as an affiliated type', function () {
@@ -266,9 +322,17 @@ it('resolves every type the user manages or audits as an affiliated type', funct
     $auditorDepartmentType = ServiceRequestType::factory()->create();
     $auditorDepartmentType->auditorDepartments()->attach($department);
 
-    $archivedAffiliatedType = ServiceRequestType::factory()->create();
-    $archivedAffiliatedType->managerUsers()->attach($user);
-    $archivedAffiliatedType->delete();
+    $archivedUserAffiliatedType = ServiceRequestType::factory()->create();
+    $archivedUserAffiliatedType->managerUsers()->attach($user);
+    $archivedUserAffiliatedType->archive();
+
+    $archivedDepartmentAffiliatedType = ServiceRequestType::factory()->create();
+    $archivedDepartmentAffiliatedType->managerDepartments()->attach($department);
+    $archivedDepartmentAffiliatedType->archive();
+
+    $deletedAffiliatedType = ServiceRequestType::factory()->create();
+    $deletedAffiliatedType->managerUsers()->attach($user);
+    $deletedAffiliatedType->delete();
 
     $unaffiliatedType = ServiceRequestType::factory()->create();
 
@@ -281,7 +345,9 @@ it('resolves every type the user manages or audits as an affiliated type', funct
             $managerDepartmentType->getKey(),
             $auditorDepartmentType->getKey(),
         ])
-        ->not->toContain($archivedAffiliatedType->getKey())
+        ->not->toContain($archivedUserAffiliatedType->getKey())
+        ->not->toContain($archivedDepartmentAffiliatedType->getKey())
+        ->not->toContain($deletedAffiliatedType->getKey())
         ->not->toContain($unaffiliatedType->getKey());
 });
 
@@ -297,13 +363,65 @@ it('populates the filter with affiliated types via the My Affiliated Types actio
 
     $archivedAffiliatedType = ServiceRequestType::factory()->create();
     $archivedAffiliatedType->managerUsers()->attach($user);
-    $archivedAffiliatedType->delete();
+    $archivedAffiliatedType->archive();
 
     ServiceRequestType::factory()->create();
 
     livewire(ServiceRequests::class)
         ->callAction(TestAction::make('loadAffiliatedServiceRequestTypes')->schemaComponent('serviceRequestTypeActions', 'filtersForm'))
         ->assertSet('filters.serviceRequestTypes', [$affiliatedType->getKey()]);
+});
+
+it('warns instead of changing the filter when the user has no affiliated types', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $type = ServiceRequestType::factory()->create();
+
+    livewire(ServiceRequests::class)
+        ->set('filters.serviceRequestTypes', [$type->getKey()])
+        ->callAction(TestAction::make('loadAffiliatedServiceRequestTypes')->schemaComponent('serviceRequestTypeActions', 'filtersForm'))
+        ->assertNotified('You are not a manager or auditor of any Service Request Types')
+        ->assertSet('filters.serviceRequestTypes', [$type->getKey()]);
+});
+
+it('keeps the types selected by the My Affiliated Types action when the page is revisited', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $affiliatedType = ServiceRequestType::factory()->create();
+    $affiliatedType->managerUsers()->attach($user);
+
+    livewire(ServiceRequests::class)
+        ->callAction(TestAction::make('loadAffiliatedServiceRequestTypes')->schemaComponent('serviceRequestTypeActions', 'filtersForm'))
+        ->assertSet('filters.serviceRequestTypes', [$affiliatedType->getKey()]);
+
+    livewire(ServiceRequests::class)
+        ->assertSet('filters.serviceRequestTypes', [$affiliatedType->getKey()]);
+});
+
+it('keeps the filter empty when the page is revisited after the Clear action', function () {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+
+    grantServiceRequestsReportAccess($user);
+
+    actingAs($user);
+
+    $type = ServiceRequestType::factory()->create();
+
+    livewire(ServiceRequests::class)
+        ->set('filters.serviceRequestTypes', [$type->getKey()])
+        ->callAction(TestAction::make('clearServiceRequestTypes')->schemaComponent('serviceRequestTypeActions', 'filtersForm'))
+        ->assertSet('filters.serviceRequestTypes', []);
+
+    livewire(ServiceRequests::class)
+        ->assertSet('filters.serviceRequestTypes', []);
 });
 
 it('disables clear action until at least one type is selected', function () {

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequests/Pages/ListServiceRequests.php
@@ -303,9 +303,11 @@ class ListServiceRequests extends ListRecords
     }
 
     /**
+     * @param  bool  $withoutArchived
+     *
      * @return array<int, array{name: string, value: string, children: array<int, mixed>}>
      */
-    public static function buildTypeTreeOptions(): array
+    public static function buildTypeTreeOptions(bool $withoutArchived = false): array
     {
         $categories = ServiceRequestTypeCategory::query()
             ->orderBy('sort')
@@ -313,6 +315,7 @@ class ListServiceRequests extends ListRecords
             ->groupBy('parent_id');
 
         $types = ServiceRequestType::query()
+            ->when($withoutArchived, fn (Builder $query): Builder => $query->withoutArchived())
             ->with('categories:id')
             ->orderBy('sort')
             ->get();
@@ -323,21 +326,24 @@ class ListServiceRequests extends ListRecords
         $uncategorizedTypes = [];
 
         foreach ($types as $type) {
-            $categoryIds = $type->categoryIds();
+            $categorySortMap = $type->categorySortMap();
 
-            if ($categoryIds === []) {
+            if ($categorySortMap === []) {
                 $uncategorizedTypes[] = $type;
 
                 continue;
             }
 
-            foreach ($categoryIds as $categoryId) {
-                $typesByCategory[$categoryId][] = $type;
+            foreach ($categorySortMap as $categoryId => $sort) {
+                $typesByCategory[$categoryId][] = ['type' => $type, 'sort' => $sort];
             }
         }
 
         /** @var Collection<int|string, Collection<int, ServiceRequestType>> $typesByCategory */
-        $typesByCategory = collect($typesByCategory)->map(fn (array $group): Collection => collect($group));
+        $typesByCategory = collect($typesByCategory)->map(fn (array $group): Collection => collect($group)
+            ->sortBy('sort')
+            ->map(fn (array $entry): ServiceRequestType => $entry['type'])
+            ->values());
 
         $tree = collect($categories->get('', collect()))
             ->map(fn (ServiceRequestTypeCategory $category) => static::buildCategoryNode($category, $categories, $typesByCategory))


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1357

### Technical Description

- Added a grouped "Service Request Types" multi-select filter
- Added "My Affiliated Types" button to auto-select types the user manages/audits.
- Added a "Clear" button, disabled when nothing is selected.
- Wired the filter into all report widgets (tables, stats, charts).
- Added shared `getServiceRequestTypes()` accessor to the filters trait.

### Any deployment steps required?

No

### Cleanup Tasks

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
