### PR TITLE
[AIDAPP-1352]: Some users have reported that when modifying base templates in a service request type, or in Global Administration, navigating away from the tabs results in an unexpected browser notice indicating the page is not saved, when it is

### DIFF
--- a/app-modules/service-management/src/Filament/Pages/ManageServiceRequestNotificationAutomationSettings.php
+++ b/app-modules/service-management/src/Filament/Pages/ManageServiceRequestNotificationAutomationSettings.php
@@ -70,7 +70,7 @@ class ManageServiceRequestNotificationAutomationSettings extends SettingsPage
 
     protected static ?int $navigationSort = 60;
 
-    protected ?bool $hasUnsavedDataChangesAlert = true;
+    protected ?bool $hasUnsavedDataChangesAlert = false;
 
     public static function canAccess(): bool
     {

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestTypes/Pages/ServiceRequestTypeEmailTemplatePage.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestTypes/Pages/ServiceRequestTypeEmailTemplatePage.php
@@ -66,7 +66,7 @@ class ServiceRequestTypeEmailTemplatePage extends EditRecord
 
     public static string | UnitEnum | null $navigationGroup = ServiceManagementAdministrationNavigationGroup::EmailTemplates;
 
-    protected ?bool $hasUnsavedDataChangesAlert = true;
+    protected ?bool $hasUnsavedDataChangesAlert = false;
 
     public function getRelationManagers(): array
     {

--- a/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestNotificationAutomationSettingsTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestNotificationAutomationSettingsTest.php
@@ -54,3 +54,13 @@ test('it allows access for super admins', function () {
     get(ManageServiceRequestNotificationAutomationSettings::getUrl())
         ->assertSuccessful();
 });
+
+test('it disables the unsaved data changes alert to avoid false positives on this complex form', function () {
+    $page = new ManageServiceRequestNotificationAutomationSettings();
+
+    $hasUnsavedDataChangesAlert = (new ReflectionClass($page))
+        ->getProperty('hasUnsavedDataChangesAlert')
+        ->getValue($page);
+
+    expect($hasUnsavedDataChangesAlert)->toBeFalse();
+});

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequestTypes/Pages/ServiceRequestTypeEmailTemplatePageTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequestTypes/Pages/ServiceRequestTypeEmailTemplatePageTest.php
@@ -105,3 +105,13 @@ test('it updates a ServiceRequestTypeEmailTemplate if it already exists', functi
     expect($emailTemplate->subject)->toEqualCanonicalizing($request['subject'])
         ->and($emailTemplate->body)->toEqualCanonicalizing($request['body']);
 });
+
+test('it disables the unsaved data changes alert to avoid false positives on this complex form', function () {
+    $page = new ServiceRequestTypeEmailTemplatePage();
+
+    $hasUnsavedDataChangesAlert = (new ReflectionClass($page))
+        ->getProperty('hasUnsavedDataChangesAlert')
+        ->getValue($page);
+
+    expect($hasUnsavedDataChangesAlert)->toBeFalse();
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1352

### Technical Description

- Disable unsaved data changes alert for complex forms in Service Request settings and email template pages

### Any deployment steps required?

No

### Cleanup Tasks

No.

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
