### PR TITLE
[AIDAPP-1351]: Relocate the base service request types templates to a dedicated page in the global administration experience

### DIFF
--- a/app-modules/audit/src/Filament/Pages/ManageAuditSettings.php
+++ b/app-modules/audit/src/Filament/Pages/ManageAuditSettings.php
@@ -50,7 +50,7 @@ class ManageAuditSettings extends SettingsPage
 {
     protected static ?string $navigationLabel = 'Auditing';
 
-    protected static ?int $navigationSort = 20;
+    protected static ?int $navigationSort = 30;
 
     protected static string $settings = AuditSettings::class;
 

--- a/app-modules/service-management/src/Filament/Pages/ManageServiceRequestNotificationAutomationSettings.php
+++ b/app-modules/service-management/src/Filament/Pages/ManageServiceRequestNotificationAutomationSettings.php
@@ -163,15 +163,22 @@ class ManageServiceRequestNotificationAutomationSettings extends SettingsPage
 
             foreach ($templates as $typeValue => $roles) {
                 foreach ($roles as $roleValue => $templateData) {
-                    ServiceRequestNotificationAutomationEmailTemplate::updateOrCreate(
-                        [
-                            'type' => $typeValue,
-                            'role' => $roleValue,
-                        ],
-                        [
-                            'ai_instructions' => trim($templateData['ai_instructions'] ?? '') ?: null,
-                        ],
-                    );
+                    $template = ServiceRequestNotificationAutomationEmailTemplate::firstOrNew([
+                        'type' => $typeValue,
+                        'role' => $roleValue,
+                    ]);
+
+                    $template->ai_instructions = trim($templateData['ai_instructions'] ?? '') ?: null;
+
+                    if (blank($template->ai_instructions) && blank($template->subject) && blank($template->body)) {
+                        if ($template->exists) {
+                            $template->delete();
+                        }
+
+                        continue;
+                    }
+
+                    $template->save();
                 }
             }
         });

--- a/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestBaseTemplatesSettingsTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestBaseTemplatesSettingsTest.php
@@ -36,8 +36,9 @@
 
 use AidingApp\ServiceManagement\Enums\ServiceRequestEmailTemplateType;
 use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
+use AidingApp\ServiceManagement\Filament\Pages\ManageServiceRequestNotificationAutomationSettings;
 use AidingApp\ServiceManagement\Models\ServiceRequestNotificationAutomationEmailTemplate;
-use App\Filament\Clusters\GlobalServiceManagementCluster\Pages\ManageServiceRequestBaseTemplates;
+use App\Filament\Clusters\GlobalServiceManagementCluster\Pages\ManageServiceRequestBaseTemplatesSettings;
 use App\Models\User;
 
 use function Pest\Laravel\actingAs;
@@ -48,14 +49,14 @@ use function Tests\asSuperAdmin;
 test('it prevents access when the user does not have permission', function () {
     actingAs(User::factory()->create());
 
-    get(ManageServiceRequestBaseTemplates::getUrl())
+    get(ManageServiceRequestBaseTemplatesSettings::getUrl())
         ->assertForbidden();
 });
 
 test('it allows access for super admins', function () {
     asSuperAdmin();
 
-    get(ManageServiceRequestBaseTemplates::getUrl())
+    get(ManageServiceRequestBaseTemplatesSettings::getUrl())
         ->assertSuccessful();
 });
 
@@ -92,7 +93,7 @@ test('it saves the example subject and body without touching ai instructions', f
         ],
     ];
 
-    livewire(ManageServiceRequestBaseTemplates::class)
+    livewire(ManageServiceRequestBaseTemplatesSettings::class)
         ->fillForm([
             "templates.{$existing->type->value}.{$existing->role->value}.subject" => $subject,
             "templates.{$existing->type->value}.{$existing->role->value}.body" => $body,
@@ -105,4 +106,71 @@ test('it saves the example subject and body without touching ai instructions', f
     expect($existing->subject)->toEqual($subject);
     expect($existing->body)->toEqual($body);
     expect($existing->ai_instructions)->toBe('Keep it friendly.');
+});
+
+test('it persists example subject/body and ai instructions correctly when saved from both pages', function () {
+    asSuperAdmin();
+
+    $type = ServiceRequestEmailTemplateType::Created;
+    $role = ServiceRequestTypeEmailTemplateRole::Customer;
+
+    expect(ServiceRequestNotificationAutomationEmailTemplate::query()
+        ->where('type', $type)
+        ->where('role', $role)
+        ->exists())->toBeFalse();
+
+    $subject = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Example Subject'],
+                ],
+            ],
+        ],
+    ];
+
+    $body = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Example Body'],
+                ],
+            ],
+        ],
+    ];
+
+    livewire(ManageServiceRequestBaseTemplatesSettings::class)
+        ->fillForm([
+            "templates.{$type->value}.{$role->value}.subject" => $subject,
+            "templates.{$type->value}.{$role->value}.body" => $body,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $template = ServiceRequestNotificationAutomationEmailTemplate::query()
+        ->where('type', $type)
+        ->where('role', $role)
+        ->firstOrFail();
+
+    expect($template->subject)->toEqual($subject);
+    expect($template->body)->toEqual($body);
+    expect($template->ai_instructions)->toBeNull();
+
+    livewire(ManageServiceRequestNotificationAutomationSettings::class)
+        ->fillForm([
+            'is_enabled' => true,
+            "templates.{$type->value}.{$role->value}.ai_instructions" => 'Be concise and friendly.',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $template->refresh();
+
+    expect($template->subject)->toEqual($subject);
+    expect($template->body)->toEqual($body);
+    expect($template->ai_instructions)->toBe('Be concise and friendly.');
 });

--- a/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestBaseTemplatesSettingsTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestBaseTemplatesSettingsTest.php
@@ -39,6 +39,7 @@ use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
 use AidingApp\ServiceManagement\Filament\Pages\ManageServiceRequestNotificationAutomationSettings;
 use AidingApp\ServiceManagement\Models\ServiceRequestNotificationAutomationEmailTemplate;
 use App\Filament\Clusters\GlobalServiceManagementCluster\Pages\ManageServiceRequestBaseTemplatesSettings;
+use App\Models\Authenticatable;
 use App\Models\User;
 
 use function Pest\Laravel\actingAs;
@@ -53,11 +54,114 @@ test('it prevents access when the user does not have permission', function () {
         ->assertForbidden();
 });
 
+test('it prevents access for ai admins', function () {
+    $user = User::factory()->create();
+    $user->assignRole(Authenticatable::AI_ADMIN_ROLE);
+
+    actingAs($user);
+
+    get(ManageServiceRequestBaseTemplatesSettings::getUrl())
+        ->assertForbidden();
+});
+
 test('it allows access for super admins', function () {
     asSuperAdmin();
 
     get(ManageServiceRequestBaseTemplatesSettings::getUrl())
         ->assertSuccessful();
+});
+
+test('it disables the unsaved data changes alert to avoid false positives on this complex form', function () {
+    $page = new ManageServiceRequestBaseTemplatesSettings();
+
+    $hasUnsavedDataChangesAlert = (new ReflectionClass($page))
+        ->getProperty('hasUnsavedDataChangesAlert')
+        ->getValue($page);
+
+    expect($hasUnsavedDataChangesAlert)->toBeFalse();
+});
+
+test('it leaves existing templates untouched when saving without changes', function () {
+    asSuperAdmin();
+
+    $existing = collect([
+        [ServiceRequestEmailTemplateType::Created, ServiceRequestTypeEmailTemplateRole::Customer, 'Keep it friendly.'],
+        [ServiceRequestEmailTemplateType::Assigned, ServiceRequestTypeEmailTemplateRole::Manager, null],
+        [ServiceRequestEmailTemplateType::Closed, ServiceRequestTypeEmailTemplateRole::Auditor, 'Be brief.'],
+        [ServiceRequestEmailTemplateType::SurveyResponse, ServiceRequestTypeEmailTemplateRole::Customer, null],
+    ])->map(fn (array $attributes) => ServiceRequestNotificationAutomationEmailTemplate::factory()->create([
+        'type' => $attributes[0],
+        'role' => $attributes[1],
+        'ai_instructions' => $attributes[2],
+    ]));
+
+    livewire(ManageServiceRequestBaseTemplatesSettings::class)
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(ServiceRequestNotificationAutomationEmailTemplate::count())->toBe(4);
+
+    foreach ($existing as $template) {
+        $fresh = ServiceRequestNotificationAutomationEmailTemplate::query()->findOrFail($template->getKey());
+
+        expect($fresh->subject)->toEqual($template->subject);
+        expect($fresh->body)->toEqual($template->body);
+        expect($fresh->ai_instructions)->toBe($template->ai_instructions);
+    }
+});
+
+test('it does not create empty templates when nothing has been filled in', function () {
+    asSuperAdmin();
+
+    livewire(ManageServiceRequestBaseTemplatesSettings::class)
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(ServiceRequestNotificationAutomationEmailTemplate::query()->exists())->toBeFalse();
+});
+
+test('it deletes a template that is left with no example subject, body, or ai instructions', function () {
+    asSuperAdmin();
+
+    $existing = ServiceRequestNotificationAutomationEmailTemplate::factory()->create([
+        'type' => ServiceRequestEmailTemplateType::Created,
+        'role' => ServiceRequestTypeEmailTemplateRole::Customer,
+        'ai_instructions' => null,
+    ]);
+
+    livewire(ManageServiceRequestBaseTemplatesSettings::class)
+        ->fillForm([
+            "templates.{$existing->type->value}.{$existing->role->value}.subject" => null,
+            "templates.{$existing->type->value}.{$existing->role->value}.body" => null,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(ServiceRequestNotificationAutomationEmailTemplate::query()->whereKey($existing->getKey())->exists())->toBeFalse();
+});
+
+test('it keeps a template with ai instructions when the example subject and body are cleared', function () {
+    asSuperAdmin();
+
+    $existing = ServiceRequestNotificationAutomationEmailTemplate::factory()->create([
+        'type' => ServiceRequestEmailTemplateType::Created,
+        'role' => ServiceRequestTypeEmailTemplateRole::Customer,
+        'ai_instructions' => 'Keep it friendly.',
+    ]);
+
+    livewire(ManageServiceRequestBaseTemplatesSettings::class)
+        ->fillForm([
+            "templates.{$existing->type->value}.{$existing->role->value}.subject" => null,
+            "templates.{$existing->type->value}.{$existing->role->value}.body" => null,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $existing->refresh();
+
+    expect($existing->subject)->toBeNull();
+    expect($existing->body)->toBeNull();
+    expect($existing->ai_instructions)->toBe('Keep it friendly.');
 });
 
 test('it saves the example subject and body without touching ai instructions', function () {

--- a/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestBaseTemplatesTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestBaseTemplatesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\ServiceManagement\Enums\ServiceRequestEmailTemplateType;
+use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
+use AidingApp\ServiceManagement\Models\ServiceRequestNotificationAutomationEmailTemplate;
+use App\Filament\Clusters\GlobalServiceManagementCluster\Pages\ManageServiceRequestBaseTemplates;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+test('it prevents access when the user does not have permission', function () {
+    actingAs(User::factory()->create());
+
+    get(ManageServiceRequestBaseTemplates::getUrl())
+        ->assertForbidden();
+});
+
+test('it allows access for super admins', function () {
+    asSuperAdmin();
+
+    get(ManageServiceRequestBaseTemplates::getUrl())
+        ->assertSuccessful();
+});
+
+test('it saves the example subject and body without touching ai instructions', function () {
+    asSuperAdmin();
+
+    $existing = ServiceRequestNotificationAutomationEmailTemplate::factory()->create([
+        'type' => ServiceRequestEmailTemplateType::Created,
+        'role' => ServiceRequestTypeEmailTemplateRole::Customer,
+        'ai_instructions' => 'Keep it friendly.',
+    ]);
+
+    $subject = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Example Subject'],
+                ],
+            ],
+        ],
+    ];
+
+    $body = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Example Body'],
+                ],
+            ],
+        ],
+    ];
+
+    livewire(ManageServiceRequestBaseTemplates::class)
+        ->fillForm([
+            "templates.{$existing->type->value}.{$existing->role->value}.subject" => $subject,
+            "templates.{$existing->type->value}.{$existing->role->value}.body" => $body,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $existing->refresh();
+
+    expect($existing->subject)->toEqual($subject);
+    expect($existing->body)->toEqual($body);
+    expect($existing->ai_instructions)->toBe('Keep it friendly.');
+});

--- a/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestNotificationAutomationSettingsTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestNotificationAutomationSettingsTest.php
@@ -114,3 +114,70 @@ test('it saves is_enabled, ai_prompt, and ai instructions without touching the e
     expect($settings->is_enabled)->toBeTrue();
     expect($settings->ai_prompt)->toEqual($aiPrompt);
 });
+
+test('it leaves existing templates untouched when saving without changes', function () {
+    asSuperAdmin();
+
+    $existing = collect([
+        [ServiceRequestEmailTemplateType::Created, ServiceRequestTypeEmailTemplateRole::Customer, 'Keep it friendly.'],
+        [ServiceRequestEmailTemplateType::Assigned, ServiceRequestTypeEmailTemplateRole::Manager, null],
+        [ServiceRequestEmailTemplateType::Closed, ServiceRequestTypeEmailTemplateRole::Auditor, 'Be brief.'],
+    ])->map(fn (array $attributes) => ServiceRequestNotificationAutomationEmailTemplate::factory()->create([
+        'type' => $attributes[0],
+        'role' => $attributes[1],
+        'ai_instructions' => $attributes[2],
+    ]));
+
+    livewire(ManageServiceRequestNotificationAutomationSettings::class)
+        ->fillForm(['is_enabled' => true])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(ServiceRequestNotificationAutomationEmailTemplate::count())->toBe(3);
+
+    foreach ($existing as $template) {
+        $fresh = ServiceRequestNotificationAutomationEmailTemplate::query()->findOrFail($template->getKey());
+
+        expect($fresh->subject)->toEqual($template->subject);
+        expect($fresh->body)->toEqual($template->body);
+        expect($fresh->ai_instructions)->toBe($template->ai_instructions);
+    }
+});
+
+test('it does not create empty templates when no ai instructions have been filled in', function () {
+    asSuperAdmin();
+
+    livewire(ManageServiceRequestNotificationAutomationSettings::class)
+        ->fillForm(['is_enabled' => true])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(ServiceRequestNotificationAutomationEmailTemplate::query()->exists())->toBeFalse();
+});
+
+test('it keeps a template with an example subject and body when the ai instructions are cleared', function () {
+    asSuperAdmin();
+
+    $existing = ServiceRequestNotificationAutomationEmailTemplate::factory()->create([
+        'type' => ServiceRequestEmailTemplateType::Created,
+        'role' => ServiceRequestTypeEmailTemplateRole::Customer,
+        'ai_instructions' => 'Old instructions.',
+    ]);
+
+    $originalSubject = $existing->subject;
+    $originalBody = $existing->body;
+
+    livewire(ManageServiceRequestNotificationAutomationSettings::class)
+        ->fillForm([
+            'is_enabled' => true,
+            "templates.{$existing->type->value}.{$existing->role->value}.ai_instructions" => '',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $existing->refresh();
+
+    expect($existing->ai_instructions)->toBeNull();
+    expect($existing->subject)->toEqual($originalSubject);
+    expect($existing->body)->toEqual($originalBody);
+});

--- a/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestNotificationAutomationSettingsTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestNotificationAutomationSettingsTest.php
@@ -69,7 +69,7 @@ test('it disables the unsaved data changes alert to avoid false positives on thi
 
     expect($hasUnsavedDataChangesAlert)->toBeFalse();
 });
-    
+
 test('it saves is_enabled, ai_prompt, and ai instructions without touching the example subject and body', function () {
     asSuperAdmin();
 

--- a/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestNotificationAutomationSettingsTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Pages/ManageServiceRequestNotificationAutomationSettingsTest.php
@@ -34,11 +34,16 @@
 </COPYRIGHT>
 */
 
+use AidingApp\ServiceManagement\Enums\ServiceRequestEmailTemplateType;
+use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
 use AidingApp\ServiceManagement\Filament\Pages\ManageServiceRequestNotificationAutomationSettings;
+use AidingApp\ServiceManagement\Models\ServiceRequestNotificationAutomationEmailTemplate;
+use AidingApp\ServiceManagement\Settings\ServiceRequestNotificationAutomationSettings;
 use App\Models\User;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
 test('it prevents access when the user does not have permission', function () {
@@ -63,4 +68,49 @@ test('it disables the unsaved data changes alert to avoid false positives on thi
         ->getValue($page);
 
     expect($hasUnsavedDataChangesAlert)->toBeFalse();
+});
+    
+test('it saves is_enabled, ai_prompt, and ai instructions without touching the example subject and body', function () {
+    asSuperAdmin();
+
+    $existing = ServiceRequestNotificationAutomationEmailTemplate::factory()->create([
+        'type' => ServiceRequestEmailTemplateType::Created,
+        'role' => ServiceRequestTypeEmailTemplateRole::Customer,
+        'ai_instructions' => 'Old instructions.',
+    ]);
+
+    $originalSubject = $existing->subject;
+    $originalBody = $existing->body;
+
+    $aiPrompt = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Custom AI prompt.'],
+                ],
+            ],
+        ],
+    ];
+
+    livewire(ManageServiceRequestNotificationAutomationSettings::class)
+        ->fillForm([
+            'is_enabled' => true,
+            'ai_prompt' => $aiPrompt,
+            "templates.{$existing->type->value}.{$existing->role->value}.ai_instructions" => 'Updated instructions.',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $existing->refresh();
+
+    expect($existing->ai_instructions)->toBe('Updated instructions.');
+    expect($existing->subject)->toEqual($originalSubject);
+    expect($existing->body)->toEqual($originalBody);
+
+    $settings = app(ServiceRequestNotificationAutomationSettings::class);
+
+    expect($settings->is_enabled)->toBeTrue();
+    expect($settings->ai_prompt)->toEqual($aiPrompt);
 });

--- a/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
+++ b/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
@@ -52,7 +52,7 @@ class ManageBrandConfigurationSettings extends SettingsPage
 {
     protected static ?string $navigationLabel = 'Branding';
 
-    protected static ?int $navigationSort = 30;
+    protected static ?int $navigationSort = 40;
 
     protected static string $settings = ThemeSettings::class;
 

--- a/app/Filament/Clusters/GlobalArtificialIntelligence.php
+++ b/app/Filament/Clusters/GlobalArtificialIntelligence.php
@@ -46,5 +46,5 @@ class GlobalArtificialIntelligence extends Cluster
 
     protected static ?string $title = 'Artificial Intelligence';
 
-    protected static ?int $navigationSort = 70;
+    protected static ?int $navigationSort = 80;
 }

--- a/app/Filament/Clusters/GlobalServiceManagementCluster.php
+++ b/app/Filament/Clusters/GlobalServiceManagementCluster.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Filament\Clusters;
+
+use App\Enums\NavigationGroup;
+use Filament\Clusters\Cluster;
+use UnitEnum;
+
+class GlobalServiceManagementCluster extends Cluster
+{
+    protected static ?int $navigationSort = 10;
+
+    protected static ?string $title = 'Service Management';
+
+    protected static string | UnitEnum | null $navigationGroup = NavigationGroup::GlobalAdmin;
+}

--- a/app/Filament/Clusters/GlobalServiceManagementCluster/Pages/ManageServiceRequestBaseTemplates.php
+++ b/app/Filament/Clusters/GlobalServiceManagementCluster/Pages/ManageServiceRequestBaseTemplates.php
@@ -34,20 +34,23 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Filament\Pages;
+namespace App\Filament\Clusters\GlobalServiceManagementCluster\Pages;
 
 use AidingApp\ServiceManagement\Enums\ServiceRequestEmailTemplateType;
 use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
+use AidingApp\ServiceManagement\Filament\Blocks\ServiceRequestTypeEmailTemplateButtonBlock;
+use AidingApp\ServiceManagement\Filament\Blocks\SurveyResponseEmailTemplateTakeSurveyButtonBlock;
 use AidingApp\ServiceManagement\Models\ServiceRequestNotificationAutomationEmailTemplate;
+use AidingApp\ServiceManagement\Models\ServiceRequestTypeEmailTemplate;
 use AidingApp\ServiceManagement\Settings\ServiceRequestNotificationAutomationSettings;
 use App\Enums\Feature;
-use App\Filament\Clusters\GlobalArtificialIntelligence;
+use App\Filament\Clusters\GlobalServiceManagementCluster;
 use App\Models\User;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\RichEditor\ToolbarButtonGroup;
 use Filament\Forms\Components\Textarea;
-use Filament\Forms\Components\Toggle;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;
@@ -56,39 +59,26 @@ use Filament\Schemas\Schema;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 
-class ManageServiceRequestNotificationAutomationSettings extends SettingsPage
+class ManageServiceRequestBaseTemplates extends SettingsPage
 {
     protected static string $settings = ServiceRequestNotificationAutomationSettings::class;
 
-    protected static ?string $title = 'Communication Automation';
+    protected static ?string $cluster = GlobalServiceManagementCluster::class;
 
-    protected static ?string $cluster = GlobalArtificialIntelligence::class;
-
-    protected static ?int $navigationSort = 60;
-
-    protected ?bool $hasUnsavedDataChangesAlert = false;
+    protected static ?string $title = 'Base Templates';
 
     public static function canAccess(): bool
     {
-        if (! Gate::check(Feature::ServiceManagement->getGateName())) {
-            return false;
-        }
-
         $user = auth()->user();
         assert($user instanceof User);
 
-        return $user->canAccessAiSettings();
+        return Gate::check(Feature::ServiceManagement->getGateName()) && $user->isSuperAdmin();
     }
 
     public function form(Schema $schema): Schema
     {
         return $schema
             ->components([
-                Toggle::make('is_enabled')
-                    ->label('Enable Communication Automation')
-                    ->helperText('When enabled, base email templates and AI instructions can be configured for automatic generation of service request email templates.')
-                    ->live()
-                    ->columnSpanFull(),
                 Tabs::make('Event templates')
                     ->persistTab()
                     ->id('event-template-tabs')
@@ -100,16 +90,7 @@ class ManageServiceRequestNotificationAutomationSettings extends SettingsPage
                                     ->id("role-template-tabs-{$type->value}")
                                     ->tabs(array_map(
                                         fn (ServiceRequestTypeEmailTemplateRole $role) => Tab::make($role->getLabel())
-                                            ->schema([
-                                                Textarea::make('ai_instructions')
-                                                    ->label('AI Instructions')
-                                                    ->placeholder('Provide guidance for how the AI should customize this template...')
-                                                    ->helperText('Natural language instructions for the AI when generating this specific event and role template.')
-                                                    ->rows(3)
-                                                    ->autosize()
-                                                    ->live(onBlur: true)
-                                                    ->columnSpanFull(),
-                                            ])
+                                            ->schema($this->getTemplateFormSchema($type, $role))
                                             ->statePath("templates.{$type->value}.{$role->value}"),
                                         $type === ServiceRequestEmailTemplateType::SurveyResponse
                                             ? [ServiceRequestTypeEmailTemplateRole::Customer]
@@ -119,46 +100,15 @@ class ManageServiceRequestNotificationAutomationSettings extends SettingsPage
                             ]),
                         ServiceRequestEmailTemplateType::cases()
                     ))
-                    ->visible(fn (Get $get) => $get('is_enabled'))
                     ->columnSpanFull(),
-                RichEditor::make('ai_prompt')
-                    ->label('AI Prompt')
-                    ->helperText('The prompt sent to the AI model when generating templates. Use merge tags to inject context at generation time.')
-                    ->toolbarButtons([])
-                    ->activePanel('mergeTags')
-                    ->mergeTags([
-                        'example subject',
-                        'example body',
-                        'user instructions',
-                        'available merge tags',
-                        'available custom blocks',
-                        'type name',
-                        'type description',
-                        'event name',
-                        'role name',
-                    ])
-                    ->extraInputAttributes(['style' => 'min-height: 12rem;'])
-                    ->visible(fn (Get $get) => $get('is_enabled'))
-                    ->json()
-                    ->columnSpanFull(),
-            ])
-            ->disabled(! auth()->user()->canAccessAiSettings());
+            ]);
     }
 
     public function save(): void
     {
-        if (! auth()->user()->canAccessAiSettings()) {
-            return;
-        }
-
         $state = $this->form->getState();
 
         DB::transaction(function () use ($state): void {
-            $settings = app(ServiceRequestNotificationAutomationSettings::class);
-            $settings->is_enabled = $state['is_enabled'];
-            $settings->ai_prompt = $state['ai_prompt'] ?? [];
-            $settings->save();
-
             $templates = $state['templates'] ?? [];
 
             foreach ($templates as $typeValue => $roles) {
@@ -169,7 +119,8 @@ class ManageServiceRequestNotificationAutomationSettings extends SettingsPage
                             'role' => $roleValue,
                         ],
                         [
-                            'ai_instructions' => trim($templateData['ai_instructions'] ?? '') ?: null,
+                            'subject' => $templateData['subject'] ?? null,
+                            'body' => $templateData['body'] ?? null,
                         ],
                     );
                 }
@@ -184,7 +135,7 @@ class ManageServiceRequestNotificationAutomationSettings extends SettingsPage
      */
     public function getFormActions(): array
     {
-        if (! auth()->user()->canAccessAiSettings()) {
+        if (! auth()->user()->isSuperAdmin()) {
             return [];
         }
 
@@ -193,11 +144,7 @@ class ManageServiceRequestNotificationAutomationSettings extends SettingsPage
 
     protected function fillForm(): void
     {
-        $settings = app(ServiceRequestNotificationAutomationSettings::class);
-
         $state = [
-            'is_enabled' => $settings->is_enabled,
-            'ai_prompt' => $settings->ai_prompt ?: ServiceRequestNotificationAutomationSettings::defaultAiPrompt(),
             'templates' => [],
         ];
 
@@ -205,10 +152,76 @@ class ManageServiceRequestNotificationAutomationSettings extends SettingsPage
 
         foreach ($templates as $template) {
             $state['templates'][$template->type->value][$template->role->value] = [
-                'ai_instructions' => $template->ai_instructions ?? '',
+                'subject' => $template->subject,
+                'body' => $template->body,
             ];
         }
 
         $this->form->fill($state);
+    }
+
+    /**
+     * @return array<int, RichEditor|Textarea>
+     */
+    protected function getTemplateFormSchema(ServiceRequestEmailTemplateType $type, ServiceRequestTypeEmailTemplateRole $role): array
+    {
+        $mergeTags = ServiceRequestTypeEmailTemplate::getMergeTags();
+
+        if ($type !== ServiceRequestEmailTemplateType::Update) {
+            unset($mergeTags['recent update']);
+        }
+
+        $hasAnyContent = function (Get $get): bool {
+            return $this->richEditorHasContent($get('subject'))
+                || $this->richEditorHasContent($get('body'));
+        };
+
+        return [
+            RichEditor::make('subject')
+                ->label('Example Subject')
+                ->placeholder('Enter the example email subject here...')
+                ->extraInputAttributes(['style' => 'min-height: 2rem; overflow-y:none;'])
+                ->toolbarButtons([])
+                ->mergeTags($mergeTags)
+                ->helperText('The example subject template the AI will customize for each service request type.')
+                ->required(fn (Get $get): bool => $hasAnyContent($get))
+                ->live(onBlur: true)
+                ->json(),
+            RichEditor::make('body')
+                ->label('Example Body')
+                ->placeholder('Enter the example email body here...')
+                ->extraInputAttributes(['style' => 'min-height: 12rem;'])
+                ->toolbarButtons([
+                    ['bold', 'italic', 'link'],
+                    [ToolbarButtonGroup::make('Heading', ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])->textualButtons(), 'bulletList', 'orderedList', 'horizontalRule'],
+                    ['textColor', 'small'],
+                    ['mergeTags', 'customBlocks'],
+                    ['clearFormatting'],
+                    ['undo', 'redo'],
+                ])
+                ->mergeTags($mergeTags)
+                ->customBlocks([
+                    ServiceRequestTypeEmailTemplateButtonBlock::class,
+                    SurveyResponseEmailTemplateTakeSurveyButtonBlock::class,
+                ])
+                ->columnSpanFull()
+                ->required(fn (Get $get): bool => $hasAnyContent($get))
+                ->live(onBlur: true)
+                ->json(),
+        ];
+    }
+
+    protected function richEditorHasContent(mixed $value): bool
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        $isEmpty = (($value['type'] ?? null) === 'doc')
+            && (count($value['content'] ?? []) === 1)
+            && (($value['content'][0]['type'] ?? null) === 'paragraph')
+            && blank($value['content'][0]['content'] ?? []);
+
+        return ! $isEmpty;
     }
 }

--- a/app/Filament/Clusters/GlobalServiceManagementCluster/Pages/ManageServiceRequestBaseTemplatesSettings.php
+++ b/app/Filament/Clusters/GlobalServiceManagementCluster/Pages/ManageServiceRequestBaseTemplatesSettings.php
@@ -59,7 +59,7 @@ use Filament\Schemas\Schema;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 
-class ManageServiceRequestBaseTemplates extends SettingsPage
+class ManageServiceRequestBaseTemplatesSettings extends SettingsPage
 {
     protected static string $settings = ServiceRequestNotificationAutomationSettings::class;
 

--- a/app/Filament/Clusters/GlobalServiceManagementCluster/Pages/ManageServiceRequestBaseTemplatesSettings.php
+++ b/app/Filament/Clusters/GlobalServiceManagementCluster/Pages/ManageServiceRequestBaseTemplatesSettings.php
@@ -46,11 +46,11 @@ use AidingApp\ServiceManagement\Settings\ServiceRequestNotificationAutomationSet
 use App\Enums\Feature;
 use App\Filament\Clusters\GlobalServiceManagementCluster;
 use App\Models\User;
+use App\Support\RichContentDocument;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\RichEditor\ToolbarButtonGroup;
-use Filament\Forms\Components\Textarea;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;
@@ -66,6 +66,8 @@ class ManageServiceRequestBaseTemplatesSettings extends SettingsPage
     protected static ?string $cluster = GlobalServiceManagementCluster::class;
 
     protected static ?string $title = 'Base Templates';
+
+    protected ?bool $hasUnsavedDataChangesAlert = false;
 
     public static function canAccess(): bool
     {
@@ -113,16 +115,27 @@ class ManageServiceRequestBaseTemplatesSettings extends SettingsPage
 
             foreach ($templates as $typeValue => $roles) {
                 foreach ($roles as $roleValue => $templateData) {
-                    ServiceRequestNotificationAutomationEmailTemplate::updateOrCreate(
-                        [
-                            'type' => $typeValue,
-                            'role' => $roleValue,
-                        ],
-                        [
-                            'subject' => $templateData['subject'] ?? null,
-                            'body' => $templateData['body'] ?? null,
-                        ],
-                    );
+                    $template = ServiceRequestNotificationAutomationEmailTemplate::firstOrNew([
+                        'type' => $typeValue,
+                        'role' => $roleValue,
+                    ]);
+
+                    $template->subject = RichContentDocument::hasContent($templateData['subject'] ?? null)
+                        ? $templateData['subject']
+                        : null;
+                    $template->body = RichContentDocument::hasContent($templateData['body'] ?? null)
+                        ? $templateData['body']
+                        : null;
+
+                    if (blank($template->subject) && blank($template->body) && blank($template->ai_instructions)) {
+                        if ($template->exists) {
+                            $template->delete();
+                        }
+
+                        continue;
+                    }
+
+                    $template->save();
                 }
             }
         });
@@ -161,7 +174,7 @@ class ManageServiceRequestBaseTemplatesSettings extends SettingsPage
     }
 
     /**
-     * @return array<int, RichEditor|Textarea>
+     * @return array<int, RichEditor>
      */
     protected function getTemplateFormSchema(ServiceRequestEmailTemplateType $type, ServiceRequestTypeEmailTemplateRole $role): array
     {
@@ -172,8 +185,8 @@ class ManageServiceRequestBaseTemplatesSettings extends SettingsPage
         }
 
         $hasAnyContent = function (Get $get): bool {
-            return $this->richEditorHasContent($get('subject'))
-                || $this->richEditorHasContent($get('body'));
+            return RichContentDocument::hasContent($get('subject'))
+                || RichContentDocument::hasContent($get('body'));
         };
 
         return [
@@ -209,19 +222,5 @@ class ManageServiceRequestBaseTemplatesSettings extends SettingsPage
                 ->live(onBlur: true)
                 ->json(),
         ];
-    }
-
-    protected function richEditorHasContent(mixed $value): bool
-    {
-        if (! is_array($value)) {
-            return false;
-        }
-
-        $isEmpty = (($value['type'] ?? null) === 'doc')
-            && (count($value['content'] ?? []) === 1)
-            && (($value['content'][0]['type'] ?? null) === 'paragraph')
-            && blank($value['content'][0]['content'] ?? []);
-
-        return ! $isEmpty;
     }
 }

--- a/app/Filament/Clusters/ProductIntegrations.php
+++ b/app/Filament/Clusters/ProductIntegrations.php
@@ -44,5 +44,5 @@ class ProductIntegrations extends Cluster
 {
     protected static string | UnitEnum | null $navigationGroup = NavigationGroup::GlobalAdmin;
 
-    protected static ?int $navigationSort = 50;
+    protected static ?int $navigationSort = 60;
 }

--- a/app/Filament/Pages/ManageLicenseSettings.php
+++ b/app/Filament/Pages/ManageLicenseSettings.php
@@ -52,7 +52,7 @@ class ManageLicenseSettings extends SettingsPage
 {
     protected static ?string $navigationLabel = 'Subscription';
 
-    protected static ?int $navigationSort = 10;
+    protected static ?int $navigationSort = 20;
 
     protected static string $settings = LicenseSettings::class;
 

--- a/app/Filament/Pages/ProductHealth.php
+++ b/app/Filament/Pages/ProductHealth.php
@@ -68,7 +68,7 @@ class ProductHealth extends HealthCheckResults
 
     public static function getNavigationSort(): ?int
     {
-        return 60;
+        return 70;
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Support/RichContentDocument.php
+++ b/app/Support/RichContentDocument.php
@@ -34,37 +34,51 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Webhook\Filament\Resources\InboundWebhooks;
+namespace App\Support;
 
-use AidingApp\Webhook\Filament\Resources\InboundWebhooks\Pages\ListInboundWebhooks;
-use AidingApp\Webhook\Filament\Resources\InboundWebhooks\Pages\ViewInboundWebhook;
-use AidingApp\Webhook\Models\InboundWebhook;
-use App\Enums\NavigationGroup;
-use App\Models\User;
-use Filament\Resources\Resource;
-use UnitEnum;
-
-class InboundWebhookResource extends Resource
+class RichContentDocument
 {
-    protected static ?string $model = InboundWebhook::class;
+    /**
+     * @var array<int, string>
+     */
+    protected const NODES_WITHOUT_INHERENT_CONTENT = ['paragraph', 'text', 'hardBreak'];
 
-    protected static ?int $navigationSort = 50;
-
-    protected static string | UnitEnum | null $navigationGroup = NavigationGroup::GlobalAdmin;
-
-    public static function canAccess(): bool
+    public static function hasContent(mixed $document): bool
     {
-        /** @var User $user */
-        $user = auth()->user();
+        if (! is_array($document)) {
+            return false;
+        }
 
-        return $user->isSuperAdmin() && parent::canAccess();
+        return static::nodesHaveContent($document['content'] ?? []);
     }
 
-    public static function getPages(): array
+    /**
+     * @param  array<int, mixed>  $nodes
+     */
+    protected static function nodesHaveContent(array $nodes): bool
     {
-        return [
-            'index' => ListInboundWebhooks::route('/'),
-            'view' => ViewInboundWebhook::route('/{record}'),
-        ];
+        foreach ($nodes as $node) {
+            if (! is_array($node)) {
+                continue;
+            }
+
+            if (filled(trim((string) ($node['text'] ?? '')))) {
+                return true;
+            }
+
+            if (array_key_exists('content', $node)) {
+                if (static::nodesHaveContent($node['content'] ?? [])) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (! in_array($node['type'] ?? null, static::NODES_WITHOUT_INHERENT_CONTENT, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Tenant/Unit/Support/RichContentDocumentTest.php
+++ b/tests/Tenant/Unit/Support/RichContentDocumentTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use App\Support\RichContentDocument;
+
+dataset('empty rich content documents', [
+    'null' => [null],
+    'empty string' => [''],
+    'empty content array' => [['type' => 'doc', 'content' => []]],
+    'no content key' => [['type' => 'doc']],
+    'single empty paragraph' => [['type' => 'doc', 'content' => [['type' => 'paragraph']]]],
+    'single paragraph with empty content' => [['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => []]]]],
+    'multiple empty paragraphs' => [['type' => 'doc', 'content' => [['type' => 'paragraph'], ['type' => 'paragraph']]]],
+    'paragraph with alignment but no content' => [['type' => 'doc', 'content' => [['type' => 'paragraph', 'attrs' => ['textAlign' => 'start']]]]],
+    'whitespace only text' => [['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => '   ']]]]]],
+]);
+
+dataset('populated rich content documents', [
+    'text' => [['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Example Subject']]]]]],
+    'merge tag only' => [['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'mergeTag', 'attrs' => ['id' => 'title']]]]]]],
+    'custom block only' => [['type' => 'doc', 'content' => [['type' => 'customBlock', 'attrs' => ['id' => 'service_request_type_email_template_button']]]]],
+    'image only' => [['type' => 'doc', 'content' => [['type' => 'image', 'attrs' => ['src' => 'https://example.com/logo.png']]]]],
+    'horizontal rule only' => [['type' => 'doc', 'content' => [['type' => 'horizontalRule']]]],
+    'text nested in a list' => [['type' => 'doc', 'content' => [['type' => 'bulletList', 'content' => [['type' => 'listItem', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Item']]]]]]]]]],
+    'text after an empty paragraph' => [['type' => 'doc', 'content' => [['type' => 'paragraph'], ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Body']]]]]],
+]);
+
+test('it treats an empty document as having no content', function (mixed $document) {
+    expect(RichContentDocument::hasContent($document))->toBeFalse();
+})->with('empty rich content documents');
+
+test('it treats a populated document as having content', function (mixed $document) {
+    expect(RichContentDocument::hasContent($document))->toBeTrue();
+})->with('populated rich content documents');


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1351

### Technical Description

> Relocate the base service request types templates to a dedicated page in the global administration experience

### Any deployment steps required?

> No

### Cleanup Tasks

> No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
