### PR TITLE
[AIDAPP-1345]: Update the widget display for Projects so that Project Access and Project Milestones are each on their own row

### DIFF
--- a/app-modules/project/resources/views/filament/resources/projects/view-project.blade.php
+++ b/app-modules/project/resources/views/filament/resources/projects/view-project.blade.php
@@ -51,17 +51,13 @@
         @livewire(ProjectStatsWidget::class, ['record' => $record])
     @endif
 
-    <div class="grid grid-cols-1 items-stretch gap-8 lg:grid-cols-2">
-        @if (ProjectAccessWidget::canView())
-            @livewire(ProjectAccessWidget::class, ['record' => $record])
-        @endif
+    @if (ProjectAccessWidget::canView())
+        @livewire(ProjectAccessWidget::class, ['record' => $record])
+    @endif
 
-        <div class="h-full">
-            @if (auth()->user()?->can('viewAny', [ProjectMilestone::class, $record]))
-                @livewire(ProjectMilestonesWidget::class, ['record' => $record])
-            @endif
-        </div>
-    </div>
+    @if (auth()->user()?->can('viewAny', [ProjectMilestone::class, $record]))
+        @livewire(ProjectMilestonesWidget::class, ['record' => $record])
+    @endif
 
     @if (ProjectWorkPipelineWidget::canView())
         @livewire(ProjectWorkPipelineWidget::class, ['record' => $record])


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1345

### Technical Description

- Update the widget display for Projects so that Project Access and Project Milestones are each on their own row

### Any deployment steps required?

No

### Cleanup Tasks

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
