### PR TITLE
[Chore]: Renovate cooldown and digest fixes

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -10,6 +10,7 @@
     "repositories": ["canyongbs/aidingapp"],
     "enabledManagers": ["custom.regex", "docker-compose"],
     "reviewers": ["orrison"],
+    "prCreation": "not-pending",
     "vulnerabilityAlerts": {
         "enabled": true
     },
@@ -91,6 +92,18 @@
             "matchDatasources": ["github-releases", "node-version", "npm"],
             "isVulnerabilityAlert": true,
             "minimumReleaseAge": "0 days"
+        },
+        {
+            "description": "Group Docker digest updates into a single PR",
+            "matchDatasources": ["docker"],
+            "matchUpdateTypes": ["digest"],
+            "groupName": "docker-digests"
+        },
+        {
+            "description": "GHCR provides no release timestamps; disable age gating so images aren't held indefinitely",
+            "matchDatasources": ["docker"],
+            "matchPackageNames": ["ghcr.io/**"],
+            "minimumReleaseAge": null
         },
         {
             "description": "Constrain PostgreSQL to 16.x",

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -9,7 +9,7 @@
     "platform": "github",
     "repositories": ["canyongbs/aidingapp"],
     "enabledManagers": ["custom.regex", "docker-compose"],
-    "reviewers": ["orrison"],
+    "reviewersFromCodeOwners": true,
     "prCreation": "not-pending",
     "vulnerabilityAlerts": {
         "enabled": true


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Fixes our renovate config so that it:
- Requests review from code owners instead of just me
- Will not open a PR for an update till it is within the defined cooldown window (to prevent supply chain attacks)
- Will now batch docker digest updates together if possible

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
