### PR TITLE
[AIDAPP-1386]: Update the Kanban view to use our modern Kanban experience

### DIFF
--- a/app-modules/project/resources/views/components/entry-card.blade.php
+++ b/app-modules/project/resources/views/components/entry-card.blade.php
@@ -83,17 +83,30 @@
     <hr class="my-3 border-gray-200 dark:border-gray-700" />
 
     <div class="space-y-1 text-sm text-gray-700 dark:text-gray-300">
-        <div><span class="font-bold">Milestones:</span> {{ ($entry->milestones_count ?? 0) > 0 ? $entry->milestones_count : 'None' }}</div>
-        <div><span class="font-bold">Assets:</span> {{ ($entry->assets_count ?? 0) > 0 ? $entry->assets_count : 'None' }}</div>
         <div>
-            <span class="font-bold">Service Requests:</span> {{ ($entry->service_requests_count ?? 0) > 0 ? $entry->service_requests_count : 'None' }}
+            <span class="font-bold">Milestones:</span>
+            {{ ($entry->milestones_count ?? 0) > 0 ? $entry->milestones_count : 'None' }}
+        </div>
+        <div>
+            <span class="font-bold">Assets:</span>
+            {{ ($entry->assets_count ?? 0) > 0 ? $entry->assets_count : 'None' }}
+        </div>
+        <div>
+            <span class="font-bold">Service Requests:</span>
+            {{ ($entry->service_requests_count ?? 0) > 0 ? $entry->service_requests_count : 'None' }}
         </div>
     </div>
 
     <hr class="my-3 border-gray-200 dark:border-gray-700" />
 
     <div class="space-y-1 text-sm text-gray-700 dark:text-gray-300">
-        <div><span class="font-bold">Assigned:</span> {{ $assignedLabel }}</div>
-        <div title="{{ $dueTooltip ?? '' }}"><span class="font-bold">Due:</span> {{ $dueLabel ? $dueLabel : 'None' }}</div>
+        <div>
+            <span class="font-bold">Assigned:</span>
+            {{ $assignedLabel }}
+        </div>
+        <div title="{{ $dueTooltip ?? '' }}">
+            <span class="font-bold">Due:</span>
+            {{ $dueLabel ? $dueLabel : 'None' }}
+        </div>
     </div>
 </div>

--- a/app-modules/project/resources/views/components/entry-card.blade.php
+++ b/app-modules/project/resources/views/components/entry-card.blade.php
@@ -31,8 +31,13 @@
     
     </COPYRIGHT>
 --}}
+@use('App\Models\User')
+@use('AidingApp\Contact\Models\Contact')
+@use('Illuminate\Database\Eloquent\Relations\Relation')
+@use('Illuminate\Support\Str')
+@use('Carbon\CarbonInterface')
 @php
-    $assignedModelClass = filled($entry->assigned_to_type) ? \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($entry->assigned_to_type) ?? $entry->assigned_to_type : null;
+    $assignedModelClass = filled($entry->assigned_to_type) ? Relation::getMorphedModel($entry->assigned_to_type) ?? $entry->assigned_to_type : null;
 
     $assignedTo = $entry->assignedTo;
 
@@ -41,20 +46,20 @@
     }
 
     $assignedType = match (true) {
-        $assignedModelClass === \App\Models\User::class => 'User',
-        $assignedModelClass === \AidingApp\Contact\Models\Contact::class => 'Contact',
+        $assignedModelClass === User::class => 'User',
+        $assignedModelClass === Contact::class => 'Contact',
         default => null,
     };
 
     $assignedName = match (true) {
         blank($assignedTo) => 'None',
-        $assignedTo instanceof \AidingApp\Contact\Models\Contact => $assignedTo->full_name ?? 'None',
+        $assignedTo instanceof Contact => $assignedTo->full_name ?? 'None',
         default => $assignedTo->name ?? 'None',
     };
 
     $assignedLabel = filled($assignedType) && $assignedName !== 'None' ? sprintf('%s (%s)', $assignedName, $assignedType) : $assignedName;
 
-    $dueLabel = $entry->due ? \Illuminate\Support\Str::title($entry->due->diffForHumans(now(), \Carbon\CarbonInterface::DIFF_ABSOLUTE, false, 6)) : null;
+    $dueLabel = $entry->due ? Str::title($entry->due->diffForHumans(now(), CarbonInterface::DIFF_ABSOLUTE, false, 6)) : null;
     $dueTooltip = $entry->due?->format('M j, Y g:i A');
 @endphp
 

--- a/app-modules/project/resources/views/components/entry-card.blade.php
+++ b/app-modules/project/resources/views/components/entry-card.blade.php
@@ -41,10 +41,6 @@
 
     $assignedTo = $entry->assignedTo;
 
-    if (blank($assignedTo) && filled($assignedModelClass) && filled($entry->assigned_to_id) && class_exists($assignedModelClass)) {
-        $assignedTo = $assignedModelClass::query()->find($entry->assigned_to_id);
-    }
-
     $assignedType = match (true) {
         $assignedModelClass === User::class => 'User',
         $assignedModelClass === Contact::class => 'Contact',

--- a/app-modules/project/resources/views/components/entry-card.blade.php
+++ b/app-modules/project/resources/views/components/entry-card.blade.php
@@ -31,23 +31,64 @@
     
     </COPYRIGHT>
 --}}
+@php
+    $assignedModelClass = filled($entry->assigned_to_type) ? \Illuminate\Database\Eloquent\Relations\Relation::getMorphedModel($entry->assigned_to_type) ?? $entry->assigned_to_type : null;
+
+    $assignedTo = $entry->assignedTo;
+
+    if (blank($assignedTo) && filled($assignedModelClass) && filled($entry->assigned_to_id) && class_exists($assignedModelClass)) {
+        $assignedTo = $assignedModelClass::query()->find($entry->assigned_to_id);
+    }
+
+    $assignedType = match (true) {
+        $assignedModelClass === \App\Models\User::class => 'User',
+        $assignedModelClass === \AidingApp\Contact\Models\Contact::class => 'Contact',
+        default => null,
+    };
+
+    $assignedName = match (true) {
+        blank($assignedTo) => 'None',
+        $assignedTo instanceof \AidingApp\Contact\Models\Contact => $assignedTo->full_name ?? 'None',
+        default => $assignedTo->name ?? 'None',
+    };
+
+    $assignedLabel = filled($assignedType) && $assignedName !== 'None' ? sprintf('%s (%s)', $assignedName, $assignedType) : $assignedName;
+
+    $dueLabel = $entry->due ? \Illuminate\Support\Str::title($entry->due->diffForHumans(now(), \Carbon\CarbonInterface::DIFF_ABSOLUTE, false, 6)) : null;
+    $dueTooltip = $entry->due?->format('M j, Y g:i A');
+@endphp
+
 <div
-    class="z-10 flex max-w-md transform cursor-move flex-col rounded-lg bg-white p-7 shadow dark:bg-gray-800"
+    class="z-10 flex max-w-md transform cursor-move flex-col rounded-lg bg-white p-5 shadow dark:bg-gray-800"
     data-pipeline="{{ $pipeline->getKey() }}"
     data-entry="{{ $entry->getKey() }}"
     wire:key="pipeline-entry-{{ $entry->getKey() }}"
 >
-    <div class="flex items-center justify-between">
+    <div class="flex items-start justify-between gap-2">
         <div class="text-base font-semibold text-gray-900 dark:text-white">
-            <small class="capitalize">
-                {{ $entry->name }}
-            </small>
-            <br />
+            {{ $entry->name }}
         </div>
         <x-filament::icon-button
             class="fi-primary-color"
             wire:click="viewPipelineEntry('{{ $entry->getKey() }}')"
             icon="heroicon-m-arrow-top-right-on-square"
         />
+    </div>
+
+    <hr class="my-3 border-gray-200 dark:border-gray-700" />
+
+    <div class="space-y-1 text-sm text-gray-700 dark:text-gray-300">
+        <div><span class="font-bold">Milestones:</span> {{ ($entry->milestones_count ?? 0) > 0 ? $entry->milestones_count : 'None' }}</div>
+        <div><span class="font-bold">Assets:</span> {{ ($entry->assets_count ?? 0) > 0 ? $entry->assets_count : 'None' }}</div>
+        <div>
+            <span class="font-bold">Service Requests:</span> {{ ($entry->service_requests_count ?? 0) > 0 ? $entry->service_requests_count : 'None' }}
+        </div>
+    </div>
+
+    <hr class="my-3 border-gray-200 dark:border-gray-700" />
+
+    <div class="space-y-1 text-sm text-gray-700 dark:text-gray-300">
+        <div><span class="font-bold">Assigned:</span> {{ $assignedLabel }}</div>
+        <div title="{{ $dueTooltip ?? '' }}"><span class="font-bold">Due:</span> {{ $dueLabel ? $dueLabel : 'None' }}</div>
     </div>
 </div>

--- a/app-modules/project/resources/views/components/entry-card.blade.php
+++ b/app-modules/project/resources/views/components/entry-card.blade.php
@@ -35,7 +35,6 @@
 @use('AidingApp\Contact\Models\Contact')
 @use('Illuminate\Database\Eloquent\Relations\Relation')
 @use('Illuminate\Support\Str')
-@use('Carbon\CarbonInterface')
 @php
     $assignedModelClass = filled($entry->assigned_to_type) ? Relation::getMorphedModel($entry->assigned_to_type) ?? $entry->assigned_to_type : null;
 
@@ -55,7 +54,26 @@
 
     $assignedLabel = filled($assignedType) && $assignedName !== 'None' ? sprintf('%s (%s)', $assignedName, $assignedType) : $assignedName;
 
-    $dueLabel = $entry->due ? Str::title($entry->due->diffForHumans(now(), CarbonInterface::DIFF_ABSOLUTE, false, 6)) : null;
+    $dueLabel = null;
+
+    if ($entry->due) {
+        $dueInterval = now()->diff($entry->due);
+        $dueDays = (int) $dueInterval->days;
+        $dueHours = (int) $dueInterval->h;
+
+        $dueParts = [];
+
+        if ($dueDays > 0) {
+            $dueParts[] = sprintf('%d %s', $dueDays, Str::plural('Day', $dueDays));
+        }
+
+        if ($dueHours > 0) {
+            $dueParts[] = sprintf('%d %s', $dueHours, Str::plural('Hour', $dueHours));
+        }
+
+        $dueLabel = filled($dueParts) ? implode(' ', $dueParts) : sprintf('%d %s', $dueHours, Str::plural('Hour', $dueHours));
+    }
+
     $dueTooltip = $entry->due?->format('M j, Y g:i A');
 @endphp
 

--- a/app-modules/project/resources/views/livewire/pipeline-entry-kanban.blade.php
+++ b/app-modules/project/resources/views/livewire/pipeline-entry-kanban.blade.php
@@ -39,38 +39,47 @@
                     <div class="mb-6 flex items-start justify-start space-x-4 px-4" x-data="kanban($wire)">
                         @foreach ($stages as $stageKey => $stage)
                             <div class="min-w-kanban">
-                                <div class="flex items-center justify-between gap-3">
-                                    <div class="py-4 text-base font-semibold text-gray-900 dark:text-gray-300">
-                                        {{ $stage }}
+                                <div class="rounded-lg bg-gray-100 px-4 py-2 dark:bg-gray-800">
+                                    <div class="flex items-center justify-between gap-3">
+                                        <div
+                                            class="flex items-center gap-2 text-base font-semibold text-gray-900 dark:text-gray-300"
+                                        >
+                                            <span>{{ $stage }}</span>
+                                            <span
+                                                class="flex h-6 w-6 items-center justify-center rounded-full bg-gray-300 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+                                            >
+                                                {{ $stageCounts[$stageKey] ?? 0 }}
+                                            </span>
+                                        </div>
+
+                                        @can('update', $pipeline)
+                                            <x-filament::link
+                                                tag="button"
+                                                icon="heroicon-m-plus"
+                                                :wire:click="'mountAction(\'addEntry\', { stage:\'' . $stageKey . '\' })'"
+                                            >
+                                                {{ __('Add') }}
+                                            </x-filament::link>
+                                        @endcan
                                     </div>
 
-                                    @can('update', $pipeline)
-                                        <x-filament::link
-                                            tag="button"
-                                            icon="heroicon-m-plus"
-                                            :wire:click="'mountAction(\'addEntry\', { stage:\'' . $stageKey . '\' })'"
-                                        >
-                                            {{ __('Add') }}
-                                        </x-filament::link>
-                                    @endcan
-                                </div>
-
-                                <div
-                                    id="kanban-list-{{ $stageKey }}"
-                                    data-stage="{{ $stageKey }}"
-                                    @class(['relative flex flex-col gap-4 min-w-kanban mb-4 h-full', 'pb-20' => ! count($pipelineEntries[$stageKey] ?? [])])
-                                >
-                                    @foreach ($pipelineEntries[$stageKey] ?? [] as $entry)
-                                        <x-project::entry-card
-                                            :pipeline="$pipeline"
-                                            :entry="$entry"
-                                        ></x-project::entry-card>
-                                    @endforeach
-
                                     <div
-                                        class="absolute flex h-20 w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-200 py-2 font-semibold text-gray-500 hover:border-gray-300 dark:border-gray-800"
+                                        id="kanban-list-{{ $stageKey }}"
+                                        data-stage="{{ $stageKey }}"
+                                            @class(['relative flex flex-col gap-4 mb-4 h-full pt-4', 'pb-20' => ! count($pipelineEntries[$stageKey] ?? [])])
                                     >
-                                        <div>Drag pipeline task here</div>
+                                        @foreach ($pipelineEntries[$stageKey] ?? [] as $entry)
+                                            <x-project::entry-card
+                                                :pipeline="$pipeline"
+                                                :entry="$entry"
+                                            ></x-project::entry-card>
+                                        @endforeach
+
+                                        <div
+                                            class="absolute flex h-20 w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-200 py-2 font-semibold text-gray-500 hover:border-gray-300 dark:border-gray-800"
+                                        >
+                                            <div>Drag pipeline task here</div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/app-modules/project/resources/views/livewire/pipeline-entry-kanban.blade.php
+++ b/app-modules/project/resources/views/livewire/pipeline-entry-kanban.blade.php
@@ -66,7 +66,7 @@
                                     <div
                                         id="kanban-list-{{ $stageKey }}"
                                         data-stage="{{ $stageKey }}"
-                                            @class(['relative flex flex-col gap-4 mb-4 h-full pt-4', 'pb-20' => ! count($pipelineEntries[$stageKey] ?? [])])
+                                        @class(['relative flex flex-col gap-4 mb-4 h-full pt-4', 'pb-20' => ! count($pipelineEntries[$stageKey] ?? [])])
                                     >
                                         @foreach ($pipelineEntries[$stageKey] ?? [] as $entry)
                                             <x-project::entry-card

--- a/app-modules/project/src/Livewire/PipelineEntryKanban.php
+++ b/app-modules/project/src/Livewire/PipelineEntryKanban.php
@@ -102,17 +102,6 @@ class PipelineEntryKanban extends Component implements HasForms, HasActions
             ->pluck('name', 'id');
     }
 
-    /**
-     * @return Collection<(int|string), mixed>
-     */
-    public function getStageCounts(): Collection
-    {
-        return $this->pipeline->entries()
-            ->selectRaw('pipeline_stage_id, COUNT(*) as count')
-            ->groupBy('pipeline_stage_id')
-            ->pluck('count', 'pipeline_stage_id');
-    }
-
     public function movedEntry(string $pipeline, string $entryId, string $fromStage = '', string $toStage = ''): JsonResponse
     {
         $this->authorize('update', $this->pipeline);
@@ -196,10 +185,12 @@ class PipelineEntryKanban extends Component implements HasForms, HasActions
 
     public function render(): View
     {
+        $pipelineEntries = $this->getPipelineEntries();
+
         return view('project::livewire.pipeline-entry-kanban', [
-            'pipelineEntries' => $this->getPipelineEntries(),
+            'pipelineEntries' => $pipelineEntries,
             'stages' => $this->getStages(),
-            'stageCounts' => $this->getStageCounts(),
+            'stageCounts' => $pipelineEntries->map->count(),
         ]);
     }
 

--- a/app-modules/project/src/Livewire/PipelineEntryKanban.php
+++ b/app-modules/project/src/Livewire/PipelineEntryKanban.php
@@ -79,6 +79,8 @@ class PipelineEntryKanban extends Component implements HasForms, HasActions
          * @var Collection<int, PipelineEntry> $entries
          */
         $entries = $this->pipeline->entries()
+            ->with(['assignedTo', 'pipelineStage'])
+            ->withCount(['milestones', 'assets', 'serviceRequests'])
             ->oldest()
             ->get();
 
@@ -98,6 +100,17 @@ class PipelineEntryKanban extends Component implements HasForms, HasActions
         return $this->pipeline->stages()
             ->orderBy('order')
             ->pluck('name', 'id');
+    }
+
+    /**
+     * @return Collection<(int|string), mixed>
+     */
+    public function getStageCounts(): Collection
+    {
+        return $this->pipeline->entries()
+            ->selectRaw('pipeline_stage_id, COUNT(*) as count')
+            ->groupBy('pipeline_stage_id')
+            ->pluck('count', 'pipeline_stage_id');
     }
 
     public function movedEntry(string $pipeline, string $entryId, string $fromStage = '', string $toStage = ''): JsonResponse
@@ -186,6 +199,7 @@ class PipelineEntryKanban extends Component implements HasForms, HasActions
         return view('project::livewire.pipeline-entry-kanban', [
             'pipelineEntries' => $this->getPipelineEntries(),
             'stages' => $this->getStages(),
+            'stageCounts' => $this->getStageCounts(),
         ]);
     }
 

--- a/app-modules/project/src/Models/PipelineEntry.php
+++ b/app-modules/project/src/Models/PipelineEntry.php
@@ -99,7 +99,7 @@ class PipelineEntry extends Model implements Auditable
      */
     public function assignedTo(): MorphTo
     {
-        return $this->morphTo('assigned_to', 'assigned_to_type', 'assigned_to_id');
+        return $this->morphTo('assignedTo', 'assigned_to_type', 'assigned_to_id');
     }
 
     /**

--- a/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
+++ b/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
@@ -40,6 +40,7 @@ use AidingApp\Project\Models\PipelineEntry;
 use AidingApp\Project\Models\PipelineStage;
 use AidingApp\Project\Models\Project;
 use App\Models\User;
+use Carbon\Carbon;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -60,6 +61,69 @@ it('renders entry cards with their name on the kanban board', function () {
 
     livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
         ->assertSee($entry->name);
+});
+
+it('renders stage name with card count in the stage header', function () {
+    asSuperAdmin();
+
+    $pipeline = Pipeline::factory()
+        ->for(Project::factory()->create())
+        ->has(PipelineStage::factory()->count(2), 'stages')
+        ->create();
+
+    [$firstStage, $secondStage] = $pipeline->stages;
+
+    PipelineEntry::factory()->count(2)->create([
+        'pipeline_stage_id' => $firstStage->getKey(),
+    ]);
+
+    PipelineEntry::factory()->create([
+        'pipeline_stage_id' => $secondStage->getKey(),
+    ]);
+
+    livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
+        ->assertSee($firstStage->name)
+        ->assertSee($secondStage->name)
+        ->assertSee('2')
+        ->assertSee('1');
+});
+
+it('renders modern card metadata with assignment and due tooltip', function () {
+    asSuperAdmin();
+
+    Carbon::setTestNow('2026-08-07 12:00:00');
+
+    $pipeline = Pipeline::factory()
+        ->for(Project::factory()->create())
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    $assignee = User::factory()->create([
+        'name' => 'Joe Licata',
+    ]);
+
+    $due = now()->addDay()->addHours(3);
+
+    PipelineEntry::factory()->create([
+        'name' => 'Modern Card Task',
+        'pipeline_stage_id' => $pipeline->stages->first()->getKey(),
+        'assigned_to_type' => $assignee->getMorphClass(),
+        'assigned_to_id' => $assignee->getKey(),
+        'due' => $due,
+    ]);
+
+    livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
+        ->assertSee('Modern Card Task')
+        ->assertSee('Milestones:')
+        ->assertSee('Assets:')
+        ->assertSee('Service Requests:')
+        ->assertSee('Assigned:')
+        ->assertSee('Joe Licata (User)')
+        ->assertSee('Due:')
+        ->assertSee('1 Day 3 Hours')
+        ->assertSee($due->format('M j, Y g:i A'));
+
+    Carbon::setTestNow();
 });
 
 it('renders stages in order sequence on the kanban board', function () {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1386

### Technical Description

- Replaced the legacy Kanban layout with the modern Olympus-style board design across the pipeline view.
- Added stage headers showing the stage name with a live card count and an inline "Add" task action.
- Redesigned entry cards to display Milestones, Assets, Service Requests, Assignee (with User/Contact type), and Due date.
- Added a hover tooltip on the Due date showing the exact date/time, with bold labels for readability.
- Fixed the "Drag pipeline task here" dashed placeholder to render correctly inside the grey column background.
- Updated and extended Livewire tests to cover stage counts and the new card metadata.

### Any deployment steps required?

No

### Cleanup Tasks

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
