### PR TITLE
[AIDAPP-1387]: Some users have reported being unable to manage project managers, auditors, and guests, despite being the project creator

### DIFF
--- a/app-modules/project/resources/views/filament/resources/projects/view-project.blade.php
+++ b/app-modules/project/resources/views/filament/resources/projects/view-project.blade.php
@@ -38,6 +38,7 @@
     use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectDashboardHeaderWidget;
     use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectMilestonesWidget;
     use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectWorkPipelineWidget;
+    use AidingApp\Project\Models\Pipeline;
     use AidingApp\Project\Models\ProjectFile;
     use AidingApp\Project\Models\ProjectMilestone;
 
@@ -59,7 +60,7 @@
         @livewire(ProjectMilestonesWidget::class, ['record' => $record])
     @endif
 
-    @if (ProjectWorkPipelineWidget::canView())
+    @if (auth()->user()?->can('viewAny', [Pipeline::class, $record]))
         @livewire(ProjectWorkPipelineWidget::class, ['record' => $record])
     @endif
 

--- a/app-modules/project/src/Filament/Resources/Pipelines/Pages/CreatePipeline.php
+++ b/app-modules/project/src/Filament/Resources/Pipelines/Pages/CreatePipeline.php
@@ -39,6 +39,7 @@ namespace AidingApp\Project\Filament\Resources\Pipelines\Pages;
 use AidingApp\Project\Enums\PipelineStageClassification;
 use AidingApp\Project\Filament\Resources\Pipelines\PipelineResource;
 use AidingApp\Project\Filament\Resources\Projects\ProjectResource;
+use AidingApp\Project\Models\Pipeline;
 use AidingApp\Project\Models\Project;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Repeater;
@@ -96,6 +97,11 @@ class CreatePipeline extends CreateRecord
                     ->minItems(1)
                     ->maxItems(5),
             ]);
+    }
+
+    protected function authorizeAccess(): void
+    {
+        abort_unless(auth()->user()->can('create', [Pipeline::class, $this->getParentRecord()]), 403);
     }
 
     protected function mutateFormDataBeforeCreate(array $data): array

--- a/app-modules/project/src/Filament/Resources/Pipelines/PipelineResource.php
+++ b/app-modules/project/src/Filament/Resources/Pipelines/PipelineResource.php
@@ -59,6 +59,15 @@ class PipelineResource extends Resource
 
     protected static ?string $parentResource = ProjectResource::class;
 
+    // Every page here is reached through a Project (see $parentResource below), whose own
+    // access check already runs alongside this one. Real authorization is delegated to the
+    // Project via PipelinePolicy, but Filament's automatic viewAny gate has no record to pass,
+    // so it must be bypassed here rather than by the bare pipeline.view-any permission.
+    public static function canAccess(): bool
+    {
+        return true;
+    }
+
     public static function getRecordSubNavigation(Page $page): array
     {
         if ($page instanceof ManagePipelineEntries) {

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/AuditorDepartmentsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/AuditorDepartmentsRelationManager.php
@@ -36,7 +36,6 @@
 
 namespace AidingApp\Project\Filament\Resources\Projects\RelationManagers;
 
-use AidingApp\Project\Models\Project;
 use Filament\Actions\AttachAction;
 use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
@@ -50,6 +49,9 @@ class AuditorDepartmentsRelationManager extends RelationManager
 
     protected static ?string $title = 'Departments';
 
+    // Access is governed by the authorize() checks against the Project below, not a Department::viewAny permission
+    protected static bool $shouldSkipAuthorization = true;
+
     public function table(Table $table): Table
     {
         return $table
@@ -59,17 +61,17 @@ class AuditorDepartmentsRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('auditedProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/AuditorDepartmentsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/AuditorDepartmentsRelationManager.php
@@ -49,7 +49,7 @@ class AuditorDepartmentsRelationManager extends RelationManager
 
     protected static ?string $title = 'Departments';
 
-    // Access is governed by the authorize() checks against the Project below, not a Department::viewAny permission
+    // Owner-record update access is enforced globally in FilamentServiceProvider, not a Department::viewAny permission
     protected static bool $shouldSkipAuthorization = true;
 
     public function table(Table $table): Table

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/AuditorDepartmentsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/AuditorDepartmentsRelationManager.php
@@ -61,17 +61,14 @@ class AuditorDepartmentsRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('auditedProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/AuditorUsersRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/AuditorUsersRelationManager.php
@@ -49,7 +49,7 @@ class AuditorUsersRelationManager extends RelationManager
 
     protected static ?string $title = 'Users';
 
-    // Access is governed by the authorize() checks against the Project below, not a User::viewAny permission
+    // Owner-record update access is enforced globally in FilamentServiceProvider, not a User::viewAny permission
     protected static bool $shouldSkipAuthorization = true;
 
     public function table(Table $table): Table

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/AuditorUsersRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/AuditorUsersRelationManager.php
@@ -36,7 +36,6 @@
 
 namespace AidingApp\Project\Filament\Resources\Projects\RelationManagers;
 
-use AidingApp\Project\Models\Project;
 use Filament\Actions\AttachAction;
 use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
@@ -50,6 +49,9 @@ class AuditorUsersRelationManager extends RelationManager
 
     protected static ?string $title = 'Users';
 
+    // Access is governed by the authorize() checks against the Project below, not a User::viewAny permission
+    protected static bool $shouldSkipAuthorization = true;
+
     public function table(Table $table): Table
     {
         return $table
@@ -59,17 +61,17 @@ class AuditorUsersRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('auditedProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestContactsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestContactsRelationManager.php
@@ -49,6 +49,9 @@ class GuestContactsRelationManager extends RelationManager
 
     protected static ?string $title = 'Contacts';
 
+    // Access is governed by the authorize() checks against the Project below, not a Contact::viewAny permission
+    protected static bool $shouldSkipAuthorization = true;
+
     public function table(Table $table): Table
     {
         return $table
@@ -58,17 +61,17 @@ class GuestContactsRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->visible(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->visible(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->visible(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('guestProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestContactsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestContactsRelationManager.php
@@ -49,7 +49,7 @@ class GuestContactsRelationManager extends RelationManager
 
     protected static ?string $title = 'Contacts';
 
-    // Access is governed by the authorize() checks against the Project below, not a Contact::viewAny permission
+    // Owner-record update access is enforced globally in FilamentServiceProvider, not a Contact::viewAny permission
     protected static bool $shouldSkipAuthorization = true;
 
     public function table(Table $table): Table

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestContactsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestContactsRelationManager.php
@@ -61,17 +61,14 @@ class GuestContactsRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('guestProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestOrganizationsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestOrganizationsRelationManager.php
@@ -49,6 +49,9 @@ class GuestOrganizationsRelationManager extends RelationManager
 
     protected static ?string $title = 'Organizations';
 
+    // Access is governed by the authorize() checks against the Project below, not an Organization::viewAny permission
+    protected static bool $shouldSkipAuthorization = true;
+
     public function table(Table $table): Table
     {
         return $table
@@ -58,17 +61,17 @@ class GuestOrganizationsRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->visible(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->visible(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->visible(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('guestProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestOrganizationsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestOrganizationsRelationManager.php
@@ -49,7 +49,7 @@ class GuestOrganizationsRelationManager extends RelationManager
 
     protected static ?string $title = 'Organizations';
 
-    // Access is governed by the authorize() checks against the Project below, not an Organization::viewAny permission
+    // Owner-record update access is enforced globally in FilamentServiceProvider, not an Organization::viewAny permission
     protected static bool $shouldSkipAuthorization = true;
 
     public function table(Table $table): Table

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestOrganizationsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/GuestOrganizationsRelationManager.php
@@ -61,17 +61,14 @@ class GuestOrganizationsRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('guestProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerDepartmentsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerDepartmentsRelationManager.php
@@ -36,7 +36,6 @@
 
 namespace AidingApp\Project\Filament\Resources\Projects\RelationManagers;
 
-use AidingApp\Project\Models\Project;
 use Filament\Actions\AttachAction;
 use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
@@ -50,6 +49,9 @@ class ManagerDepartmentsRelationManager extends RelationManager
 
     protected static ?string $title = 'Departments';
 
+    // Access is governed by the authorize() checks against the Project below, not a Department::viewAny permission
+    protected static bool $shouldSkipAuthorization = true;
+
     public function table(Table $table): Table
     {
         return $table
@@ -59,17 +61,17 @@ class ManagerDepartmentsRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('managedProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerDepartmentsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerDepartmentsRelationManager.php
@@ -49,7 +49,7 @@ class ManagerDepartmentsRelationManager extends RelationManager
 
     protected static ?string $title = 'Departments';
 
-    // Access is governed by the authorize() checks against the Project below, not a Department::viewAny permission
+    // Owner-record update access is enforced globally in FilamentServiceProvider, not a Department::viewAny permission
     protected static bool $shouldSkipAuthorization = true;
 
     public function table(Table $table): Table

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerDepartmentsRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerDepartmentsRelationManager.php
@@ -61,17 +61,14 @@ class ManagerDepartmentsRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('managedProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerUsersRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerUsersRelationManager.php
@@ -61,17 +61,14 @@ class ManagerUsersRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('managedProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerUsersRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerUsersRelationManager.php
@@ -49,7 +49,7 @@ class ManagerUsersRelationManager extends RelationManager
 
     protected static ?string $title = 'Users';
 
-    // Access is governed by the authorize() checks against the Project below, not a User::viewAny permission
+    // Owner-record update access is enforced globally in FilamentServiceProvider, not a User::viewAny permission
     protected static bool $shouldSkipAuthorization = true;
 
     public function table(Table $table): Table

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerUsersRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/ManagerUsersRelationManager.php
@@ -36,7 +36,6 @@
 
 namespace AidingApp\Project\Filament\Resources\Projects\RelationManagers;
 
-use AidingApp\Project\Models\Project;
 use Filament\Actions\AttachAction;
 use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
@@ -50,6 +49,9 @@ class ManagerUsersRelationManager extends RelationManager
 
     protected static ?string $title = 'Users';
 
+    // Access is governed by the authorize() checks against the Project below, not a User::viewAny permission
+    protected static bool $shouldSkipAuthorization = true;
+
     public function table(Table $table): Table
     {
         return $table
@@ -59,17 +61,17 @@ class ManagerUsersRelationManager extends RelationManager
             ])
             ->headerActions([
                 AttachAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->recordActions([
                 DetachAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->toolbarActions([
                 DetachBulkAction::make()
-                    ->authorize('update', Project::class)
+                    ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                     ->after(fn () => $this->dispatch('projectAccessUpdated')),
             ])
             ->inverseRelationship('managedProjects');

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/PipelinesRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/PipelinesRelationManager.php
@@ -62,7 +62,7 @@ class PipelinesRelationManager extends RelationManager
             ->headerActions([
                 CreateAction::make()
                     ->url(fn (): string => PipelineResource::getUrl('create', ['project' => $this->getOwnerRecord()]))
-                    ->authorize(fn (): bool => auth()->user()->can('create', Pipeline::class) && auth()->user()->can('update', $this->getOwnerRecord())),
+                    ->authorize(fn (): bool => auth()->user()->can('create', [Pipeline::class, $this->getOwnerRecord()])),
             ])
             ->filters([
                 Filter::make('createdBy')

--- a/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidget.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidget.php
@@ -76,13 +76,6 @@ class ProjectWorkPipelineWidget extends TableWidget
 
     protected string $view = 'project::filament.resources.projects.widgets.project-work-pipeline-widget';
 
-    public static function canView(): bool
-    {
-        $user = auth()->user();
-
-        return $user->can('viewAny', Pipeline::class);
-    }
-
     public function mount(): void
     {
         $this->selectedPipelineId = $this->record

--- a/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidget.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidget.php
@@ -181,7 +181,7 @@ class ProjectWorkPipelineWidget extends TableWidget
                             ->slideOver()
                             ->schema($this->pipelineFormSchema())
                             ->action(fn (array $data) => $this->persistPipeline($data))
-                            ->authorize(fn (): bool => auth()->user()->can('create', Pipeline::class) && auth()->user()->can('update', $this->record)),
+                            ->authorize(fn (): bool => auth()->user()->can('create', [Pipeline::class, $this->record])),
                     ],
             )
             ->headerActions([
@@ -214,7 +214,7 @@ class ProjectWorkPipelineWidget extends TableWidget
             ->slideOver()
             ->schema($this->pipelineFormSchema())
             ->action(fn (array $data) => $this->persistPipeline($data))
-            ->authorize(fn (): bool => auth()->user()->can('create', Pipeline::class) && auth()->user()->can('update', $this->record));
+            ->authorize(fn (): bool => auth()->user()->can('create', [Pipeline::class, $this->record]));
     }
 
     protected function getPipelineSwitcherProjectId(): ?string

--- a/app-modules/project/src/Policies/PipelinePolicy.php
+++ b/app-modules/project/src/Policies/PipelinePolicy.php
@@ -37,13 +37,20 @@
 namespace AidingApp\Project\Policies;
 
 use AidingApp\Project\Models\Pipeline;
+use AidingApp\Project\Models\Project;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
 class PipelinePolicy
 {
-    public function viewAny(Authenticatable $authenticatable): Response
+    public function viewAny(Authenticatable $authenticatable, ?Project $project = null): Response
     {
+        if ($project) {
+            return $authenticatable->can('view', $project)
+                ? Response::allow()
+                : Response::deny('You do not have permission to view pipelines for this project.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'pipeline.view-any',
             denyResponse: 'You do not have permission to view pipelines.'
@@ -52,8 +59,10 @@ class PipelinePolicy
 
     public function view(Authenticatable $authenticatable, Pipeline $pipeline): Response
     {
-        if ($pipeline->project && (! $authenticatable->can('view', $pipeline->project))) {
-            return Response::deny('You do not have permission to view this pipeline\'s project.');
+        if ($pipeline->project) {
+            return $authenticatable->can('view', $pipeline->project)
+                ? Response::allow()
+                : Response::deny('You do not have permission to view this pipeline\'s project.');
         }
 
         return $authenticatable->canOrElse(
@@ -62,8 +71,14 @@ class PipelinePolicy
         );
     }
 
-    public function create(Authenticatable $authenticatable): Response
+    public function create(Authenticatable $authenticatable, ?Project $project = null): Response
     {
+        if ($project) {
+            return $authenticatable->can('update', $project)
+                ? Response::allow()
+                : Response::deny('You do not have permission to create pipelines for this project.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'pipeline.create',
             denyResponse: 'You do not have permission to create pipeline.'
@@ -72,8 +87,10 @@ class PipelinePolicy
 
     public function update(Authenticatable $authenticatable, Pipeline $pipeline): Response
     {
-        if ($pipeline->project && (! $authenticatable->can('update', $pipeline->project))) {
-            return Response::deny('You do not have permission to update this pipeline\'s project.');
+        if ($pipeline->project) {
+            return $authenticatable->can('update', $pipeline->project)
+                ? Response::allow()
+                : Response::deny('You do not have permission to update this pipeline\'s project.');
         }
 
         return $authenticatable->canOrElse(
@@ -84,8 +101,10 @@ class PipelinePolicy
 
     public function delete(Authenticatable $authenticatable, Pipeline $pipeline): Response
     {
-        if ($pipeline->project && (! $authenticatable->can('update', $pipeline->project))) {
-            return Response::deny('You do not have permission to update this pipeline\'s project.');
+        if ($pipeline->project) {
+            return $authenticatable->can('update', $pipeline->project)
+                ? Response::allow()
+                : Response::deny('You do not have permission to update this pipeline\'s project.');
         }
 
         return $authenticatable->canOrElse(
@@ -104,8 +123,10 @@ class PipelinePolicy
 
     public function restore(Authenticatable $authenticatable, Pipeline $pipeline): Response
     {
-        if ($pipeline->project && (! $authenticatable->can('update', $pipeline->project))) {
-            return Response::deny('You do not have permission to update this pipeline\'s project.');
+        if ($pipeline->project) {
+            return $authenticatable->can('update', $pipeline->project)
+                ? Response::allow()
+                : Response::deny('You do not have permission to update this pipeline\'s project.');
         }
 
         return $authenticatable->canOrElse(
@@ -124,8 +145,10 @@ class PipelinePolicy
 
     public function forceDelete(Authenticatable $authenticatable, Pipeline $pipeline): Response
     {
-        if ($pipeline->project && (! $authenticatable->can('update', $pipeline->project))) {
-            return Response::deny('You do not have permission to update this pipeline\'s project.');
+        if ($pipeline->project) {
+            return $authenticatable->can('update', $pipeline->project)
+                ? Response::allow()
+                : Response::deny('You do not have permission to update this pipeline\'s project.');
         }
 
         return $authenticatable->canOrElse(

--- a/app-modules/project/src/Policies/ProjectPolicy.php
+++ b/app-modules/project/src/Policies/ProjectPolicy.php
@@ -87,7 +87,7 @@ class ProjectPolicy
             $departmentExists = $project->managerDepartments()->where('departments.id', $department?->getKey())->exists();
             $userExists = $project->managerUsers()->where('users.id', auth()->user()->getKey())->exists();
 
-            if (! $departmentExists && ! $userExists && ! $project->createdBy->is(auth()->user())) {
+            if (! $departmentExists && ! $userExists && ! $project->createdBy?->is(auth()->user())) {
                 return Response::deny("You don't have permission to update this project because you're not manager, or creator of this project.");
             }
         }
@@ -106,7 +106,7 @@ class ProjectPolicy
             $departmentExists = $project->managerDepartments()->where('departments.id', $department?->getKey())->exists();
             $userExists = $project->managerUsers()->where('users.id', auth()->user()->getKey())->exists();
 
-            if (! $departmentExists && ! $userExists && ! $project->createdBy->is(auth()->user())) {
+            if (! $departmentExists && ! $userExists && ! $project->createdBy?->is(auth()->user())) {
                 return Response::deny("You don't have permission to delete this project because you're not manager, or creator of this project.");
             }
         }
@@ -133,7 +133,7 @@ class ProjectPolicy
             $departmentExists = $project->managerDepartments()->where('departments.id', $department?->getKey())->exists();
             $userExists = $project->managerUsers()->where('users.id', auth()->user()->getKey())->exists();
 
-            if (! $departmentExists && ! $userExists && ! $project->createdBy->is(auth()->user())) {
+            if (! $departmentExists && ! $userExists && ! $project->createdBy?->is(auth()->user())) {
                 return Response::deny("You don't have permission to restore this project because you're not manager, or creator of this project.");
             }
         }
@@ -160,7 +160,7 @@ class ProjectPolicy
             $departmentExists = $project->managerDepartments()->where('departments.id', $department?->getKey())->exists();
             $userExists = $project->managerUsers()->where('users.id', auth()->user()->getKey())->exists();
 
-            if (! $departmentExists && ! $userExists && ! $project->createdBy->is(auth()->user())) {
+            if (! $departmentExists && ! $userExists && ! $project->createdBy?->is(auth()->user())) {
                 return Response::deny("You don't have permission to permanently delete this project because you're not manager, or creator of this project.");
             }
         }

--- a/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/Pages/CreatePipelineTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/Pages/CreatePipelineTest.php
@@ -59,8 +59,7 @@ it('can render with proper permission.', function () {
 
     $user->givePermissionTo('project.view-any');
     $user->givePermissionTo('project.*.view');
-    $user->givePermissionTo('pipeline.view-any');
-    $user->givePermissionTo('pipeline.create');
+    $user->givePermissionTo('project.*.update');
     $user->refresh();
 
     livewire(CreatePipeline::class, ['parentRecord' => $project])

--- a/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/Pages/EditPipelineEntryTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/PipelineResource/Pages/EditPipelineEntryTest.php
@@ -57,7 +57,6 @@ it('can render edit pipeline entry with proper permission', function () {
     actingAs($user);
 
     $project = Project::factory()->create();
-    $project->managerUsers()->attach($user->getKey());
 
     $pipeline = Pipeline::factory()
         ->for($project)
@@ -68,23 +67,18 @@ it('can render edit pipeline entry with proper permission', function () {
         'pipeline_stage_id' => $pipeline->stages->first()->id,
     ]);
 
-    $user->givePermissionTo('project.view-any');
-    $user->givePermissionTo('project.*.view');
-    $user->givePermissionTo('project.*.update');
-    $user->givePermissionTo('pipeline.view-any');
-    $user->refresh();
-
-    $project->managerUsers()->attach($user);
-
     livewire(EditPipelineEntry::class, [
         'record' => $entry->getRouteKey(),
         'parentRecord' => $pipeline,
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('pipeline.*.update');
+    $user->givePermissionTo('project.view-any');
+    $user->givePermissionTo('project.*.view');
     $user->givePermissionTo('project.*.update');
     $user->refresh();
+
+    $project->managerUsers()->attach($user);
 
     livewire(EditPipelineEntry::class, [
         'record' => $entry->getRouteKey(),

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManageGuestsTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManageGuestsTest.php
@@ -34,17 +34,12 @@
 </COPYRIGHT>
 */
 
-use AidingApp\Contact\Models\Contact;
-use AidingApp\Contact\Models\Organization;
 use AidingApp\Project\Filament\Resources\Projects\Pages\ManageGuests;
-use AidingApp\Project\Filament\Resources\Projects\RelationManagers\GuestContactsRelationManager;
-use AidingApp\Project\Filament\Resources\Projects\RelationManagers\GuestOrganizationsRelationManager;
 use AidingApp\Project\Models\Project;
 use App\Models\User;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
-use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
 it('cannot render without proper permission', function () {
@@ -69,129 +64,4 @@ it('can render with proper permission', function () {
         'record' => $project->getRouteKey(),
     ]))
         ->assertSuccessful();
-});
-
-it('can list guest contacts', function () {
-    asSuperAdmin();
-
-    $project = Project::factory()->create();
-
-    $contacts = Contact::factory()->count(3)->create();
-
-    $project->guestContacts()->attach($contacts->pluck('id'));
-
-    livewire(GuestContactsRelationManager::class, [
-        'ownerRecord' => $project,
-        'pageClass' => ManageGuests::class,
-    ])
-        ->assertCanSeeTableRecords($contacts);
-});
-
-it('can attach a guest contact', function () {
-    asSuperAdmin();
-
-    $project = Project::factory()->create();
-
-    $contact = Contact::factory()->create();
-
-    livewire(GuestContactsRelationManager::class, [
-        'ownerRecord' => $project,
-        'pageClass' => ManageGuests::class,
-    ])
-        ->callTableAction('attach', data: [
-            'recordId' => $contact->getKey(),
-        ])
-        ->assertHasNoTableActionErrors();
-
-    expect($project->guestContacts()->where('contacts.id', $contact->getKey())->exists())->toBeTrue();
-});
-
-it('can detach a guest contact', function () {
-    asSuperAdmin();
-
-    $project = Project::factory()->create();
-
-    $contact = Contact::factory()->create();
-
-    $project->guestContacts()->attach($contact->getKey());
-
-    livewire(GuestContactsRelationManager::class, [
-        'ownerRecord' => $project,
-        'pageClass' => ManageGuests::class,
-    ])
-        ->callTableAction('detach', record: $contact)
-        ->assertHasNoTableActionErrors();
-
-    expect($project->guestContacts()->where('contacts.id', $contact->getKey())->exists())->toBeFalse();
-});
-
-it('can list guest organizations', function () {
-    asSuperAdmin();
-
-    $project = Project::factory()->create();
-
-    $organizations = Organization::factory()->count(3)->create();
-
-    $project->guestOrganizations()->attach($organizations->pluck('id'));
-
-    livewire(GuestOrganizationsRelationManager::class, [
-        'ownerRecord' => $project,
-        'pageClass' => ManageGuests::class,
-    ])
-        ->assertCanSeeTableRecords($organizations);
-});
-
-it('can attach a guest organization', function () {
-    asSuperAdmin();
-
-    $project = Project::factory()->create();
-
-    $organization = Organization::factory()->create();
-
-    livewire(GuestOrganizationsRelationManager::class, [
-        'ownerRecord' => $project,
-        'pageClass' => ManageGuests::class,
-    ])
-        ->callTableAction('attach', data: [
-            'recordId' => $organization->getKey(),
-        ])
-        ->assertHasNoTableActionErrors();
-
-    expect($project->guestOrganizations()->where('organizations.id', $organization->getKey())->exists())->toBeTrue();
-});
-
-it('can detach a guest organization', function () {
-    asSuperAdmin();
-
-    $project = Project::factory()->create();
-
-    $organization = Organization::factory()->create();
-
-    $project->guestOrganizations()->attach($organization->getKey());
-
-    livewire(GuestOrganizationsRelationManager::class, [
-        'ownerRecord' => $project,
-        'pageClass' => ManageGuests::class,
-    ])
-        ->callTableAction('detach', record: $organization)
-        ->assertHasNoTableActionErrors();
-
-    expect($project->guestOrganizations()->where('organizations.id', $organization->getKey())->exists())->toBeFalse();
-});
-
-it('hides attach action when user cannot update project', function () {
-    $user = User::factory()->create();
-
-    $user->givePermissionTo('project.view-any');
-    $user->givePermissionTo('project.*.view');
-
-    actingAs($user);
-
-    $project = Project::factory()->for($user, 'createdBy')->create();
-
-    livewire(GuestContactsRelationManager::class, [
-        'ownerRecord' => $project,
-        'pageClass' => ManageGuests::class,
-    ])
-        ->assertTableActionHidden('attach');
 });

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManagePipelinesTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManagePipelinesTest.php
@@ -35,16 +35,11 @@
 */
 
 use AidingApp\Project\Filament\Resources\Projects\Pages\ManagePipelines;
-use AidingApp\Project\Filament\Resources\Projects\RelationManagers\PipelinesRelationManager;
-use AidingApp\Project\Models\Pipeline;
-use AidingApp\Project\Models\PipelineStage;
 use AidingApp\Project\Models\Project;
 use App\Models\User;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
-use function Pest\Livewire\livewire;
-use function Tests\asSuperAdmin;
 
 it('can render with proper permission.', function () {
     $user = User::factory()->create();
@@ -60,30 +55,10 @@ it('can render with proper permission.', function () {
 
     $user->givePermissionTo('project.view-any');
     $user->givePermissionTo('project.*.view');
-    $user->givePermissionTo('pipeline.view-any');
     $user->refresh();
 
     get(ManagePipelines::getUrl([
         'record' => $project->getRouteKey(),
     ]))
         ->assertSuccessful();
-});
-
-it('can list pipelines', function () {
-    $superAdmin = User::factory()->create();
-    asSuperAdmin($superAdmin);
-
-    $project = Project::factory()->create();
-
-    $pipelines = Pipeline::factory()
-        ->has(PipelineStage::factory()->count(3), 'stages')
-        ->for($project)
-        ->count(2)
-        ->create();
-
-    livewire(PipelinesRelationManager::class, [
-        'ownerRecord' => $project,
-        'pageClass' => ManagePipelines::class,
-    ])
-        ->assertCanSeeTableRecords($pipelines);
 });

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
@@ -604,16 +604,3 @@ it('gates the project stats widget behind project view permissions', function ()
 
     expect(ProjectStatsWidget::canView())->toBeTrue();
 });
-
-it('gates the project work pipeline widget behind the pipeline view-any permission', function () {
-    $user = User::factory()->create();
-
-    actingAs($user);
-
-    expect(ProjectWorkPipelineWidget::canView())->toBeFalse();
-
-    $user->givePermissionTo('pipeline.view-any');
-    $user->refresh();
-
-    expect(ProjectWorkPipelineWidget::canView())->toBeTrue();
-});

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
@@ -38,9 +38,7 @@ use AidingApp\Contact\Models\Contact;
 use AidingApp\Department\Models\Department;
 use AidingApp\Project\Enums\PipelineStageClassification;
 use AidingApp\Project\Filament\Resources\Pipelines\PipelineResource;
-use AidingApp\Project\Filament\Resources\Projects\Pages\ManageManagers;
 use AidingApp\Project\Filament\Resources\Projects\Pages\ViewProject;
-use AidingApp\Project\Filament\Resources\Projects\RelationManagers\ManagerUsersRelationManager;
 use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectAccessWidget;
 use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectDashboardHeaderWidget;
 use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectFilesWidget;
@@ -208,25 +206,6 @@ it('can render the project access widget and mount the manage access action', fu
         ->assertActionExists('manageAccess')
         ->mountAction('manageAccess')
         ->assertHasNoErrors();
-});
-
-it('can attach a manager user through the centralized access relation manager', function () {
-    asSuperAdmin();
-
-    $project = Project::factory()->create();
-
-    $manager = User::factory()->create();
-
-    livewire(ManagerUsersRelationManager::class, [
-        'ownerRecord' => $project,
-        'pageClass' => ManageManagers::class,
-    ])
-        ->callTableAction('attach', data: [
-            'recordId' => $manager->getKey(),
-        ])
-        ->assertHasNoTableActionErrors();
-
-    expect($project->managerUsers()->whereKey($manager->getKey())->exists())->toBeTrue();
 });
 
 it('can list milestones in the project milestones widget', function () {

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorDepartmentsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorDepartmentsRelationManagerTest.php
@@ -128,11 +128,19 @@ describe('authorization', function () {
 
         $project = Project::factory()->create();
 
+        $department = Department::factory()->create();
+
         livewire(AuditorDepartmentsRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $department->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->auditorDepartments()->whereKey($department->getKey())->exists())->toBeTrue();
     });
 
     it('allows the project creator with the update permission to attach an auditor department', function () {
@@ -178,11 +186,19 @@ describe('authorization', function () {
 
         actingAs($user);
 
+        $newDepartment = Department::factory()->create();
+
         livewire(AuditorDepartmentsRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $newDepartment->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->auditorDepartments()->whereKey($newDepartment->getKey())->exists())->toBeTrue();
     });
 
     it('hides the attach action when the user\'s department is only an auditor department, not a manager department', function () {

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorDepartmentsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorDepartmentsRelationManagerTest.php
@@ -39,7 +39,10 @@ use AidingApp\Project\Filament\Resources\Projects\Pages\ManageAuditors;
 use AidingApp\Project\Filament\Resources\Projects\RelationManagers\AuditorDepartmentsRelationManager;
 use AidingApp\Project\Models\Project;
 use App\Models\User;
+use Filament\Actions\AttachAction;
+use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
+use Filament\Actions\Testing\TestAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -72,10 +75,10 @@ it('can attach an auditor department to a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageAuditors::class,
     ])
-        ->callTableAction('attach', data: [
+        ->callAction(TestAction::make(AttachAction::class)->table(), data: [
             'recordId' => $department->getKey(),
         ])
-        ->assertHasNoTableActionErrors();
+        ->assertHasNoFormErrors();
 
     expect($project->auditorDepartments()->whereKey($department->getKey())->exists())->toBeTrue();
 });
@@ -93,8 +96,8 @@ it('can detach an auditor department from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageAuditors::class,
     ])
-        ->callTableAction('detach', record: $department)
-        ->assertHasNoTableActionErrors();
+        ->callAction(TestAction::make(DetachAction::class)->table($department))
+        ->assertHasNoFormErrors();
 
     expect($project->auditorDepartments()->whereKey($department->getKey())->exists())->toBeFalse();
 });
@@ -112,8 +115,9 @@ it('can bulk detach auditor departments from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageAuditors::class,
     ])
-        ->callTableBulkAction(DetachBulkAction::class, $departments)
-        ->assertHasNoTableBulkActionErrors();
+        ->selectTableRecords($departments->pluck('id')->all())
+        ->callAction(TestAction::make(DetachBulkAction::class)->table()->bulk())
+        ->assertHasNoFormErrors();
 
     expect($project->auditorDepartments()->count())->toBe(0);
 });
@@ -128,7 +132,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('allows the project creator with the update permission to attach an auditor department', function () {
@@ -148,11 +152,11 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionVisible('attach')
-            ->callTableAction('attach', data: [
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
                 'recordId' => $department->getKey(),
             ])
-            ->assertHasNoTableActionErrors();
+            ->assertHasNoFormErrors();
 
         expect($project->auditorDepartments()->whereKey($department->getKey())->exists())->toBeTrue();
     });
@@ -178,7 +182,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user\'s department is only an auditor department, not a manager department', function () {
@@ -202,7 +206,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has no update permission', function () {
@@ -219,7 +223,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
@@ -237,6 +241,6 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 });

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorDepartmentsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorDepartmentsRelationManagerTest.php
@@ -1,0 +1,242 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Department\Models\Department;
+use AidingApp\Project\Filament\Resources\Projects\Pages\ManageAuditors;
+use AidingApp\Project\Filament\Resources\Projects\RelationManagers\AuditorDepartmentsRelationManager;
+use AidingApp\Project\Models\Project;
+use App\Models\User;
+use Filament\Actions\DetachBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can list auditor departments', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $departments = Department::factory()->count(3)->create();
+
+    $project->auditorDepartments()->attach($departments->pluck('id'));
+
+    livewire(AuditorDepartmentsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageAuditors::class,
+    ])
+        ->assertCanSeeTableRecords($departments);
+});
+
+it('can attach an auditor department to a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $department = Department::factory()->create();
+
+    livewire(AuditorDepartmentsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageAuditors::class,
+    ])
+        ->callTableAction('attach', data: [
+            'recordId' => $department->getKey(),
+        ])
+        ->assertHasNoTableActionErrors();
+
+    expect($project->auditorDepartments()->whereKey($department->getKey())->exists())->toBeTrue();
+});
+
+it('can detach an auditor department from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $department = Department::factory()->create();
+
+    $project->auditorDepartments()->attach($department->getKey());
+
+    livewire(AuditorDepartmentsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageAuditors::class,
+    ])
+        ->callTableAction('detach', record: $department)
+        ->assertHasNoTableActionErrors();
+
+    expect($project->auditorDepartments()->whereKey($department->getKey())->exists())->toBeFalse();
+});
+
+it('can bulk detach auditor departments from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $departments = Department::factory()->count(2)->create();
+
+    $project->auditorDepartments()->attach($departments->pluck('id'));
+
+    livewire(AuditorDepartmentsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageAuditors::class,
+    ])
+        ->callTableBulkAction(DetachBulkAction::class, $departments)
+        ->assertHasNoTableBulkActionErrors();
+
+    expect($project->auditorDepartments()->count())->toBe(0);
+});
+
+describe('authorization', function () {
+    it('allows a super admin to attach an auditor department', function () {
+        asSuperAdmin();
+
+        $project = Project::factory()->create();
+
+        livewire(AuditorDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('allows the project creator with the update permission to attach an auditor department', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        $department = Department::factory()->create();
+
+        livewire(AuditorDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionVisible('attach')
+            ->callTableAction('attach', data: [
+                'recordId' => $department->getKey(),
+            ])
+            ->assertHasNoTableActionErrors();
+
+        expect($project->auditorDepartments()->whereKey($department->getKey())->exists())->toBeTrue();
+    });
+
+    it('allows a manager whose department manages the project with the update permission to attach an auditor department', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $department = Department::factory()->create();
+
+        $user->department()->associate($department)->save();
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        $project->managerDepartments()->attach($department->getKey());
+
+        actingAs($user);
+
+        livewire(AuditorDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('hides the attach action when the user\'s department is only an auditor department, not a manager department', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $department = Department::factory()->create();
+
+        $user->department()->associate($department)->save();
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        $project->auditorDepartments()->attach($department->getKey());
+
+        actingAs($user);
+
+        livewire(AuditorDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+
+    it('hides the attach action when the user has no update permission', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        livewire(AuditorDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+
+    it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        actingAs($user);
+
+        livewire(AuditorDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorUsersRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorUsersRelationManagerTest.php
@@ -38,7 +38,10 @@ use AidingApp\Project\Filament\Resources\Projects\Pages\ManageAuditors;
 use AidingApp\Project\Filament\Resources\Projects\RelationManagers\AuditorUsersRelationManager;
 use AidingApp\Project\Models\Project;
 use App\Models\User;
+use Filament\Actions\AttachAction;
+use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
+use Filament\Actions\Testing\TestAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -71,10 +74,10 @@ it('can attach an auditor user to a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageAuditors::class,
     ])
-        ->callTableAction('attach', data: [
+        ->callAction(TestAction::make(AttachAction::class)->table(), data: [
             'recordId' => $auditor->getKey(),
         ])
-        ->assertHasNoTableActionErrors();
+        ->assertHasNoFormErrors();
 
     expect($project->auditorUsers()->whereKey($auditor->getKey())->exists())->toBeTrue();
 });
@@ -92,8 +95,8 @@ it('can detach an auditor user from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageAuditors::class,
     ])
-        ->callTableAction('detach', record: $auditor)
-        ->assertHasNoTableActionErrors();
+        ->callAction(TestAction::make(DetachAction::class)->table($auditor))
+        ->assertHasNoFormErrors();
 
     expect($project->auditorUsers()->whereKey($auditor->getKey())->exists())->toBeFalse();
 });
@@ -111,8 +114,9 @@ it('can bulk detach auditor users from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageAuditors::class,
     ])
-        ->callTableBulkAction(DetachBulkAction::class, $auditors)
-        ->assertHasNoTableBulkActionErrors();
+        ->selectTableRecords($auditors->pluck('id')->all())
+        ->callAction(TestAction::make(DetachBulkAction::class)->table()->bulk())
+        ->assertHasNoFormErrors();
 
     expect($project->auditorUsers()->count())->toBe(0);
 });
@@ -127,7 +131,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('allows the project creator with the update permission to attach an auditor user', function () {
@@ -147,11 +151,11 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionVisible('attach')
-            ->callTableAction('attach', data: [
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
                 'recordId' => $auditor->getKey(),
             ])
-            ->assertHasNoTableActionErrors();
+            ->assertHasNoFormErrors();
 
         expect($project->auditorUsers()->whereKey($auditor->getKey())->exists())->toBeTrue();
     });
@@ -173,7 +177,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user is only an auditor, not a manager or creator', function () {
@@ -193,7 +197,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has no update permission', function () {
@@ -210,7 +214,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
@@ -228,6 +232,6 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 });

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorUsersRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorUsersRelationManagerTest.php
@@ -127,11 +127,19 @@ describe('authorization', function () {
 
         $project = Project::factory()->create();
 
+        $auditor = User::factory()->create();
+
         livewire(AuditorUsersRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $auditor->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->auditorUsers()->whereKey($auditor->getKey())->exists())->toBeTrue();
     });
 
     it('allows the project creator with the update permission to attach an auditor user', function () {
@@ -173,11 +181,19 @@ describe('authorization', function () {
 
         actingAs($user);
 
+        $auditor = User::factory()->create();
+
         livewire(AuditorUsersRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageAuditors::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $auditor->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->auditorUsers()->whereKey($auditor->getKey())->exists())->toBeTrue();
     });
 
     it('hides the attach action when the user is only an auditor, not a manager or creator', function () {

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorUsersRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/AuditorUsersRelationManagerTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Project\Filament\Resources\Projects\Pages\ManageAuditors;
+use AidingApp\Project\Filament\Resources\Projects\RelationManagers\AuditorUsersRelationManager;
+use AidingApp\Project\Models\Project;
+use App\Models\User;
+use Filament\Actions\DetachBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can list auditor users', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $auditors = User::factory()->count(3)->create();
+
+    $project->auditorUsers()->attach($auditors->pluck('id'));
+
+    livewire(AuditorUsersRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageAuditors::class,
+    ])
+        ->assertCanSeeTableRecords($auditors);
+});
+
+it('can attach an auditor user to a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $auditor = User::factory()->create();
+
+    livewire(AuditorUsersRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageAuditors::class,
+    ])
+        ->callTableAction('attach', data: [
+            'recordId' => $auditor->getKey(),
+        ])
+        ->assertHasNoTableActionErrors();
+
+    expect($project->auditorUsers()->whereKey($auditor->getKey())->exists())->toBeTrue();
+});
+
+it('can detach an auditor user from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $auditor = User::factory()->create();
+
+    $project->auditorUsers()->attach($auditor->getKey());
+
+    livewire(AuditorUsersRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageAuditors::class,
+    ])
+        ->callTableAction('detach', record: $auditor)
+        ->assertHasNoTableActionErrors();
+
+    expect($project->auditorUsers()->whereKey($auditor->getKey())->exists())->toBeFalse();
+});
+
+it('can bulk detach auditor users from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $auditors = User::factory()->count(2)->create();
+
+    $project->auditorUsers()->attach($auditors->pluck('id'));
+
+    livewire(AuditorUsersRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageAuditors::class,
+    ])
+        ->callTableBulkAction(DetachBulkAction::class, $auditors)
+        ->assertHasNoTableBulkActionErrors();
+
+    expect($project->auditorUsers()->count())->toBe(0);
+});
+
+describe('authorization', function () {
+    it('allows a super admin to attach an auditor user', function () {
+        asSuperAdmin();
+
+        $project = Project::factory()->create();
+
+        livewire(AuditorUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('allows the project creator with the update permission to attach an auditor user', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        $auditor = User::factory()->create();
+
+        livewire(AuditorUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionVisible('attach')
+            ->callTableAction('attach', data: [
+                'recordId' => $auditor->getKey(),
+            ])
+            ->assertHasNoTableActionErrors();
+
+        expect($project->auditorUsers()->whereKey($auditor->getKey())->exists())->toBeTrue();
+    });
+
+    it('allows an assigned project manager with the update permission to attach an auditor user', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        $project->managerUsers()->attach($user->getKey());
+
+        actingAs($user);
+
+        livewire(AuditorUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('hides the attach action when the user is only an auditor, not a manager or creator', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        $project->auditorUsers()->attach($user->getKey());
+
+        actingAs($user);
+
+        livewire(AuditorUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+
+    it('hides the attach action when the user has no update permission', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        livewire(AuditorUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+
+    it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        actingAs($user);
+
+        livewire(AuditorUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageAuditors::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestContactsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestContactsRelationManagerTest.php
@@ -39,7 +39,10 @@ use AidingApp\Project\Filament\Resources\Projects\Pages\ManageGuests;
 use AidingApp\Project\Filament\Resources\Projects\RelationManagers\GuestContactsRelationManager;
 use AidingApp\Project\Models\Project;
 use App\Models\User;
+use Filament\Actions\AttachAction;
+use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
+use Filament\Actions\Testing\TestAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -72,10 +75,10 @@ it('can attach a guest contact to a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageGuests::class,
     ])
-        ->callTableAction('attach', data: [
+        ->callAction(TestAction::make(AttachAction::class)->table(), data: [
             'recordId' => $contact->getKey(),
         ])
-        ->assertHasNoTableActionErrors();
+        ->assertHasNoFormErrors();
 
     expect($project->guestContacts()->where('contacts.id', $contact->getKey())->exists())->toBeTrue();
 });
@@ -93,8 +96,8 @@ it('can detach a guest contact from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageGuests::class,
     ])
-        ->callTableAction('detach', record: $contact)
-        ->assertHasNoTableActionErrors();
+        ->callAction(TestAction::make(DetachAction::class)->table($contact))
+        ->assertHasNoFormErrors();
 
     expect($project->guestContacts()->where('contacts.id', $contact->getKey())->exists())->toBeFalse();
 });
@@ -112,8 +115,9 @@ it('can bulk detach guest contacts from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageGuests::class,
     ])
-        ->callTableBulkAction(DetachBulkAction::class, $contacts)
-        ->assertHasNoTableBulkActionErrors();
+        ->selectTableRecords($contacts->pluck('id')->all())
+        ->callAction(TestAction::make(DetachBulkAction::class)->table()->bulk())
+        ->assertHasNoFormErrors();
 
     expect($project->guestContacts()->count())->toBe(0);
 });
@@ -128,7 +132,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('allows the project creator with the update permission to attach a guest contact', function () {
@@ -148,11 +152,11 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertTableActionVisible('attach')
-            ->callTableAction('attach', data: [
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
                 'recordId' => $contact->getKey(),
             ])
-            ->assertHasNoTableActionErrors();
+            ->assertHasNoFormErrors();
 
         expect($project->guestContacts()->where('contacts.id', $contact->getKey())->exists())->toBeTrue();
     });
@@ -174,7 +178,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has no update permission', function () {
@@ -191,7 +195,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
@@ -209,6 +213,6 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 });

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestContactsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestContactsRelationManagerTest.php
@@ -128,11 +128,19 @@ describe('authorization', function () {
 
         $project = Project::factory()->create();
 
+        $contact = Contact::factory()->create();
+
         livewire(GuestContactsRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $contact->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->guestContacts()->where('contacts.id', $contact->getKey())->exists())->toBeTrue();
     });
 
     it('allows the project creator with the update permission to attach a guest contact', function () {
@@ -174,11 +182,19 @@ describe('authorization', function () {
 
         actingAs($user);
 
+        $contact = Contact::factory()->create();
+
         livewire(GuestContactsRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $contact->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->guestContacts()->where('contacts.id', $contact->getKey())->exists())->toBeTrue();
     });
 
     it('hides the attach action when the user has no update permission', function () {

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestContactsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestContactsRelationManagerTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Contact\Models\Contact;
+use AidingApp\Project\Filament\Resources\Projects\Pages\ManageGuests;
+use AidingApp\Project\Filament\Resources\Projects\RelationManagers\GuestContactsRelationManager;
+use AidingApp\Project\Models\Project;
+use App\Models\User;
+use Filament\Actions\DetachBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can list guest contacts', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $contacts = Contact::factory()->count(3)->create();
+
+    $project->guestContacts()->attach($contacts->pluck('id'));
+
+    livewire(GuestContactsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageGuests::class,
+    ])
+        ->assertCanSeeTableRecords($contacts);
+});
+
+it('can attach a guest contact to a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $contact = Contact::factory()->create();
+
+    livewire(GuestContactsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageGuests::class,
+    ])
+        ->callTableAction('attach', data: [
+            'recordId' => $contact->getKey(),
+        ])
+        ->assertHasNoTableActionErrors();
+
+    expect($project->guestContacts()->where('contacts.id', $contact->getKey())->exists())->toBeTrue();
+});
+
+it('can detach a guest contact from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $contact = Contact::factory()->create();
+
+    $project->guestContacts()->attach($contact->getKey());
+
+    livewire(GuestContactsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageGuests::class,
+    ])
+        ->callTableAction('detach', record: $contact)
+        ->assertHasNoTableActionErrors();
+
+    expect($project->guestContacts()->where('contacts.id', $contact->getKey())->exists())->toBeFalse();
+});
+
+it('can bulk detach guest contacts from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $contacts = Contact::factory()->count(2)->create();
+
+    $project->guestContacts()->attach($contacts->pluck('id'));
+
+    livewire(GuestContactsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageGuests::class,
+    ])
+        ->callTableBulkAction(DetachBulkAction::class, $contacts)
+        ->assertHasNoTableBulkActionErrors();
+
+    expect($project->guestContacts()->count())->toBe(0);
+});
+
+describe('authorization', function () {
+    it('allows a super admin to attach a guest contact', function () {
+        asSuperAdmin();
+
+        $project = Project::factory()->create();
+
+        livewire(GuestContactsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageGuests::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('allows the project creator with the update permission to attach a guest contact', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        $contact = Contact::factory()->create();
+
+        livewire(GuestContactsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageGuests::class,
+        ])
+            ->assertTableActionVisible('attach')
+            ->callTableAction('attach', data: [
+                'recordId' => $contact->getKey(),
+            ])
+            ->assertHasNoTableActionErrors();
+
+        expect($project->guestContacts()->where('contacts.id', $contact->getKey())->exists())->toBeTrue();
+    });
+
+    it('allows an assigned project manager with the update permission to attach a guest contact', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        $project->managerUsers()->attach($user->getKey());
+
+        actingAs($user);
+
+        livewire(GuestContactsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageGuests::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('hides the attach action when the user has no update permission', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        livewire(GuestContactsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageGuests::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+
+    it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        actingAs($user);
+
+        livewire(GuestContactsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageGuests::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestOrganizationsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestOrganizationsRelationManagerTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Contact\Models\Organization;
+use AidingApp\Project\Filament\Resources\Projects\Pages\ManageGuests;
+use AidingApp\Project\Filament\Resources\Projects\RelationManagers\GuestOrganizationsRelationManager;
+use AidingApp\Project\Models\Project;
+use App\Models\User;
+use Filament\Actions\DetachBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can list guest organizations', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $organizations = Organization::factory()->count(3)->create();
+
+    $project->guestOrganizations()->attach($organizations->pluck('id'));
+
+    livewire(GuestOrganizationsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageGuests::class,
+    ])
+        ->assertCanSeeTableRecords($organizations);
+});
+
+it('can attach a guest organization to a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $organization = Organization::factory()->create();
+
+    livewire(GuestOrganizationsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageGuests::class,
+    ])
+        ->callTableAction('attach', data: [
+            'recordId' => $organization->getKey(),
+        ])
+        ->assertHasNoTableActionErrors();
+
+    expect($project->guestOrganizations()->where('organizations.id', $organization->getKey())->exists())->toBeTrue();
+});
+
+it('can detach a guest organization from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $organization = Organization::factory()->create();
+
+    $project->guestOrganizations()->attach($organization->getKey());
+
+    livewire(GuestOrganizationsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageGuests::class,
+    ])
+        ->callTableAction('detach', record: $organization)
+        ->assertHasNoTableActionErrors();
+
+    expect($project->guestOrganizations()->where('organizations.id', $organization->getKey())->exists())->toBeFalse();
+});
+
+it('can bulk detach guest organizations from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $organizations = Organization::factory()->count(2)->create();
+
+    $project->guestOrganizations()->attach($organizations->pluck('id'));
+
+    livewire(GuestOrganizationsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageGuests::class,
+    ])
+        ->callTableBulkAction(DetachBulkAction::class, $organizations)
+        ->assertHasNoTableBulkActionErrors();
+
+    expect($project->guestOrganizations()->count())->toBe(0);
+});
+
+describe('authorization', function () {
+    it('allows a super admin to attach a guest organization', function () {
+        asSuperAdmin();
+
+        $project = Project::factory()->create();
+
+        livewire(GuestOrganizationsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageGuests::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('allows the project creator with the update permission to attach a guest organization', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        $organization = Organization::factory()->create();
+
+        livewire(GuestOrganizationsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageGuests::class,
+        ])
+            ->assertTableActionVisible('attach')
+            ->callTableAction('attach', data: [
+                'recordId' => $organization->getKey(),
+            ])
+            ->assertHasNoTableActionErrors();
+
+        expect($project->guestOrganizations()->where('organizations.id', $organization->getKey())->exists())->toBeTrue();
+    });
+
+    it('allows an assigned project manager with the update permission to attach a guest organization', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        $project->managerUsers()->attach($user->getKey());
+
+        actingAs($user);
+
+        livewire(GuestOrganizationsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageGuests::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('hides the attach action when the user has no update permission', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        livewire(GuestOrganizationsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageGuests::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+
+    it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        actingAs($user);
+
+        livewire(GuestOrganizationsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageGuests::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestOrganizationsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestOrganizationsRelationManagerTest.php
@@ -39,7 +39,10 @@ use AidingApp\Project\Filament\Resources\Projects\Pages\ManageGuests;
 use AidingApp\Project\Filament\Resources\Projects\RelationManagers\GuestOrganizationsRelationManager;
 use AidingApp\Project\Models\Project;
 use App\Models\User;
+use Filament\Actions\AttachAction;
+use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
+use Filament\Actions\Testing\TestAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -72,10 +75,10 @@ it('can attach a guest organization to a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageGuests::class,
     ])
-        ->callTableAction('attach', data: [
+        ->callAction(TestAction::make(AttachAction::class)->table(), data: [
             'recordId' => $organization->getKey(),
         ])
-        ->assertHasNoTableActionErrors();
+        ->assertHasNoFormErrors();
 
     expect($project->guestOrganizations()->where('organizations.id', $organization->getKey())->exists())->toBeTrue();
 });
@@ -93,8 +96,8 @@ it('can detach a guest organization from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageGuests::class,
     ])
-        ->callTableAction('detach', record: $organization)
-        ->assertHasNoTableActionErrors();
+        ->callAction(TestAction::make(DetachAction::class)->table($organization))
+        ->assertHasNoFormErrors();
 
     expect($project->guestOrganizations()->where('organizations.id', $organization->getKey())->exists())->toBeFalse();
 });
@@ -112,8 +115,9 @@ it('can bulk detach guest organizations from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageGuests::class,
     ])
-        ->callTableBulkAction(DetachBulkAction::class, $organizations)
-        ->assertHasNoTableBulkActionErrors();
+        ->selectTableRecords($organizations->pluck('id')->all())
+        ->callAction(TestAction::make(DetachBulkAction::class)->table()->bulk())
+        ->assertHasNoFormErrors();
 
     expect($project->guestOrganizations()->count())->toBe(0);
 });
@@ -128,7 +132,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('allows the project creator with the update permission to attach a guest organization', function () {
@@ -148,11 +152,11 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertTableActionVisible('attach')
-            ->callTableAction('attach', data: [
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
                 'recordId' => $organization->getKey(),
             ])
-            ->assertHasNoTableActionErrors();
+            ->assertHasNoFormErrors();
 
         expect($project->guestOrganizations()->where('organizations.id', $organization->getKey())->exists())->toBeTrue();
     });
@@ -174,7 +178,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has no update permission', function () {
@@ -191,7 +195,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
@@ -209,6 +213,6 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 });

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestOrganizationsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/GuestOrganizationsRelationManagerTest.php
@@ -128,11 +128,19 @@ describe('authorization', function () {
 
         $project = Project::factory()->create();
 
+        $organization = Organization::factory()->create();
+
         livewire(GuestOrganizationsRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $organization->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->guestOrganizations()->where('organizations.id', $organization->getKey())->exists())->toBeTrue();
     });
 
     it('allows the project creator with the update permission to attach a guest organization', function () {
@@ -174,11 +182,19 @@ describe('authorization', function () {
 
         actingAs($user);
 
+        $organization = Organization::factory()->create();
+
         livewire(GuestOrganizationsRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageGuests::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $organization->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->guestOrganizations()->where('organizations.id', $organization->getKey())->exists())->toBeTrue();
     });
 
     it('hides the attach action when the user has no update permission', function () {

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerDepartmentsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerDepartmentsRelationManagerTest.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Department\Models\Department;
+use AidingApp\Project\Filament\Resources\Projects\Pages\ManageManagers;
+use AidingApp\Project\Filament\Resources\Projects\RelationManagers\ManagerDepartmentsRelationManager;
+use AidingApp\Project\Models\Project;
+use App\Models\User;
+use Filament\Actions\DetachBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can list manager departments', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $departments = Department::factory()->count(3)->create();
+
+    $project->managerDepartments()->attach($departments->pluck('id'));
+
+    livewire(ManagerDepartmentsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageManagers::class,
+    ])
+        ->assertCanSeeTableRecords($departments);
+});
+
+it('can attach a manager department to a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $department = Department::factory()->create();
+
+    livewire(ManagerDepartmentsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageManagers::class,
+    ])
+        ->callTableAction('attach', data: [
+            'recordId' => $department->getKey(),
+        ])
+        ->assertHasNoTableActionErrors();
+
+    expect($project->managerDepartments()->whereKey($department->getKey())->exists())->toBeTrue();
+});
+
+it('can detach a manager department from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $department = Department::factory()->create();
+
+    $project->managerDepartments()->attach($department->getKey());
+
+    livewire(ManagerDepartmentsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageManagers::class,
+    ])
+        ->callTableAction('detach', record: $department)
+        ->assertHasNoTableActionErrors();
+
+    expect($project->managerDepartments()->whereKey($department->getKey())->exists())->toBeFalse();
+});
+
+it('can bulk detach manager departments from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $departments = Department::factory()->count(2)->create();
+
+    $project->managerDepartments()->attach($departments->pluck('id'));
+
+    livewire(ManagerDepartmentsRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageManagers::class,
+    ])
+        ->callTableBulkAction(DetachBulkAction::class, $departments)
+        ->assertHasNoTableBulkActionErrors();
+
+    expect($project->managerDepartments()->count())->toBe(0);
+});
+
+describe('authorization', function () {
+    it('allows a super admin to attach a manager department', function () {
+        asSuperAdmin();
+
+        $project = Project::factory()->create();
+
+        livewire(ManagerDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageManagers::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('allows the project creator with the update permission to attach a manager department', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        $department = Department::factory()->create();
+
+        livewire(ManagerDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageManagers::class,
+        ])
+            ->assertTableActionVisible('attach')
+            ->callTableAction('attach', data: [
+                'recordId' => $department->getKey(),
+            ])
+            ->assertHasNoTableActionErrors();
+
+        expect($project->managerDepartments()->whereKey($department->getKey())->exists())->toBeTrue();
+    });
+
+    it('allows a manager whose department manages the project with the update permission to attach a manager department', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $department = Department::factory()->create();
+
+        $user->department()->associate($department)->save();
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        $project->managerDepartments()->attach($department->getKey());
+
+        actingAs($user);
+
+        livewire(ManagerDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageManagers::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('hides the attach action when the user has no update permission', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        livewire(ManagerDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageManagers::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+
+    it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        actingAs($user);
+
+        livewire(ManagerDepartmentsRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageManagers::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerDepartmentsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerDepartmentsRelationManagerTest.php
@@ -39,7 +39,10 @@ use AidingApp\Project\Filament\Resources\Projects\Pages\ManageManagers;
 use AidingApp\Project\Filament\Resources\Projects\RelationManagers\ManagerDepartmentsRelationManager;
 use AidingApp\Project\Models\Project;
 use App\Models\User;
+use Filament\Actions\AttachAction;
+use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
+use Filament\Actions\Testing\TestAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -72,10 +75,10 @@ it('can attach a manager department to a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageManagers::class,
     ])
-        ->callTableAction('attach', data: [
+        ->callAction(TestAction::make(AttachAction::class)->table(), data: [
             'recordId' => $department->getKey(),
         ])
-        ->assertHasNoTableActionErrors();
+        ->assertHasNoFormErrors();
 
     expect($project->managerDepartments()->whereKey($department->getKey())->exists())->toBeTrue();
 });
@@ -93,8 +96,8 @@ it('can detach a manager department from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageManagers::class,
     ])
-        ->callTableAction('detach', record: $department)
-        ->assertHasNoTableActionErrors();
+        ->callAction(TestAction::make(DetachAction::class)->table($department))
+        ->assertHasNoFormErrors();
 
     expect($project->managerDepartments()->whereKey($department->getKey())->exists())->toBeFalse();
 });
@@ -112,8 +115,9 @@ it('can bulk detach manager departments from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageManagers::class,
     ])
-        ->callTableBulkAction(DetachBulkAction::class, $departments)
-        ->assertHasNoTableBulkActionErrors();
+        ->selectTableRecords($departments->pluck('id')->all())
+        ->callAction(TestAction::make(DetachBulkAction::class)->table()->bulk())
+        ->assertHasNoFormErrors();
 
     expect($project->managerDepartments()->count())->toBe(0);
 });
@@ -128,7 +132,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('allows the project creator with the update permission to attach a manager department', function () {
@@ -148,11 +152,11 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertTableActionVisible('attach')
-            ->callTableAction('attach', data: [
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
                 'recordId' => $department->getKey(),
             ])
-            ->assertHasNoTableActionErrors();
+            ->assertHasNoFormErrors();
 
         expect($project->managerDepartments()->whereKey($department->getKey())->exists())->toBeTrue();
     });
@@ -178,7 +182,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has no update permission', function () {
@@ -195,7 +199,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
@@ -213,6 +217,6 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 });

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerDepartmentsRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerDepartmentsRelationManagerTest.php
@@ -128,11 +128,19 @@ describe('authorization', function () {
 
         $project = Project::factory()->create();
 
+        $department = Department::factory()->create();
+
         livewire(ManagerDepartmentsRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $department->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->managerDepartments()->whereKey($department->getKey())->exists())->toBeTrue();
     });
 
     it('allows the project creator with the update permission to attach a manager department', function () {
@@ -178,11 +186,19 @@ describe('authorization', function () {
 
         actingAs($user);
 
+        $newDepartment = Department::factory()->create();
+
         livewire(ManagerDepartmentsRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $newDepartment->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->managerDepartments()->whereKey($newDepartment->getKey())->exists())->toBeTrue();
     });
 
     it('hides the attach action when the user has no update permission', function () {

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerUsersRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerUsersRelationManagerTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Project\Filament\Resources\Projects\Pages\ManageManagers;
+use AidingApp\Project\Filament\Resources\Projects\RelationManagers\ManagerUsersRelationManager;
+use AidingApp\Project\Models\Project;
+use App\Models\User;
+use Filament\Actions\DetachBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can list manager users', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $managers = User::factory()->count(3)->create();
+
+    $project->managerUsers()->attach($managers->pluck('id'));
+
+    livewire(ManagerUsersRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageManagers::class,
+    ])
+        ->assertCanSeeTableRecords($managers);
+});
+
+it('can attach a manager user to a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $manager = User::factory()->create();
+
+    livewire(ManagerUsersRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageManagers::class,
+    ])
+        ->callTableAction('attach', data: [
+            'recordId' => $manager->getKey(),
+        ])
+        ->assertHasNoTableActionErrors();
+
+    expect($project->managerUsers()->whereKey($manager->getKey())->exists())->toBeTrue();
+});
+
+it('can detach a manager user from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $manager = User::factory()->create();
+
+    $project->managerUsers()->attach($manager->getKey());
+
+    livewire(ManagerUsersRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageManagers::class,
+    ])
+        ->callTableAction('detach', record: $manager)
+        ->assertHasNoTableActionErrors();
+
+    expect($project->managerUsers()->whereKey($manager->getKey())->exists())->toBeFalse();
+});
+
+it('can bulk detach manager users from a project', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $managers = User::factory()->count(2)->create();
+
+    $project->managerUsers()->attach($managers->pluck('id'));
+
+    livewire(ManagerUsersRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManageManagers::class,
+    ])
+        ->callTableBulkAction(DetachBulkAction::class, $managers)
+        ->assertHasNoTableBulkActionErrors();
+
+    expect($project->managerUsers()->count())->toBe(0);
+});
+
+describe('authorization', function () {
+    it('allows a super admin to attach a manager user', function () {
+        asSuperAdmin();
+
+        $project = Project::factory()->create();
+
+        livewire(ManagerUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageManagers::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('allows the project creator with the update permission to attach a manager user', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        $manager = User::factory()->create();
+
+        livewire(ManagerUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageManagers::class,
+        ])
+            ->assertTableActionVisible('attach')
+            ->callTableAction('attach', data: [
+                'recordId' => $manager->getKey(),
+            ])
+            ->assertHasNoTableActionErrors();
+
+        expect($project->managerUsers()->whereKey($manager->getKey())->exists())->toBeTrue();
+    });
+
+    it('allows an assigned project manager with the update permission to attach a manager user', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->create();
+
+        $project->managerUsers()->attach($user->getKey());
+
+        actingAs($user);
+
+        livewire(ManagerUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageManagers::class,
+        ])
+            ->assertTableActionVisible('attach');
+    });
+
+    it('hides the attach action when the user has no update permission', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        livewire(ManagerUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageManagers::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+
+    it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        actingAs($user);
+
+        livewire(ManagerUsersRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManageManagers::class,
+        ])
+            ->assertTableActionHidden('attach');
+    });
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerUsersRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerUsersRelationManagerTest.php
@@ -127,11 +127,19 @@ describe('authorization', function () {
 
         $project = Project::factory()->create();
 
+        $manager = User::factory()->create();
+
         livewire(ManagerUsersRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $manager->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->managerUsers()->whereKey($manager->getKey())->exists())->toBeTrue();
     });
 
     it('allows the project creator with the update permission to attach a manager user', function () {
@@ -173,11 +181,19 @@ describe('authorization', function () {
 
         actingAs($user);
 
+        $manager = User::factory()->create();
+
         livewire(ManagerUsersRelationManager::class, [
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
+                'recordId' => $manager->getKey(),
+            ])
+            ->assertHasNoFormErrors();
+
+        expect($project->managerUsers()->whereKey($manager->getKey())->exists())->toBeTrue();
     });
 
     it('hides the attach action when the user has no update permission', function () {

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerUsersRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/ManagerUsersRelationManagerTest.php
@@ -38,7 +38,10 @@ use AidingApp\Project\Filament\Resources\Projects\Pages\ManageManagers;
 use AidingApp\Project\Filament\Resources\Projects\RelationManagers\ManagerUsersRelationManager;
 use AidingApp\Project\Models\Project;
 use App\Models\User;
+use Filament\Actions\AttachAction;
+use Filament\Actions\DetachAction;
 use Filament\Actions\DetachBulkAction;
+use Filament\Actions\Testing\TestAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -71,10 +74,10 @@ it('can attach a manager user to a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageManagers::class,
     ])
-        ->callTableAction('attach', data: [
+        ->callAction(TestAction::make(AttachAction::class)->table(), data: [
             'recordId' => $manager->getKey(),
         ])
-        ->assertHasNoTableActionErrors();
+        ->assertHasNoFormErrors();
 
     expect($project->managerUsers()->whereKey($manager->getKey())->exists())->toBeTrue();
 });
@@ -92,8 +95,8 @@ it('can detach a manager user from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageManagers::class,
     ])
-        ->callTableAction('detach', record: $manager)
-        ->assertHasNoTableActionErrors();
+        ->callAction(TestAction::make(DetachAction::class)->table($manager))
+        ->assertHasNoFormErrors();
 
     expect($project->managerUsers()->whereKey($manager->getKey())->exists())->toBeFalse();
 });
@@ -111,8 +114,9 @@ it('can bulk detach manager users from a project', function () {
         'ownerRecord' => $project,
         'pageClass' => ManageManagers::class,
     ])
-        ->callTableBulkAction(DetachBulkAction::class, $managers)
-        ->assertHasNoTableBulkActionErrors();
+        ->selectTableRecords($managers->pluck('id')->all())
+        ->callAction(TestAction::make(DetachBulkAction::class)->table()->bulk())
+        ->assertHasNoFormErrors();
 
     expect($project->managerUsers()->count())->toBe(0);
 });
@@ -127,7 +131,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('allows the project creator with the update permission to attach a manager user', function () {
@@ -147,11 +151,11 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertTableActionVisible('attach')
-            ->callTableAction('attach', data: [
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table())
+            ->callAction(TestAction::make(AttachAction::class)->table(), data: [
                 'recordId' => $manager->getKey(),
             ])
-            ->assertHasNoTableActionErrors();
+            ->assertHasNoFormErrors();
 
         expect($project->managerUsers()->whereKey($manager->getKey())->exists())->toBeTrue();
     });
@@ -173,7 +177,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertTableActionVisible('attach');
+            ->assertActionVisible(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has no update permission', function () {
@@ -190,7 +194,7 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 
     it('hides the attach action when the user has the update permission but is unrelated to the project', function () {
@@ -208,6 +212,6 @@ describe('authorization', function () {
             'ownerRecord' => $project,
             'pageClass' => ManageManagers::class,
         ])
-            ->assertTableActionHidden('attach');
+            ->assertActionHidden(TestAction::make(AttachAction::class)->table());
     });
 });

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/PipelinesRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/PipelinesRelationManagerTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Project\Filament\Resources\Projects\Pages\ManagePipelines;
+use AidingApp\Project\Filament\Resources\Projects\RelationManagers\PipelinesRelationManager;
+use AidingApp\Project\Models\Pipeline;
+use AidingApp\Project\Models\PipelineStage;
+use AidingApp\Project\Models\Project;
+use App\Models\User;
+use Filament\Actions\CreateAction;
+use Filament\Actions\Testing\TestAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can list pipelines', function () {
+    $superAdmin = User::factory()->create();
+    asSuperAdmin($superAdmin);
+
+    $project = Project::factory()->create();
+
+    $pipelines = Pipeline::factory()
+        ->has(PipelineStage::factory()->count(3), 'stages')
+        ->for($project)
+        ->count(2)
+        ->create();
+
+    livewire(PipelinesRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManagePipelines::class,
+    ])
+        ->assertCanSeeTableRecords($pipelines);
+});
+
+describe('authorization', function () {
+    it('allows a super admin to create a pipeline', function () {
+        asSuperAdmin();
+
+        $project = Project::factory()->create();
+
+        livewire(PipelinesRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManagePipelines::class,
+        ])
+            ->assertActionVisible(TestAction::make(CreateAction::class)->table());
+    });
+
+    it('allows the project creator with the update permission to create a pipeline', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        livewire(PipelinesRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManagePipelines::class,
+        ])
+            ->assertActionVisible(TestAction::make(CreateAction::class)->table());
+    });
+
+    it('allows an assigned project manager with the update permission to create a pipeline', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        $project->managerUsers()->attach($user->getKey());
+
+        actingAs($user);
+
+        livewire(PipelinesRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManagePipelines::class,
+        ])
+            ->assertActionVisible(TestAction::make(CreateAction::class)->table());
+    });
+
+    it('hides the create action when the user has no update permission', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+
+        actingAs($user);
+
+        $project = Project::factory()->for($user, 'createdBy')->create();
+
+        livewire(PipelinesRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManagePipelines::class,
+        ])
+            ->assertActionHidden(TestAction::make(CreateAction::class)->table());
+    });
+
+    it('hides the create action when the user has the update permission but is unrelated to the project', function () {
+        $user = User::factory()->create();
+
+        $user->givePermissionTo('project.view-any');
+        $user->givePermissionTo('project.*.view');
+        $user->givePermissionTo('project.*.update');
+
+        $project = Project::factory()->for(User::factory(), 'createdBy')->create();
+
+        actingAs($user);
+
+        livewire(PipelinesRelationManager::class, [
+            'ownerRecord' => $project,
+            'pageClass' => ManagePipelines::class,
+        ])
+            ->assertActionHidden(TestAction::make(CreateAction::class)->table());
+    });
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/PipelinesRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/RelationManagers/PipelinesRelationManagerTest.php
@@ -34,17 +34,21 @@
 </COPYRIGHT>
 */
 
+use AidingApp\Project\Filament\Resources\Pipelines\Pages\CreatePipeline;
 use AidingApp\Project\Filament\Resources\Projects\Pages\ManagePipelines;
 use AidingApp\Project\Filament\Resources\Projects\RelationManagers\PipelinesRelationManager;
 use AidingApp\Project\Models\Pipeline;
 use AidingApp\Project\Models\PipelineStage;
 use AidingApp\Project\Models\Project;
+use AidingApp\Project\Tests\Tenant\Filament\Resources\PipelineResource\RequestFactory\CreatePipelineRequestFactory;
 use App\Models\User;
 use Filament\Actions\CreateAction;
 use Filament\Actions\Testing\TestAction;
+use Filament\Forms\Components\Repeater;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
+use function PHPUnit\Framework\assertCount;
 use function Tests\asSuperAdmin;
 
 it('can list pipelines', function () {
@@ -68,6 +72,8 @@ it('can list pipelines', function () {
 
 describe('authorization', function () {
     it('allows a super admin to create a pipeline', function () {
+        $undoRepeaterFake = Repeater::fake();
+
         asSuperAdmin();
 
         $project = Project::factory()->create();
@@ -77,9 +83,23 @@ describe('authorization', function () {
             'pageClass' => ManagePipelines::class,
         ])
             ->assertActionVisible(TestAction::make(CreateAction::class)->table());
+
+        $pipelineData = CreatePipelineRequestFactory::new()->create();
+
+        livewire(CreatePipeline::class, ['parentRecord' => $project])
+            ->fillForm($pipelineData)
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        assertCount(1, Pipeline::all());
+        expect(Pipeline::first()->project_id)->toBe($project->getKey());
+
+        $undoRepeaterFake();
     });
 
     it('allows the project creator with the update permission to create a pipeline', function () {
+        $undoRepeaterFake = Repeater::fake();
+
         $user = User::factory()->create();
 
         $user->givePermissionTo('project.view-any');
@@ -95,9 +115,23 @@ describe('authorization', function () {
             'pageClass' => ManagePipelines::class,
         ])
             ->assertActionVisible(TestAction::make(CreateAction::class)->table());
+
+        $pipelineData = CreatePipelineRequestFactory::new()->create();
+
+        livewire(CreatePipeline::class, ['parentRecord' => $project])
+            ->fillForm($pipelineData)
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        assertCount(1, Pipeline::all());
+        expect(Pipeline::first()->project_id)->toBe($project->getKey());
+
+        $undoRepeaterFake();
     });
 
     it('allows an assigned project manager with the update permission to create a pipeline', function () {
+        $undoRepeaterFake = Repeater::fake();
+
         $user = User::factory()->create();
 
         $user->givePermissionTo('project.view-any');
@@ -115,6 +149,18 @@ describe('authorization', function () {
             'pageClass' => ManagePipelines::class,
         ])
             ->assertActionVisible(TestAction::make(CreateAction::class)->table());
+
+        $pipelineData = CreatePipelineRequestFactory::new()->create();
+
+        livewire(CreatePipeline::class, ['parentRecord' => $project])
+            ->fillForm($pipelineData)
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        assertCount(1, Pipeline::all());
+        expect(Pipeline::first()->project_id)->toBe($project->getKey());
+
+        $undoRepeaterFake();
     });
 
     it('hides the create action when the user has no update permission', function () {

--- a/app-modules/project/tests/Tenant/Policies/PipelinePolicyTest.php
+++ b/app-modules/project/tests/Tenant/Policies/PipelinePolicyTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Project\Models\Pipeline;
+use AidingApp\Project\Models\PipelineStage;
+use AidingApp\Project\Models\Project;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+it('delegates viewAny to the project when a project is passed', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    $project = Project::factory()->for($user, 'createdBy')->create();
+
+    expect($user->can('viewAny', [Pipeline::class, $project]))->toBeFalse();
+
+    $user->givePermissionTo('project.view-any');
+    $user->givePermissionTo('project.*.view');
+    $user->refresh();
+
+    expect($user->can('viewAny', [Pipeline::class, $project]))->toBeTrue();
+});
+
+it('falls back to the pipeline.view-any permission when no project is passed', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    expect($user->can('viewAny', Pipeline::class))->toBeFalse();
+
+    $user->givePermissionTo('pipeline.view-any');
+    $user->refresh();
+
+    expect($user->can('viewAny', Pipeline::class))->toBeTrue();
+});
+
+it('delegates create to the project when a project is passed', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    $project = Project::factory()->for($user, 'createdBy')->create();
+
+    expect($user->can('create', [Pipeline::class, $project]))->toBeFalse();
+
+    $user->givePermissionTo('project.view-any');
+    $user->givePermissionTo('project.*.view');
+    $user->givePermissionTo('project.*.update');
+    $user->refresh();
+
+    expect($user->can('create', [Pipeline::class, $project]))->toBeTrue();
+});
+
+it('falls back to the pipeline.create permission when no project is passed', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    expect($user->can('create', Pipeline::class))->toBeFalse();
+
+    $user->givePermissionTo('pipeline.create');
+    $user->refresh();
+
+    expect($user->can('create', Pipeline::class))->toBeTrue();
+});
+
+it('delegates update to the pipeline\'s project when it has one', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    $project = Project::factory()->for($user, 'createdBy')->create();
+
+    $pipeline = Pipeline::factory()
+        ->for($project)
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    expect($user->can('update', $pipeline))->toBeFalse();
+
+    $user->givePermissionTo('project.view-any');
+    $user->givePermissionTo('project.*.view');
+    $user->givePermissionTo('project.*.update');
+    $user->refresh();
+
+    expect($user->can('update', $pipeline))->toBeTrue();
+});
+
+it('falls back to the pipeline.*.update permission when the pipeline has no project', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    $pipeline = Pipeline::factory()
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create(['project_id' => null]);
+
+    expect($user->can('update', $pipeline))->toBeFalse();
+
+    $user->givePermissionTo('pipeline.*.update');
+    $user->refresh();
+
+    expect($user->can('update', $pipeline))->toBeTrue();
+});

--- a/app-modules/project/tests/Tenant/Policies/ProjectPolicyTest.php
+++ b/app-modules/project/tests/Tenant/Policies/ProjectPolicyTest.php
@@ -34,43 +34,45 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Project\Filament\Resources\Projects\RelationManagers;
+use AidingApp\Project\Models\Project;
+use App\Models\User;
 
-use Filament\Actions\AttachAction;
-use Filament\Actions\DetachAction;
-use Filament\Actions\DetachBulkAction;
-use Filament\Resources\RelationManagers\RelationManager;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Table;
+use function Pest\Laravel\actingAs;
 
-class AuditorUsersRelationManager extends RelationManager
-{
-    protected static string $relationship = 'auditorUsers';
+it('does not throw when checking a permission whose project creator has been deleted', function (string $ability) {
+    $creator = User::factory()->create();
 
-    protected static ?string $title = 'Users';
+    $project = Project::factory()->for($creator, 'createdBy')->create();
 
-    // Access is governed by the authorize() checks against the Project below, not a User::viewAny permission
-    protected static bool $shouldSkipAuthorization = true;
+    $creator->delete();
 
-    public function table(Table $table): Table
-    {
-        return $table
-            ->recordTitleAttribute('name')
-            ->columns([
-                TextColumn::make('name'),
-            ])
-            ->headerActions([
-                AttachAction::make()
-                    ->after(fn () => $this->dispatch('projectAccessUpdated')),
-            ])
-            ->recordActions([
-                DetachAction::make()
-                    ->after(fn () => $this->dispatch('projectAccessUpdated')),
-            ])
-            ->toolbarActions([
-                DetachBulkAction::make()
-                    ->after(fn () => $this->dispatch('projectAccessUpdated')),
-            ])
-            ->inverseRelationship('auditedProjects');
-    }
-}
+    $user = User::factory()->create();
+
+    $user->givePermissionTo("project.*.{$ability}");
+
+    actingAs($user);
+
+    expect($project->refresh()->createdBy)->toBeNull()
+        ->and($user->can($ability, $project))->toBeFalse();
+})->with([
+    'update',
+    'delete',
+    'restore',
+]);
+
+it('does not throw when checking the force-delete permission and the project creator has been deleted', function () {
+    $creator = User::factory()->create();
+
+    $project = Project::factory()->for($creator, 'createdBy')->create();
+
+    $creator->delete();
+
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('project.*.force-delete');
+
+    actingAs($user);
+
+    expect($project->refresh()->createdBy)->toBeNull()
+        ->and($user->can('forceDelete', $project))->toBeFalse();
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1387

### Technical Description

Fixes issues with access on the view project page. It was always expected that Project update permission as well as being the creator, a manager, or a super admin granted the ability to manage access and other resources of a project.
We have decided in most places that you DO NOT need the permissions of the underlying related model.

This fixes that as the relation managers were currently requiring that preventing users from having the proper access.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
