### PR TITLE
[AIDAPP-1371]: Enhance the capabilities of the pipeline selection modal

### DIFF
--- a/.cleanup-tasks/2026_08_07_pipeline_archiving_cleanup.md
+++ b/.cleanup-tasks/2026_08_07_pipeline_archiving_cleanup.md
@@ -1,0 +1,8 @@
+---
+title: Pipeline Archiving Cleanup
+created: 2026-08-07
+---
+
+## Feature Flags
+
+- App\Features\PipelineArchivingFeature

--- a/app-modules/project/database/migrations/2026_08_07_000000_add_archived_at_for_pipeline_archiving.php
+++ b/app-modules/project/database/migrations/2026_08_07_000000_add_archived_at_for_pipeline_archiving.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Features\PipelineArchivingFeature;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::transaction(function (): void {
+            Schema::table('pipelines', function (Blueprint $table): void {
+                $table->timestamp('archived_at')->nullable();
+            });
+
+            Schema::table('pipeline_entries', function (Blueprint $table): void {
+                $table->timestamp('archived_at')->nullable();
+            });
+
+            Schema::table('project_milestones', function (Blueprint $table): void {
+                $table->timestamp('archived_at')->nullable();
+            });
+
+            PipelineArchivingFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function (): void {
+            Schema::table('project_milestones', function (Blueprint $table): void {
+                $table->dropColumn('archived_at');
+            });
+
+            Schema::table('pipeline_entries', function (Blueprint $table): void {
+                $table->dropColumn('archived_at');
+            });
+
+            Schema::table('pipelines', function (Blueprint $table): void {
+                $table->dropColumn('archived_at');
+            });
+
+            PipelineArchivingFeature::deactivate();
+        });
+    }
+};

--- a/app-modules/project/database/migrations/2026_08_07_000000_add_archived_at_for_pipeline_archiving.php
+++ b/app-modules/project/database/migrations/2026_08_07_000000_add_archived_at_for_pipeline_archiving.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -48,6 +48,10 @@ return new class () extends Migration {
                 $table->timestamp('archived_at')->nullable();
             });
 
+            Schema::table('pipeline_stages', function (Blueprint $table): void {
+                $table->timestamp('archived_at')->nullable();
+            });
+
             Schema::table('pipeline_entries', function (Blueprint $table): void {
                 $table->timestamp('archived_at')->nullable();
             });
@@ -68,6 +72,10 @@ return new class () extends Migration {
             });
 
             Schema::table('pipeline_entries', function (Blueprint $table): void {
+                $table->dropColumn('archived_at');
+            });
+
+            Schema::table('pipeline_stages', function (Blueprint $table): void {
                 $table->dropColumn('archived_at');
             });
 

--- a/app-modules/project/database/migrations/2026_08_07_000000_add_archived_at_for_pipeline_archiving.php
+++ b/app-modules/project/database/migrations/2026_08_07_000000_add_archived_at_for_pipeline_archiving.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\PipelineArchivingFeature;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;

--- a/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
+++ b/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
@@ -42,6 +42,7 @@ use App\Features\PipelineArchivingFeature;
 use Filament\Actions\Action;
 use Filament\Forms\Components\TableSelect;
 use Filament\Notifications\Notification;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 
 trait HasPipelineSwitcherAction
@@ -69,6 +70,10 @@ trait HasPipelineSwitcherAction
                     blank($pipelineId) ||
                     ! Pipeline::query()
                         ->where('project_id', $this->getPipelineSwitcherProjectId())
+                        ->when(
+                            PipelineArchivingFeature::active(),
+                            fn (Builder $query): Builder => $query->withoutArchived(),
+                        )
                         ->whereKey($pipelineId)
                         ->exists()
                 ) {

--- a/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
+++ b/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
@@ -164,6 +164,7 @@ trait HasPipelineSwitcherAction
             ->modalHeading('Archive Pipeline')
             ->modalDescription('Are you sure you want to archive this pipeline? All related milestones and tasks will also be archived.')
             ->modalSubmitActionLabel('Archive')
+            ->cancelParentActions(fn (): bool => ! $this->switcherHasSelectablePipelines())
             ->action(function (): void {
                 $pipelineId = data_get($this->mountedActions, '0.data.pipeline_id');
 
@@ -181,6 +182,14 @@ trait HasPipelineSwitcherAction
             ->first();
 
         return $pipeline !== null && (bool) auth()->user()?->can('delete', $pipeline);
+    }
+
+    protected function switcherHasSelectablePipelines(): bool
+    {
+        return Pipeline::query()
+            ->where('project_id', $this->getPipelineSwitcherProjectId())
+            ->withoutArchived()
+            ->exists();
     }
 
     abstract protected function getPipelineSwitcherProjectId(): ?string;

--- a/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
+++ b/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
@@ -38,6 +38,7 @@ namespace AidingApp\Project\Filament\Concerns;
 
 use AidingApp\Project\Filament\Tables\ProjectPipelinesTable;
 use AidingApp\Project\Models\Pipeline;
+use App\Features\PipelineArchivingFeature;
 use Filament\Actions\Action;
 use Filament\Forms\Components\TableSelect;
 use Filament\Notifications\Notification;
@@ -46,7 +47,7 @@ trait HasPipelineSwitcherAction
 {
     public function selectPipelineAction(): Action
     {
-        return Action::make('selectPipeline')
+        $action = Action::make('selectPipeline')
             ->label('Select Pipeline')
             ->modalHeading('Select Pipeline')
             ->modalSubmitActionLabel('Select')
@@ -80,6 +81,102 @@ trait HasPipelineSwitcherAction
 
                 $this->onPipelineSwitcherSelected($pipelineId);
             });
+
+        return $action->modalFooterActions(fn (): array => [
+            $action->getModalSubmitAction(),
+            $action->getModalCancelAction(),
+            $this->archivePipelineAction(),
+        ]);
+    }
+
+    public function archivePipelineFromSwitcher(string $pipelineId): void
+    {
+        if (! PipelineArchivingFeature::active()) {
+            return;
+        }
+
+        $projectId = $this->getPipelineSwitcherProjectId();
+
+        $pipeline = Pipeline::query()
+            ->where('project_id', $projectId)
+            ->whereKey($pipelineId)
+            ->first();
+
+        if (! $pipeline) {
+            Notification::make()
+                ->danger()
+                ->title('Invalid pipeline selection')
+                ->body('The selected pipeline does not belong to this project.')
+                ->send();
+
+            return;
+        }
+
+        if (auth()->user()?->cannot('delete', $pipeline)) {
+            Notification::make()
+                ->danger()
+                ->title('Unauthorized')
+                ->body('You do not have permission to archive this pipeline.')
+                ->send();
+
+            return;
+        }
+
+        $wasActive = (string) $pipeline->getKey() === (string) $this->getPipelineSwitcherCurrentPipelineId();
+
+        $pipeline->archive();
+
+        Notification::make()
+            ->success()
+            ->title('Pipeline archived')
+            ->send();
+
+        if (! $wasActive) {
+            return;
+        }
+
+        $next = Pipeline::query()
+            ->where('project_id', $projectId)
+            ->withoutArchived()
+            ->oldest()
+            ->value('id');
+
+        if (filled($next)) {
+            $this->onPipelineSwitcherSelected((string) $next);
+
+            return;
+        }
+
+        $this->onPipelineSwitcherCleared();
+    }
+
+    protected function archivePipelineAction(): Action
+    {
+        return Action::make('archivePipeline')
+            ->label('Archive')
+            ->color('danger')
+            ->visible(fn (): bool => PipelineArchivingFeature::active() && $this->canArchivePipelinesFromSwitcher())
+            ->requiresConfirmation()
+            ->modalHeading('Archive Pipeline')
+            ->modalDescription('Are you sure you want to archive this pipeline? All related milestones and tasks will also be archived.')
+            ->modalSubmitActionLabel('Archive')
+            ->action(function (): void {
+                $pipelineId = data_get($this->mountedActions, '0.data.pipeline_id');
+
+                if (filled($pipelineId)) {
+                    $this->archivePipelineFromSwitcher((string) $pipelineId);
+                }
+            });
+    }
+
+    protected function canArchivePipelinesFromSwitcher(): bool
+    {
+        $pipeline = Pipeline::query()
+            ->where('project_id', $this->getPipelineSwitcherProjectId())
+            ->withoutArchived()
+            ->first();
+
+        return $pipeline !== null && (bool) auth()->user()?->can('delete', $pipeline);
     }
 
     abstract protected function getPipelineSwitcherProjectId(): ?string;

--- a/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
+++ b/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
@@ -50,6 +50,7 @@ trait HasPipelineSwitcherAction
     {
         $action = Action::make('selectPipeline')
             ->label('Select Pipeline')
+            ->slideOver()
             ->modalHeading('Select Pipeline')
             ->modalSubmitActionLabel('Select')
             ->visible(fn (): bool => filled($this->getPipelineSwitcherProjectId()))

--- a/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
+++ b/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
@@ -42,6 +42,7 @@ use App\Features\PipelineArchivingFeature;
 use Filament\Actions\Action;
 use Filament\Forms\Components\TableSelect;
 use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\DB;
 
 trait HasPipelineSwitcherAction
 {
@@ -124,7 +125,9 @@ trait HasPipelineSwitcherAction
 
         $wasActive = (string) $pipeline->getKey() === (string) $this->getPipelineSwitcherCurrentPipelineId();
 
-        $pipeline->archive();
+        DB::transaction(function () use ($pipeline): void {
+            $pipeline->archive();
+        });
 
         Notification::make()
             ->success()

--- a/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
+++ b/app-modules/project/src/Filament/Concerns/HasPipelineSwitcherAction.php
@@ -87,4 +87,6 @@ trait HasPipelineSwitcherAction
     abstract protected function getPipelineSwitcherCurrentPipelineId(): ?string;
 
     abstract protected function onPipelineSwitcherSelected(string $pipelineId): void;
+
+    abstract protected function onPipelineSwitcherCleared(): void;
 }

--- a/app-modules/project/src/Filament/Resources/Pipelines/Pages/ManagePipelineEntries.php
+++ b/app-modules/project/src/Filament/Resources/Pipelines/Pages/ManagePipelineEntries.php
@@ -157,4 +157,9 @@ class ManagePipelineEntries extends ManageRelatedRecords
             'project' => $this->getParentRecord(),
         ]));
     }
+
+    protected function onPipelineSwitcherCleared(): void
+    {
+        $this->redirect(ProjectResource::getUrl('view', ['record' => $this->getParentRecord()]));
+    }
 }

--- a/app-modules/project/src/Filament/Resources/Projects/Pages/ManageMilestones.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Pages/ManageMilestones.php
@@ -38,6 +38,7 @@ namespace AidingApp\Project\Filament\Resources\Projects\Pages;
 
 use AidingApp\Project\Filament\Resources\Projects\ProjectResource;
 use AidingApp\Project\Models\ProjectMilestone;
+use App\Features\PipelineArchivingFeature;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
@@ -50,6 +51,7 @@ use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 
 class ManageMilestones extends ManageRelatedRecords
 {
@@ -92,6 +94,13 @@ class ManageMilestones extends ManageRelatedRecords
     {
         return $table
             ->recordTitleAttribute('title')
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->when(
+                PipelineArchivingFeature::active(),
+                function (Builder $query): Builder {
+                    /** @var Builder<ProjectMilestone> $query */
+                    return $query->withoutArchived();
+                },
+            ))
             ->columns([
                 IdColumn::make(),
                 TextColumn::make('title'),

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/PipelinesRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/PipelinesRelationManager.php
@@ -38,6 +38,8 @@ namespace AidingApp\Project\Filament\Resources\Projects\RelationManagers;
 
 use AidingApp\Project\Filament\Resources\Pipelines\PipelineResource;
 use AidingApp\Project\Models\Pipeline;
+use App\Features\PipelineArchivingFeature;
+use CanyonGBS\Common\Filament\Actions\ArchiveAction;
 use Filament\Actions\CreateAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
@@ -46,7 +48,11 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 
+// TODO: This relation manager (and its ManagePipelines page) is currently only
+// reachable by direct URL. Evaluate whether it is still needed now that the
+// pipeline switcher owns pipeline management; remove if redundant.
 class PipelinesRelationManager extends RelationManager
 {
     protected static string $relationship = 'pipelines';
@@ -55,6 +61,13 @@ class PipelinesRelationManager extends RelationManager
     {
         return $table
             ->recordTitleAttribute('name')
+            ->modifyQueryUsing(function (Builder $query): Builder {
+                /** @var Builder<Pipeline> $query */
+                return $query->when(
+                    PipelineArchivingFeature::active(),
+                    fn (Builder $query): Builder => $query->withoutArchived(),
+                );
+            })
             ->columns([
                 TextColumn::make('name'),
                 TextColumn::make('createdBy.name')->label('Created By'),
@@ -81,6 +94,14 @@ class PipelinesRelationManager extends RelationManager
                         'record' => $record,
                         'project' => $this->getOwnerRecord(),
                     ])),
+                ArchiveAction::make()
+                    ->visible(fn (): bool => PipelineArchivingFeature::active())
+                    ->authorize(fn (Pipeline $record): bool => auth()->user()?->can('delete', $record) ?? false)
+                    ->modalHeading('Archive Pipeline')
+                    ->modalDescription('Are you sure you want to archive this pipeline? All related milestones and tasks will also be archived.')
+                    ->modalSubmitActionLabel('Archive')
+                    ->using(fn (Pipeline $record): bool => DB::transaction(fn (): bool => $record->archive()))
+                    ->successRedirectUrl(null),
             ]);
     }
 }

--- a/app-modules/project/src/Filament/Resources/Projects/RelationManagers/PipelinesRelationManager.php
+++ b/app-modules/project/src/Filament/Resources/Projects/RelationManagers/PipelinesRelationManager.php
@@ -44,6 +44,7 @@ use Filament\Actions\CreateAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
@@ -95,6 +96,7 @@ class PipelinesRelationManager extends RelationManager
                         'project' => $this->getOwnerRecord(),
                     ])),
                 ArchiveAction::make()
+                    ->icon(Heroicon::ArchiveBox)
                     ->visible(fn (): bool => PipelineArchivingFeature::active())
                     ->authorize(fn (Pipeline $record): bool => auth()->user()?->can('delete', $record) ?? false)
                     ->modalHeading('Archive Pipeline')

--- a/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectMilestonesWidget.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectMilestonesWidget.php
@@ -38,6 +38,7 @@ namespace AidingApp\Project\Filament\Resources\Projects\Widgets;
 
 use AidingApp\Project\Models\Project;
 use AidingApp\Project\Models\ProjectMilestoneStatus;
+use App\Features\PipelineArchivingFeature;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
@@ -73,7 +74,11 @@ class ProjectMilestonesWidget extends TableWidget
     public function table(Table $table): Table
     {
         return $table
-            ->query(fn (): Builder => $this->record->milestones()->getQuery())
+            ->query(fn (): Builder => $this->record->milestones()->getQuery()
+                ->when(
+                    PipelineArchivingFeature::active(),
+                    fn (Builder $query): Builder => $query->withoutArchived(),
+                ))
             ->recordTitleAttribute('title')
             ->heading('Project Milestones')
             ->paginated([5, 10, 25])

--- a/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidget.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidget.php
@@ -117,6 +117,10 @@ class ProjectWorkPipelineWidget extends TableWidget
 
                 return PipelineEntry::query()
                     ->whereHas('pipelineStage', fn (Builder $query) => $query->where('pipeline_id', $pipeline->getKey()))
+                    ->when(
+                        PipelineArchivingFeature::active(),
+                        fn (Builder $query): Builder => $query->withoutArchived(),
+                    )
                     ->with(['milestones', 'assets', 'serviceRequests', 'pipelineStage.pipeline.project']);
             })
             ->heading(fn (): View => $this->getTableHeadingView($pipeline))

--- a/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidget.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidget.php
@@ -43,6 +43,7 @@ use AidingApp\Project\Filament\Resources\Pipelines\PipelineResource;
 use AidingApp\Project\Models\Pipeline;
 use AidingApp\Project\Models\PipelineEntry;
 use AidingApp\Project\Models\Project;
+use App\Features\PipelineArchivingFeature;
 use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
 use Filament\Actions\EditAction;
@@ -80,6 +81,10 @@ class ProjectWorkPipelineWidget extends TableWidget
     {
         $this->selectedPipelineId = $this->record
             ->pipelines()
+            ->when(
+                PipelineArchivingFeature::active(),
+                fn (Builder $query): Builder => $query->withoutArchived(),
+            )
             ->oldest()
             ->value('id');
     }
@@ -92,6 +97,10 @@ class ProjectWorkPipelineWidget extends TableWidget
 
         return $this->record
             ->pipelines()
+            ->when(
+                PipelineArchivingFeature::active(),
+                fn (Builder $query): Builder => $query->withoutArchived(),
+            )
             ->whereKey($this->selectedPipelineId)
             ->first();
     }
@@ -232,6 +241,12 @@ class ProjectWorkPipelineWidget extends TableWidget
     protected function onPipelineSwitcherSelected(string $pipelineId): void
     {
         $this->selectedPipelineId = $pipelineId;
+        $this->resetTable();
+    }
+
+    protected function onPipelineSwitcherCleared(): void
+    {
+        $this->selectedPipelineId = null;
         $this->resetTable();
     }
 

--- a/app-modules/project/src/Livewire/PipelineEntryKanban.php
+++ b/app-modules/project/src/Livewire/PipelineEntryKanban.php
@@ -40,6 +40,7 @@ use AidingApp\Project\Filament\Resources\Pipelines\Forms\PipelineEntryForm;
 use AidingApp\Project\Filament\Resources\Pipelines\Resources\PipelineEntries\PipelineEntryResource;
 use AidingApp\Project\Models\Pipeline;
 use AidingApp\Project\Models\PipelineEntry;
+use App\Features\PipelineArchivingFeature;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
@@ -48,6 +49,7 @@ use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
 use Livewire\Component;
@@ -79,6 +81,10 @@ class PipelineEntryKanban extends Component implements HasForms, HasActions
          * @var Collection<int, PipelineEntry> $entries
          */
         $entries = $this->pipeline->entries()
+            ->when(
+                PipelineArchivingFeature::active(),
+                fn (Builder $query): Builder => $query->withoutArchived(),
+            )
             ->with(['assignedTo', 'pipelineStage'])
             ->withCount(['milestones', 'assets', 'serviceRequests'])
             ->oldest()

--- a/app-modules/project/src/Models/Pipeline.php
+++ b/app-modules/project/src/Models/Pipeline.php
@@ -101,11 +101,9 @@ class Pipeline extends BaseModel implements Auditable
     protected static function booted(): void
     {
         static::archived(function (Pipeline $pipeline): void {
-            $pipeline->stages()->withoutArchived()->get()->each->archive();
-        });
-
-        static::unarchived(function (Pipeline $pipeline): void {
-            $pipeline->stages()->onlyArchived()->get()->each->unarchive();
+            $pipeline->stages()->withoutArchived()->eachById(function (PipelineStage $stage): void {
+                $stage->archive();
+            });
         });
     }
 }

--- a/app-modules/project/src/Models/Pipeline.php
+++ b/app-modules/project/src/Models/Pipeline.php
@@ -101,11 +101,11 @@ class Pipeline extends BaseModel implements Auditable
     protected static function booted(): void
     {
         static::archived(function (Pipeline $pipeline): void {
-            $pipeline->entries()->withoutArchived()->get()->each->archive();
+            $pipeline->stages()->withoutArchived()->get()->each->archive();
         });
 
         static::unarchived(function (Pipeline $pipeline): void {
-            $pipeline->entries()->onlyArchived()->get()->each->unarchive();
+            $pipeline->stages()->onlyArchived()->get()->each->unarchive();
         });
     }
 }

--- a/app-modules/project/src/Models/Pipeline.php
+++ b/app-modules/project/src/Models/Pipeline.php
@@ -39,6 +39,7 @@ namespace AidingApp\Project\Models;
 use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\Project\Database\Factories\PipelineFactory;
 use App\Models\BaseModel;
+use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use CanyonGBS\Common\Models\Concerns\HasUserSaveTracking;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -56,6 +57,7 @@ class Pipeline extends BaseModel implements Auditable
     use HasFactory;
 
     use AuditableTrait;
+    use CanBeArchived;
     use HasUuids;
     use HasUserSaveTracking;
 
@@ -94,5 +96,16 @@ class Pipeline extends BaseModel implements Auditable
             'id',
             'id'
         );
+    }
+
+    protected static function booted(): void
+    {
+        static::archived(function (Pipeline $pipeline): void {
+            $pipeline->entries()->withoutArchived()->get()->each->archive();
+        });
+
+        static::unarchived(function (Pipeline $pipeline): void {
+            $pipeline->entries()->onlyArchived()->get()->each->unarchive();
+        });
     }
 }

--- a/app-modules/project/src/Models/PipelineEntry.php
+++ b/app-modules/project/src/Models/PipelineEntry.php
@@ -42,6 +42,7 @@ use AidingApp\Project\Database\Factories\PipelineEntryFactory;
 use AidingApp\Project\Observers\PipelineEntryObserver;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use App\Models\User;
+use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -67,6 +68,7 @@ class PipelineEntry extends Model implements Auditable
 
     use HasUuids;
     use AuditableTrait;
+    use CanBeArchived;
 
     protected $table = 'pipeline_entries';
 
@@ -85,6 +87,13 @@ class PipelineEntry extends Model implements Auditable
         'due' => 'datetime',
         'is_visible_to_guests' => 'boolean',
     ];
+
+    public function reevaluateLinkedMilestones(): void
+    {
+        $this->milestones()->get()->each(
+            fn (ProjectMilestone $milestone) => $milestone->reevaluateArchivedState(),
+        );
+    }
 
     /**
      * @return BelongsTo<PipelineStage, $this>
@@ -141,5 +150,11 @@ class PipelineEntry extends Model implements Auditable
             ->belongsToMany(ServiceRequest::class, 'pipeline_entry_service_requests', 'pipeline_entry_id', 'service_request_id')
             ->using(PipelineEntryServiceRequest::class)
             ->withTimestamps();
+    }
+
+    protected static function booted(): void
+    {
+        static::archived(fn (PipelineEntry $entry) => $entry->reevaluateLinkedMilestones());
+        static::unarchived(fn (PipelineEntry $entry) => $entry->reevaluateLinkedMilestones());
     }
 }

--- a/app-modules/project/src/Models/PipelineEntry.php
+++ b/app-modules/project/src/Models/PipelineEntry.php
@@ -90,8 +90,11 @@ class PipelineEntry extends Model implements Auditable
 
     public function reevaluateLinkedMilestones(): void
     {
-        $this->milestones()->get()->each(
-            fn (ProjectMilestone $milestone) => $milestone->reevaluateArchivedState(),
+        $this->milestones()->eachById(
+            function (ProjectMilestone $milestone): void {
+                $milestone->reevaluateArchivedState();
+            },
+            column: 'project_milestones.id',
         );
     }
 
@@ -155,6 +158,5 @@ class PipelineEntry extends Model implements Auditable
     protected static function booted(): void
     {
         static::archived(fn (PipelineEntry $entry) => $entry->reevaluateLinkedMilestones());
-        static::unarchived(fn (PipelineEntry $entry) => $entry->reevaluateLinkedMilestones());
     }
 }

--- a/app-modules/project/src/Models/PipelineStage.php
+++ b/app-modules/project/src/Models/PipelineStage.php
@@ -91,11 +91,9 @@ class PipelineStage extends BaseModel implements Auditable
     protected static function booted(): void
     {
         static::archived(function (PipelineStage $stage): void {
-            $stage->pipelineEntries()->withoutArchived()->get()->each->archive();
-        });
-
-        static::unarchived(function (PipelineStage $stage): void {
-            $stage->pipelineEntries()->onlyArchived()->get()->each->unarchive();
+            $stage->pipelineEntries()->withoutArchived()->eachById(function (PipelineEntry $entry): void {
+                $entry->archive();
+            });
         });
     }
 }

--- a/app-modules/project/src/Models/PipelineStage.php
+++ b/app-modules/project/src/Models/PipelineStage.php
@@ -40,6 +40,7 @@ use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\Project\Database\Factories\PipelineStageFactory;
 use AidingApp\Project\Enums\PipelineStageClassification;
 use App\Models\BaseModel;
+use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use CanyonGBS\Common\Models\Concerns\HasUserSaveTracking;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -56,6 +57,7 @@ class PipelineStage extends BaseModel implements Auditable
     use HasFactory;
 
     use AuditableTrait;
+    use CanBeArchived;
     use HasUuids;
     use HasUserSaveTracking;
 
@@ -84,5 +86,16 @@ class PipelineStage extends BaseModel implements Auditable
     public function pipelineEntries(): HasMany
     {
         return $this->hasMany(PipelineEntry::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::archived(function (PipelineStage $stage): void {
+            $stage->pipelineEntries()->withoutArchived()->get()->each->archive();
+        });
+
+        static::unarchived(function (PipelineStage $stage): void {
+            $stage->pipelineEntries()->onlyArchived()->get()->each->unarchive();
+        });
     }
 }

--- a/app-modules/project/src/Models/ProjectMilestone.php
+++ b/app-modules/project/src/Models/ProjectMilestone.php
@@ -111,7 +111,8 @@ class ProjectMilestone extends Model implements Auditable
                 'project_milestone_id',
                 'pipeline_entry_id',
             )
-            ->using(PipelineEntryMilestone::class);
+            ->using(PipelineEntryMilestone::class)
+            ->withTimestamps();
     }
 
     public function reevaluateArchivedState(): void

--- a/app-modules/project/src/Models/ProjectMilestone.php
+++ b/app-modules/project/src/Models/ProjectMilestone.php
@@ -125,12 +125,6 @@ class ProjectMilestone extends Model implements Auditable
 
         if (! $hasActiveTask && ! $this->isArchived()) {
             $this->archiveQuietly();
-
-            return;
-        }
-
-        if ($hasActiveTask && $this->isArchived()) {
-            $this->unarchiveQuietly();
         }
     }
 }

--- a/app-modules/project/src/Models/ProjectMilestone.php
+++ b/app-modules/project/src/Models/ProjectMilestone.php
@@ -116,9 +116,7 @@ class ProjectMilestone extends Model implements Auditable
 
     public function reevaluateArchivedState(): void
     {
-        $linkedTasksCount = $this->pipelineEntries()->count();
-
-        if ($linkedTasksCount === 0) {
+        if (! $this->pipelineEntries()->exists()) {
             return;
         }
 

--- a/app-modules/project/src/Models/ProjectMilestone.php
+++ b/app-modules/project/src/Models/ProjectMilestone.php
@@ -40,11 +40,13 @@ use AidingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
 use AidingApp\Project\Database\Factories\ProjectMilestoneFactory;
 use AidingApp\Project\Observers\ProjectMilestoneObserver;
 use App\Models\User;
+use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use OwenIt\Auditing\Contracts\Auditable;
 
@@ -60,6 +62,7 @@ class ProjectMilestone extends Model implements Auditable
     use HasUuids;
     use SoftDeletes;
     use AuditableTrait;
+    use CanBeArchived;
 
     protected $fillable = [
         'title',
@@ -94,5 +97,35 @@ class ProjectMilestone extends Model implements Auditable
     public function project(): BelongsTo
     {
         return $this->belongsTo(Project::class);
+    }
+
+    /**
+     * @return BelongsToMany<PipelineEntry, $this, PipelineEntryMilestone>
+     */
+    public function pipelineEntries(): BelongsToMany
+    {
+        return $this
+            ->belongsToMany(
+                PipelineEntry::class,
+                'pipeline_entry_milestones',
+                'project_milestone_id',
+                'pipeline_entry_id',
+            )
+            ->using(PipelineEntryMilestone::class);
+    }
+
+    public function reevaluateArchivedState(): void
+    {
+        $hasActiveTask = $this->pipelineEntries()->withoutArchived()->exists();
+
+        if (! $hasActiveTask && ! $this->isArchived()) {
+            $this->archiveQuietly();
+
+            return;
+        }
+
+        if ($hasActiveTask && $this->isArchived()) {
+            $this->unarchiveQuietly();
+        }
     }
 }

--- a/app-modules/project/src/Models/ProjectMilestone.php
+++ b/app-modules/project/src/Models/ProjectMilestone.php
@@ -116,6 +116,12 @@ class ProjectMilestone extends Model implements Auditable
 
     public function reevaluateArchivedState(): void
     {
+        $linkedTasksCount = $this->pipelineEntries()->count();
+
+        if ($linkedTasksCount === 0) {
+            return;
+        }
+
         $hasActiveTask = $this->pipelineEntries()->withoutArchived()->exists();
 
         if (! $hasActiveTask && ! $this->isArchived()) {

--- a/app-modules/project/tests/Tenant/Filament/Resources/Pipelines/Forms/PipelineEntryMilestoneSelectorTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Pipelines/Forms/PipelineEntryMilestoneSelectorTest.php
@@ -48,7 +48,7 @@ beforeEach(function () {
     asSuperAdmin(User::factory()->create());
 });
 
-it('excludes archived milestones from the related-milestones picker when the flag is active', function () {
+it('excludes archived milestones from the related-milestones picker', function () {
     $project = Project::factory()->create();
     $active = ProjectMilestone::factory()->for($project)->create();
     $archived = ProjectMilestone::factory()->for($project)->create();

--- a/app-modules/project/tests/Tenant/Filament/Resources/Pipelines/Forms/PipelineEntryMilestoneSelectorTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Pipelines/Forms/PipelineEntryMilestoneSelectorTest.php
@@ -34,38 +34,34 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Project\Filament\Tables;
-
+use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectWorkPipelineWidget;
+use AidingApp\Project\Filament\Tables\PipelineEntryMilestonesTable;
+use AidingApp\Project\Models\Project;
 use AidingApp\Project\Models\ProjectMilestone;
-use App\Features\PipelineArchivingFeature;
-use Filament\Tables\Columns\TextColumn;
+use App\Models\User;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
 
-class PipelineEntryMilestonesTable
-{
-    public static function configure(Table $table): Table
-    {
-        return $table
-            ->query(function () use ($table): Builder {
-                $projectId = $table->getArguments()['projectId'] ?? null;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
 
-                return ProjectMilestone::query()
-                    ->where('project_id', $projectId)
-                    ->when(
-                        PipelineArchivingFeature::active(),
-                        fn (Builder $query): Builder => $query->withoutArchived(),
-                    );
-            })
-            ->columns([
-                TextColumn::make('title')
-                    ->searchable()
-                    ->sortable(),
-                TextColumn::make('target_date')
-                    ->date()
-                    ->placeholder('N/A'),
-            ])
-            ->paginated([5])
-            ->defaultSort('created_at');
-    }
-}
+beforeEach(function () {
+    asSuperAdmin(User::factory()->create());
+});
+
+it('excludes archived milestones from the related-milestones picker when the flag is active', function () {
+    $project = Project::factory()->create();
+    $active = ProjectMilestone::factory()->for($project)->create();
+    $archived = ProjectMilestone::factory()->for($project)->create();
+    $archived->archive();
+
+    $component = livewire(ProjectWorkPipelineWidget::class, ['record' => $project])->instance();
+
+    $table = PipelineEntryMilestonesTable::configure(
+        Table::make($component)->arguments(['projectId' => $project->getKey()]),
+    );
+
+    $ids = $table->getQuery()->pluck('id');
+
+    expect($ids)->toContain($active->getKey())
+        ->and($ids)->not->toContain($archived->getKey());
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManageMilestonesTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManageMilestonesTest.php
@@ -118,6 +118,22 @@ it('can list milestones', function () {
         ->assertCanSeeTableRecords($project->milestones);
 });
 
+it('hides archived milestones when the archiving feature is active', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $active = ProjectMilestone::factory()->for($project)->create();
+    $archived = ProjectMilestone::factory()->for($project)->create();
+    $archived->archive();
+
+    livewire(ManageMilestones::class, [
+        'record' => $project->getRouteKey(),
+    ])
+        ->assertCanSeeTableRecords([$active])
+        ->assertCanNotSeeTableRecords([$archived]);
+});
+
 it('can validate create milestone inputs', function ($data, $errors) {
     asSuperAdmin();
 

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManageMilestonesTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManageMilestonesTest.php
@@ -118,7 +118,7 @@ it('can list milestones', function () {
         ->assertCanSeeTableRecords($project->milestones);
 });
 
-it('hides archived milestones when the archiving feature is active', function () {
+it('hides archived milestones', function () {
     asSuperAdmin();
 
     $project = Project::factory()->create();

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
@@ -234,6 +234,22 @@ it('can list milestones in the project milestones widget', function () {
         ->assertCanSeeTableRecords($milestones);
 });
 
+it('hides archived milestones in the project milestones widget when the archiving feature is active', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $active = ProjectMilestone::factory()->for($project)->create();
+    $archived = ProjectMilestone::factory()->for($project)->create();
+    $archived->archive();
+
+    livewire(ProjectMilestonesWidget::class, [
+        'record' => $project,
+    ])
+        ->assertCanSeeTableRecords([$active])
+        ->assertCanNotSeeTableRecords([$archived]);
+});
+
 it('can create a milestone through the project milestones widget create action', function () {
     asSuperAdmin();
 

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
@@ -234,7 +234,7 @@ it('can list milestones in the project milestones widget', function () {
         ->assertCanSeeTableRecords($milestones);
 });
 
-it('hides archived milestones in the project milestones widget when the archiving feature is active', function () {
+it('hides archived milestones in the project milestones widget', function () {
     asSuperAdmin();
 
     $project = Project::factory()->create();
@@ -373,7 +373,7 @@ it('rejects selecting a pipeline that belongs to another project', function () {
         ->assertSet('selectedPipelineId', $pipeline->getKey());
 });
 
-it('rejects selecting an archived pipeline when the archiving feature is active', function () {
+it('rejects selecting an archived pipeline', function () {
     asSuperAdmin();
 
     $project = Project::factory()->create();

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
@@ -357,6 +357,33 @@ it('rejects selecting a pipeline that belongs to another project', function () {
         ->assertSet('selectedPipelineId', $pipeline->getKey());
 });
 
+it('rejects selecting an archived pipeline when the archiving feature is active', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $pipeline = Pipeline::factory()
+        ->for($project)
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    $archivedPipeline = Pipeline::factory()
+        ->for($project)
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    $archivedPipeline->archive();
+
+    livewire(ProjectWorkPipelineWidget::class, [
+        'record' => $project,
+    ])
+        ->callAction('selectPipeline', data: [
+            'pipeline_id' => $archivedPipeline->getKey(),
+        ])
+        ->assertNotified('Invalid pipeline selection')
+        ->assertSet('selectedPipelineId', $pipeline->getKey());
+});
+
 it('can create a pipeline through the create pipeline action', function () {
     $undoRepeaterFake = Repeater::fake();
 

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/RelationManagers/PipelinesRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/RelationManagers/PipelinesRelationManagerTest.php
@@ -41,6 +41,7 @@ use AidingApp\Project\Models\Project;
 use App\Features\PipelineArchivingFeature;
 use App\Models\User;
 use Filament\Actions\Testing\TestAction;
+use Filament\Support\Icons\Heroicon;
 
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
@@ -94,6 +95,7 @@ it('archives a pipeline through the row action', function () {
         'ownerRecord' => $project,
         'pageClass' => ManagePipelines::class,
     ])
+        ->assertActionHasIcon(TestAction::make('archive')->table($pipeline), Heroicon::ArchiveBox)
         ->callAction(TestAction::make('archive')->table($pipeline))
         ->assertHasNoActionErrors();
 

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/RelationManagers/PipelinesRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/RelationManagers/PipelinesRelationManagerTest.php
@@ -50,14 +50,7 @@ beforeEach(function () {
     asSuperAdmin(User::factory()->create());
 });
 
-// The archiving flag is activated globally by the archiving migration (RefreshDatabase
-// runs it), matching how ProjectWorkPipelineWidgetTest treats the active default and
-// only ever calls deactivate() for the inactive cases. We still activate explicitly in
-// the active-path tests for clarity.
-
-it('hides archived pipelines when the archiving flag is active', function () {
-    PipelineArchivingFeature::activate();
-
+it('hides archived pipelines', function () {
     $project = Project::factory()->create();
     $active = Pipeline::factory()->for($project)->create(['created_by_id' => auth()->id()]);
     $archived = Pipeline::factory()->for($project)->create(['created_by_id' => auth()->id()]);
@@ -86,8 +79,6 @@ it('shows archived pipelines when the archiving flag is inactive', function () {
 });
 
 it('archives a pipeline through the row action', function () {
-    PipelineArchivingFeature::activate();
-
     $project = Project::factory()->create();
     $pipeline = Pipeline::factory()->for($project)->create(['created_by_id' => auth()->id()]);
 

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/RelationManagers/PipelinesRelationManagerTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/RelationManagers/PipelinesRelationManagerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Project\Filament\Resources\Projects\Pages\ManagePipelines;
+use AidingApp\Project\Filament\Resources\Projects\RelationManagers\PipelinesRelationManager;
+use AidingApp\Project\Models\Pipeline;
+use AidingApp\Project\Models\Project;
+use App\Features\PipelineArchivingFeature;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+beforeEach(function () {
+    asSuperAdmin(User::factory()->create());
+});
+
+// The archiving flag is activated globally by the archiving migration (RefreshDatabase
+// runs it), matching how ProjectWorkPipelineWidgetTest treats the active default and
+// only ever calls deactivate() for the inactive cases. We still activate explicitly in
+// the active-path tests for clarity.
+
+it('hides archived pipelines when the archiving flag is active', function () {
+    PipelineArchivingFeature::activate();
+
+    $project = Project::factory()->create();
+    $active = Pipeline::factory()->for($project)->create(['created_by_id' => auth()->id()]);
+    $archived = Pipeline::factory()->for($project)->create(['created_by_id' => auth()->id()]);
+    $archived->archive();
+
+    livewire(PipelinesRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManagePipelines::class,
+    ])
+        ->assertCanSeeTableRecords([$active])
+        ->assertCanNotSeeTableRecords([$archived]);
+});
+
+it('shows archived pipelines when the archiving flag is inactive', function () {
+    PipelineArchivingFeature::deactivate();
+    $project = Project::factory()->create();
+    $active = Pipeline::factory()->for($project)->create(['created_by_id' => auth()->id()]);
+    $archived = Pipeline::factory()->for($project)->create(['created_by_id' => auth()->id()]);
+    $archived->archive();
+
+    livewire(PipelinesRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManagePipelines::class,
+    ])
+        ->assertCanSeeTableRecords([$active, $archived]);
+});
+
+it('archives a pipeline through the row action', function () {
+    PipelineArchivingFeature::activate();
+
+    $project = Project::factory()->create();
+    $pipeline = Pipeline::factory()->for($project)->create(['created_by_id' => auth()->id()]);
+
+    livewire(PipelinesRelationManager::class, [
+        'ownerRecord' => $project,
+        'pageClass' => ManagePipelines::class,
+    ])
+        ->callAction(TestAction::make('archive')->table($pipeline))
+        ->assertHasNoActionErrors();
+
+    expect($pipeline->refresh()->isArchived())->toBeTrue();
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
@@ -37,6 +37,8 @@
 use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectWorkPipelineWidget;
 use AidingApp\Project\Filament\Tables\ProjectPipelinesTable;
 use AidingApp\Project\Models\Pipeline;
+use AidingApp\Project\Models\PipelineEntry;
+use AidingApp\Project\Models\PipelineStage;
 use AidingApp\Project\Models\Project;
 use App\Features\PipelineArchivingFeature;
 use App\Models\User;
@@ -131,6 +133,26 @@ it('clears the selection when the last pipeline is archived', function () {
     livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
         ->call('archivePipelineFromSwitcher', $only->getKey())
         ->assertSet('selectedPipelineId', null);
+});
+
+it('excludes archived tasks from the pipeline board when the flag is active', function () {
+    $project = Project::factory()->create();
+    $pipeline = Pipeline::factory()->for($project)->create();
+    $stage = PipelineStage::factory()->for($pipeline)->create();
+
+    $active = PipelineEntry::factory()->for($stage, 'pipelineStage')->create([
+        'assigned_to_id' => null,
+        'assigned_to_type' => null,
+    ]);
+    $archived = PipelineEntry::factory()->for($stage, 'pipelineStage')->create([
+        'assigned_to_id' => null,
+        'assigned_to_type' => null,
+    ]);
+    $archived->archive();
+
+    livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+        ->assertCanSeeTableRecords([$active])
+        ->assertCanNotSeeTableRecords([$archived]);
 });
 
 describe('feature flag inactive', function () {

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
@@ -135,7 +135,7 @@ it('clears the selection when the last pipeline is archived', function () {
         ->assertSet('selectedPipelineId', null);
 });
 
-it('excludes archived tasks from the pipeline board when the flag is active', function () {
+it('excludes archived tasks from the pipeline board', function () {
     $project = Project::factory()->create();
     $pipeline = Pipeline::factory()->for($project)->create();
     $stage = PipelineStage::factory()->for($pipeline)->create();

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
@@ -72,6 +72,22 @@ it('archives the checked pipeline and cascades to its tasks', function () {
         ->and($active->refresh()->isArchived())->toBeFalse();
 });
 
+it('archives the checked pipeline through the switcher footer archive action', function () {
+    $project = Project::factory()->create();
+    $active = Pipeline::factory()->for($project)->create();
+    $other = Pipeline::factory()->for($project)->create();
+
+    livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+        ->mountAction('selectPipeline')
+        ->setActionData(['pipeline_id' => $active->getKey()])
+        ->mountAction('archivePipeline')
+        ->callMountedAction()
+        ->assertSet('selectedPipelineId', $other->getKey());
+
+    expect($active->refresh()->isArchived())->toBeTrue()
+        ->and($other->refresh()->isArchived())->toBeFalse();
+});
+
 it('re-selects the oldest remaining pipeline after archiving the active one', function () {
     $project = Project::factory()->create();
     $active = Pipeline::factory()->for($project)->create();

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
@@ -55,3 +55,35 @@ it('defaults the widget to the oldest non-archived pipeline', function () {
     livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
         ->assertSet('selectedPipelineId', $newer->getKey());
 });
+
+it('archives the checked pipeline and cascades to its tasks', function () {
+    $project = Project::factory()->create();
+    $active = Pipeline::factory()->for($project)->create();
+    $other = Pipeline::factory()->for($project)->create();
+
+    livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+        ->call('archivePipelineFromSwitcher', $other->getKey());
+
+    expect($other->refresh()->isArchived())->toBeTrue()
+        ->and($active->refresh()->isArchived())->toBeFalse();
+});
+
+it('re-selects the oldest remaining pipeline after archiving the active one', function () {
+    $project = Project::factory()->create();
+    $active = Pipeline::factory()->for($project)->create();
+    $next = Pipeline::factory()->for($project)->create();
+
+    livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+        ->assertSet('selectedPipelineId', $active->getKey())
+        ->call('archivePipelineFromSwitcher', $active->getKey())
+        ->assertSet('selectedPipelineId', $next->getKey());
+});
+
+it('clears the selection when the last pipeline is archived', function () {
+    $project = Project::factory()->create();
+    $only = Pipeline::factory()->for($project)->create();
+
+    livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+        ->call('archivePipelineFromSwitcher', $only->getKey())
+        ->assertSet('selectedPipelineId', null);
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
@@ -35,10 +35,14 @@
 */
 
 use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectWorkPipelineWidget;
+use AidingApp\Project\Filament\Tables\ProjectPipelinesTable;
 use AidingApp\Project\Models\Pipeline;
 use AidingApp\Project\Models\Project;
+use App\Features\PipelineArchivingFeature;
 use App\Models\User;
+use Filament\Tables\Table;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
@@ -86,4 +90,79 @@ it('clears the selection when the last pipeline is archived', function () {
     livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
         ->call('archivePipelineFromSwitcher', $only->getKey())
         ->assertSet('selectedPipelineId', null);
+});
+
+describe('feature flag inactive', function () {
+    it('keeps archived pipelines in the switcher list when the flag is inactive', function () {
+        PipelineArchivingFeature::deactivate();
+
+        $project = Project::factory()->create();
+        $active = Pipeline::factory()->for($project)->create();
+        $archived = Pipeline::factory()->for($project)->create();
+        $archived->archive();
+
+        $table = ProjectPipelinesTable::configure(
+            Table::make(livewire(ProjectWorkPipelineWidget::class, ['record' => $project])->instance())
+                ->arguments(['projectId' => $project->getKey()]),
+        );
+
+        $ids = $table->getQuery()->pluck('id');
+
+        expect($ids)->toContain($active->getKey())
+            ->and($ids)->toContain($archived->getKey());
+    });
+
+    it('hides the footer archive control when the flag is inactive', function () {
+        PipelineArchivingFeature::deactivate();
+
+        $project = Project::factory()->create();
+        Pipeline::factory()->for($project)->create();
+
+        livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+            ->mountAction('selectPipeline')
+            ->assertActionHidden('archivePipeline');
+    });
+
+    it('does not archive when archivePipelineFromSwitcher is called directly while the flag is inactive', function () {
+        PipelineArchivingFeature::deactivate();
+
+        $project = Project::factory()->create();
+        $pipeline = Pipeline::factory()->for($project)->create();
+
+        livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+            ->call('archivePipelineFromSwitcher', $pipeline->getKey());
+
+        expect($pipeline->refresh()->isArchived())->toBeFalse();
+    });
+});
+
+describe('archive authorization', function () {
+    it('does not archive when the acting user lacks the pipeline delete ability', function () {
+        $user = User::factory()->create();
+        $user->givePermissionTo('pipeline.view-any');
+        $user->refresh();
+        actingAs($user);
+
+        $project = Project::factory()->create();
+        $pipeline = Pipeline::factory()->for($project)->create();
+
+        livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+            ->call('archivePipelineFromSwitcher', $pipeline->getKey());
+
+        expect($pipeline->refresh()->isArchived())->toBeFalse();
+    });
+
+    it('hides the footer archive control from a user lacking the pipeline delete ability', function () {
+        $user = User::factory()->create();
+        $user->givePermissionTo('pipeline.view-any');
+        $user->refresh();
+        actingAs($user);
+
+        $project = Project::factory()->create();
+        Pipeline::factory()->for($project)->create();
+
+        livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+            ->mountAction('selectPipeline')
+            ->assertActionHidden('archivePipeline');
+    });
 });

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
@@ -88,6 +88,31 @@ it('archives the checked pipeline through the switcher footer archive action', f
         ->and($other->refresh()->isArchived())->toBeFalse();
 });
 
+it('keeps the switcher modal open after archiving when other pipelines remain', function () {
+    $project = Project::factory()->create();
+    $active = Pipeline::factory()->for($project)->create();
+    Pipeline::factory()->for($project)->create();
+
+    livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+        ->mountAction('selectPipeline')
+        ->setActionData(['pipeline_id' => $active->getKey()])
+        ->mountAction('archivePipeline')
+        ->callMountedAction()
+        ->assertActionMounted('selectPipeline');
+});
+
+it('closes the switcher modal after archiving the last remaining pipeline', function () {
+    $project = Project::factory()->create();
+    $only = Pipeline::factory()->for($project)->create();
+
+    livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+        ->mountAction('selectPipeline')
+        ->setActionData(['pipeline_id' => $only->getKey()])
+        ->mountAction('archivePipeline')
+        ->callMountedAction()
+        ->assertActionNotMounted();
+});
+
 it('re-selects the oldest remaining pipeline after archiving the active one', function () {
     $project = Project::factory()->create();
     $active = Pipeline::factory()->for($project)->create();

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectWorkPipelineWidget;
+use AidingApp\Project\Models\Pipeline;
+use AidingApp\Project\Models\Project;
+use App\Models\User;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+beforeEach(function () {
+    asSuperAdmin(User::factory()->create());
+});
+
+it('defaults the widget to the oldest non-archived pipeline', function () {
+    $project = Project::factory()->create();
+    $oldest = Pipeline::factory()->for($project)->create();
+    $newer = Pipeline::factory()->for($project)->create();
+    $oldest->archive();
+
+    livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+        ->assertSet('selectedPipelineId', $newer->getKey());
+});

--- a/app-modules/project/tests/Tenant/Filament/Tables/ProjectPipelinesTableTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Tables/ProjectPipelinesTableTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -34,45 +34,29 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Project\Filament\Tables;
-
 use AidingApp\Project\Models\Pipeline;
+use AidingApp\Project\Models\Project;
 use App\Features\PipelineArchivingFeature;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 
-class ProjectPipelinesTable
-{
-    public static function configure(Table $table): Table
-    {
-        return $table
-            ->query(function () use ($table): Builder {
-                $projectId = $table->getArguments()['projectId'] ?? null;
+it('excludes archived pipelines from the switcher list when the flag is active', function () {
+    $project = Project::factory()->create();
+    $active = Pipeline::factory()->for($project)->create();
+    $archived = Pipeline::factory()->for($project)->create();
+    $archived->archive();
 
-                return Pipeline::query()
-                    ->where('project_id', $projectId)
-                    ->when(
-                        PipelineArchivingFeature::active(),
-                        fn (Builder $query): Builder => $query->withoutArchived(),
-                    );
-            })
-            ->columns([
-                TextColumn::make('name')
-                    ->label('Pipeline')
-                    ->searchable()
-                    ->sortable(),
-                TextColumn::make('stages_count')
-                    ->label('Stages')
-                    ->counts('stages'),
-                TextColumn::make('entries_count')
-                    ->label('Entries')
-                    ->counts('entries'),
-                TextColumn::make('created_at')
-                    ->label('Created')
-                    ->dateTime()
-                    ->sortable(),
-            ])
-            ->defaultSort('created_at');
-    }
-}
+    // Simulate the query from ProjectPipelinesTable::configure()
+    $projectId = $project->getKey();
+
+    $query = Pipeline::query()
+        ->where('project_id', $projectId)
+        ->when(
+            PipelineArchivingFeature::active(),
+            fn (Builder $query): Builder => $query->withoutArchived(),
+        );
+
+    $ids = $query->pluck('id');
+
+    expect($ids)->toContain($active->getKey())
+        ->and($ids)->not->toContain($archived->getKey());
+});

--- a/app-modules/project/tests/Tenant/Filament/Tables/ProjectPipelinesTableTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Tables/ProjectPipelinesTableTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Aiding App® are registered trademarks of
@@ -34,10 +34,19 @@
 </COPYRIGHT>
 */
 
+use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectWorkPipelineWidget;
+use AidingApp\Project\Filament\Tables\ProjectPipelinesTable;
 use AidingApp\Project\Models\Pipeline;
 use AidingApp\Project\Models\Project;
-use App\Features\PipelineArchivingFeature;
-use Illuminate\Database\Eloquent\Builder;
+use App\Models\User;
+use Filament\Tables\Table;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+beforeEach(function () {
+    asSuperAdmin(User::factory()->create());
+});
 
 it('excludes archived pipelines from the switcher list when the flag is active', function () {
     $project = Project::factory()->create();
@@ -45,17 +54,13 @@ it('excludes archived pipelines from the switcher list when the flag is active',
     $archived = Pipeline::factory()->for($project)->create();
     $archived->archive();
 
-    // Simulate the query from ProjectPipelinesTable::configure()
-    $projectId = $project->getKey();
+    $component = livewire(ProjectWorkPipelineWidget::class, ['record' => $project])->instance();
 
-    $query = Pipeline::query()
-        ->where('project_id', $projectId)
-        ->when(
-            PipelineArchivingFeature::active(),
-            fn (Builder $query): Builder => $query->withoutArchived(),
-        );
+    $table = ProjectPipelinesTable::configure(
+        Table::make($component)->arguments(['projectId' => $project->getKey()]),
+    );
 
-    $ids = $query->pluck('id');
+    $ids = $table->getQuery()->pluck('id');
 
     expect($ids)->toContain($active->getKey())
         ->and($ids)->not->toContain($archived->getKey());

--- a/app-modules/project/tests/Tenant/Filament/Tables/ProjectPipelinesTableTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Tables/ProjectPipelinesTableTest.php
@@ -48,7 +48,7 @@ beforeEach(function () {
     asSuperAdmin(User::factory()->create());
 });
 
-it('excludes archived pipelines from the switcher list when the flag is active', function () {
+it('excludes archived pipelines from the switcher list', function () {
     $project = Project::factory()->create();
     $active = Pipeline::factory()->for($project)->create();
     $archived = Pipeline::factory()->for($project)->create();

--- a/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
+++ b/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
@@ -126,6 +126,31 @@ it('renders modern card metadata with assignment and due tooltip', function () {
     Carbon::setTestNow();
 });
 
+it('hides archived tasks from the kanban board when the archiving feature is active', function () {
+    asSuperAdmin();
+
+    $pipeline = Pipeline::factory()
+        ->for(Project::factory()->create())
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    $stageId = $pipeline->stages->first()->getKey();
+
+    $active = PipelineEntry::factory()->create([
+        'name' => 'Active Task',
+        'pipeline_stage_id' => $stageId,
+    ]);
+    $archived = PipelineEntry::factory()->create([
+        'name' => 'Archived Task',
+        'pipeline_stage_id' => $stageId,
+    ]);
+    $archived->archive();
+
+    livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
+        ->assertSee($active->name)
+        ->assertDontSee($archived->name);
+});
+
 it('renders stages in order sequence on the kanban board', function () {
     asSuperAdmin();
 

--- a/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
+++ b/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
@@ -126,7 +126,7 @@ it('renders modern card metadata with assignment and due tooltip', function () {
     Carbon::setTestNow();
 });
 
-it('hides archived tasks from the kanban board when the archiving feature is active', function () {
+it('hides archived tasks from the kanban board', function () {
     asSuperAdmin();
 
     $pipeline = Pipeline::factory()

--- a/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
+++ b/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
@@ -55,17 +55,6 @@ it('archives a milestone once it has no remaining non-archived linked task', fun
     expect($milestone->refresh()->isArchived())->toBeTrue();
 });
 
-it('unarchives a milestone when a linked task becomes active again', function () {
-    $milestone = ProjectMilestone::factory()->create();
-    $entry = PipelineEntry::factory()->create();
-    $entry->milestones()->attach($milestone);
-    $entry->archive();
-
-    $entry->unarchive();
-
-    expect($milestone->refresh()->isArchived())->toBeFalse();
-});
-
 it('leaves a milestone with no linked tasks untouched', function () {
     $milestone = ProjectMilestone::factory()->create();
 
@@ -91,7 +80,7 @@ it('keeps a milestone active while it still has a task in another active pipelin
     expect($milestone->refresh()->isArchived())->toBeTrue();
 });
 
-it('archives all of a pipeline\'s tasks when the pipeline is archived, and restores them on unarchive', function () {
+it('archives all of a pipeline\'s tasks when the pipeline is archived', function () {
     $pipeline = Pipeline::factory()->create();
     $stage = PipelineStage::factory()->for($pipeline)->create();
     // Entries are created without an assignee: assignment is orthogonal to archiving,
@@ -108,10 +97,6 @@ it('archives all of a pipeline\'s tasks when the pipeline is archived, and resto
     $pipeline->archive();
 
     $entries->each(fn (PipelineEntry $entry) => expect($entry->refresh()->isArchived())->toBeTrue());
-
-    $pipeline->unarchive();
-
-    $entries->each(fn (PipelineEntry $entry) => expect($entry->refresh()->isArchived())->toBeFalse());
 });
 
 it('archives a milestone linked only to tasks in the archived pipeline', function () {
@@ -126,20 +111,16 @@ it('archives a milestone linked only to tasks in the archived pipeline', functio
     expect($milestone->refresh()->isArchived())->toBeTrue();
 });
 
-it('archives a pipeline\'s stages when the pipeline is archived, and restores them on unarchive', function () {
+it('archives a pipeline\'s stages when the pipeline is archived', function () {
     $pipeline = Pipeline::factory()->create();
     $stages = PipelineStage::factory()->count(2)->for($pipeline)->create();
 
     $pipeline->archive();
 
     $stages->each(fn (PipelineStage $stage) => expect($stage->refresh()->isArchived())->toBeTrue());
-
-    $pipeline->unarchive();
-
-    $stages->each(fn (PipelineStage $stage) => expect($stage->refresh()->isArchived())->toBeFalse());
 });
 
-it('archives a stage\'s non-archived tasks when the stage is archived, and restores them on unarchive', function () {
+it('archives a stage\'s non-archived tasks when the stage is archived', function () {
     $stage = PipelineStage::factory()->for(Pipeline::factory())->create();
     $entries = PipelineEntry::factory()
         ->count(3)
@@ -150,8 +131,7 @@ it('archives a stage\'s non-archived tasks when the stage is archived, and resto
         ]);
 
     // One task is archived independently, before the stage cascade runs. The archive
-    // cascade uses withoutArchived() (so it is left as-is), and the unarchive cascade
-    // uses onlyArchived() (so it is restored alongside the cascade-archived tasks).
+    // cascade uses withoutArchived(), so the pre-archived task is left untouched.
     $preArchived = PipelineEntry::factory()->for($stage, 'pipelineStage')->create([
         'assigned_to_id' => null,
         'assigned_to_type' => null,
@@ -163,12 +143,6 @@ it('archives a stage\'s non-archived tasks when the stage is archived, and resto
     expect($stage->refresh()->isArchived())->toBeTrue();
     $entries->each(fn (PipelineEntry $entry) => expect($entry->refresh()->isArchived())->toBeTrue());
     expect($preArchived->refresh()->isArchived())->toBeTrue();
-
-    $stage->unarchive();
-
-    expect($stage->refresh()->isArchived())->toBeFalse();
-    $entries->each(fn (PipelineEntry $entry) => expect($entry->refresh()->isArchived())->toBeFalse());
-    expect($preArchived->refresh()->isArchived())->toBeFalse();
 });
 
 it('rolls back the whole cascade when a child archive fails through the switcher', function () {

--- a/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
+++ b/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
@@ -120,6 +120,19 @@ it('archives a milestone linked only to tasks in the archived pipeline', functio
     expect($milestone->refresh()->isArchived())->toBeTrue();
 });
 
+it('archives a pipeline\'s stages when the pipeline is archived, and restores them on unarchive', function () {
+    $pipeline = Pipeline::factory()->create();
+    $stages = PipelineStage::factory()->count(2)->for($pipeline)->create();
+
+    $pipeline->archive();
+
+    $stages->each(fn (PipelineStage $stage) => expect($stage->refresh()->isArchived())->toBeTrue());
+
+    $pipeline->unarchive();
+
+    $stages->each(fn (PipelineStage $stage) => expect($stage->refresh()->isArchived())->toBeFalse());
+});
+
 it('archives a stage\'s non-archived tasks when the stage is archived, and restores them on unarchive', function () {
     $stage = PipelineStage::factory()->for(Pipeline::factory())->create();
     $entries = PipelineEntry::factory()

--- a/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
+++ b/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
@@ -149,35 +149,26 @@ it('archives a stage\'s non-archived tasks when the stage is archived, and resto
             'assigned_to_type' => null,
         ]);
 
+    // One task is archived independently, before the stage cascade runs. The archive
+    // cascade uses withoutArchived() (so it is left as-is), and the unarchive cascade
+    // uses onlyArchived() (so it is restored alongside the cascade-archived tasks).
+    $preArchived = PipelineEntry::factory()->for($stage, 'pipelineStage')->create([
+        'assigned_to_id' => null,
+        'assigned_to_type' => null,
+    ]);
+    $preArchived->archive();
+
     $stage->archive();
 
     expect($stage->refresh()->isArchived())->toBeTrue();
     $entries->each(fn (PipelineEntry $entry) => expect($entry->refresh()->isArchived())->toBeTrue());
+    expect($preArchived->refresh()->isArchived())->toBeTrue();
 
     $stage->unarchive();
 
     expect($stage->refresh()->isArchived())->toBeFalse();
     $entries->each(fn (PipelineEntry $entry) => expect($entry->refresh()->isArchived())->toBeFalse());
-});
-
-it('leaves an already-archived task untouched when its stage is unarchived', function () {
-    $stage = PipelineStage::factory()->for(Pipeline::factory())->create();
-    $active = PipelineEntry::factory()->for($stage, 'pipelineStage')->create([
-        'assigned_to_id' => null,
-        'assigned_to_type' => null,
-    ]);
-    $manuallyArchived = PipelineEntry::factory()->for($stage, 'pipelineStage')->create([
-        'assigned_to_id' => null,
-        'assigned_to_type' => null,
-    ]);
-
-    $stage->archive();
-    $manuallyArchived->refresh();
-
-    $stage->unarchive();
-
-    expect($active->refresh()->isArchived())->toBeFalse()
-        ->and($manuallyArchived->refresh()->isArchived())->toBeFalse();
+    expect($preArchived->refresh()->isArchived())->toBeFalse();
 });
 
 it('rolls back the whole cascade when a child archive fails through the switcher', function () {

--- a/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
+++ b/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
@@ -119,3 +119,44 @@ it('archives a milestone linked only to tasks in the archived pipeline', functio
 
     expect($milestone->refresh()->isArchived())->toBeTrue();
 });
+
+it('archives a stage\'s non-archived tasks when the stage is archived, and restores them on unarchive', function () {
+    $stage = PipelineStage::factory()->for(Pipeline::factory())->create();
+    $entries = PipelineEntry::factory()
+        ->count(3)
+        ->for($stage, 'pipelineStage')
+        ->create([
+            'assigned_to_id' => null,
+            'assigned_to_type' => null,
+        ]);
+
+    $stage->archive();
+
+    expect($stage->refresh()->isArchived())->toBeTrue();
+    $entries->each(fn (PipelineEntry $entry) => expect($entry->refresh()->isArchived())->toBeTrue());
+
+    $stage->unarchive();
+
+    expect($stage->refresh()->isArchived())->toBeFalse();
+    $entries->each(fn (PipelineEntry $entry) => expect($entry->refresh()->isArchived())->toBeFalse());
+});
+
+it('leaves an already-archived task untouched when its stage is unarchived', function () {
+    $stage = PipelineStage::factory()->for(Pipeline::factory())->create();
+    $active = PipelineEntry::factory()->for($stage, 'pipelineStage')->create([
+        'assigned_to_id' => null,
+        'assigned_to_type' => null,
+    ]);
+    $manuallyArchived = PipelineEntry::factory()->for($stage, 'pipelineStage')->create([
+        'assigned_to_id' => null,
+        'assigned_to_type' => null,
+    ]);
+
+    $stage->archive();
+    $manuallyArchived->refresh();
+
+    $stage->unarchive();
+
+    expect($active->refresh()->isArchived())->toBeFalse()
+        ->and($manuallyArchived->refresh()->isArchived())->toBeFalse();
+});

--- a/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
+++ b/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Project\Models\PipelineEntry;
+use AidingApp\Project\Models\ProjectMilestone;
+
+it('archives a milestone once it has no remaining non-archived linked task', function () {
+    $milestone = ProjectMilestone::factory()->create();
+    $entry = PipelineEntry::factory()->create();
+    $entry->milestones()->attach($milestone);
+
+    $entry->archive();
+
+    expect($milestone->refresh()->isArchived())->toBeTrue();
+});
+
+it('unarchives a milestone when a linked task becomes active again', function () {
+    $milestone = ProjectMilestone::factory()->create();
+    $entry = PipelineEntry::factory()->create();
+    $entry->milestones()->attach($milestone);
+    $entry->archive();
+
+    $entry->unarchive();
+
+    expect($milestone->refresh()->isArchived())->toBeFalse();
+});
+
+it('leaves a milestone with no linked tasks untouched', function () {
+    $milestone = ProjectMilestone::factory()->create();
+
+    $milestone->reevaluateArchivedState();
+
+    expect($milestone->refresh()->isArchived())->toBeFalse();
+});

--- a/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
+++ b/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
@@ -65,3 +65,20 @@ it('leaves a milestone with no linked tasks untouched', function () {
 
     expect($milestone->refresh()->isArchived())->toBeFalse();
 });
+
+it('keeps a milestone active while it still has a task in another active pipeline', function () {
+    $milestone = ProjectMilestone::factory()->create();
+
+    $entryA = PipelineEntry::factory()->create();
+    $entryB = PipelineEntry::factory()->create();
+    $entryA->milestones()->attach($milestone);
+    $entryB->milestones()->attach($milestone);
+
+    $entryA->archive();
+
+    expect($milestone->refresh()->isArchived())->toBeFalse();
+
+    $entryB->archive();
+
+    expect($milestone->refresh()->isArchived())->toBeTrue();
+});

--- a/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
+++ b/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
@@ -34,7 +34,9 @@
 </COPYRIGHT>
 */
 
+use AidingApp\Project\Models\Pipeline;
 use AidingApp\Project\Models\PipelineEntry;
+use AidingApp\Project\Models\PipelineStage;
 use AidingApp\Project\Models\ProjectMilestone;
 
 it('archives a milestone once it has no remaining non-archived linked task', function () {
@@ -79,6 +81,41 @@ it('keeps a milestone active while it still has a task in another active pipelin
     expect($milestone->refresh()->isArchived())->toBeFalse();
 
     $entryB->archive();
+
+    expect($milestone->refresh()->isArchived())->toBeTrue();
+});
+
+it('archives all of a pipeline\'s tasks when the pipeline is archived, and restores them on unarchive', function () {
+    $pipeline = Pipeline::factory()->create();
+    $stage = PipelineStage::factory()->for($pipeline)->create();
+    // Entries are created without an assignee: assignment is orthogonal to archiving,
+    // and refreshing an assigned entry trips an unrelated pre-existing quirk in the
+    // assignedTo() morphTo (relation name "assigned_to" has no matching method).
+    $entries = PipelineEntry::factory()
+        ->count(3)
+        ->for($stage, 'pipelineStage')
+        ->create([
+            'assigned_to_id' => null,
+            'assigned_to_type' => null,
+        ]);
+
+    $pipeline->archive();
+
+    $entries->each(fn (PipelineEntry $entry) => expect($entry->refresh()->isArchived())->toBeTrue());
+
+    $pipeline->unarchive();
+
+    $entries->each(fn (PipelineEntry $entry) => expect($entry->refresh()->isArchived())->toBeFalse());
+});
+
+it('archives a milestone linked only to tasks in the archived pipeline', function () {
+    $pipeline = Pipeline::factory()->create();
+    $stage = PipelineStage::factory()->for($pipeline)->create();
+    $entry = PipelineEntry::factory()->for($stage, 'pipelineStage')->create();
+    $milestone = ProjectMilestone::factory()->create();
+    $entry->milestones()->attach($milestone);
+
+    $pipeline->archive();
 
     expect($milestone->refresh()->isArchived())->toBeTrue();
 });

--- a/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
+++ b/app-modules/project/tests/Tenant/PipelineArchivingFeatureCascadeTest.php
@@ -34,10 +34,16 @@
 </COPYRIGHT>
 */
 
+use AidingApp\Project\Filament\Resources\Projects\Widgets\ProjectWorkPipelineWidget;
 use AidingApp\Project\Models\Pipeline;
 use AidingApp\Project\Models\PipelineEntry;
 use AidingApp\Project\Models\PipelineStage;
+use AidingApp\Project\Models\Project;
 use AidingApp\Project\Models\ProjectMilestone;
+use App\Models\User;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
 
 it('archives a milestone once it has no remaining non-archived linked task', function () {
     $milestone = ProjectMilestone::factory()->create();
@@ -172,4 +178,32 @@ it('leaves an already-archived task untouched when its stage is unarchived', fun
 
     expect($active->refresh()->isArchived())->toBeFalse()
         ->and($manuallyArchived->refresh()->isArchived())->toBeFalse();
+});
+
+it('rolls back the whole cascade when a child archive fails through the switcher', function () {
+    asSuperAdmin(User::factory()->create());
+
+    $project = Project::factory()->create();
+    $pipeline = Pipeline::factory()->for($project)->create();
+    $stage = PipelineStage::factory()->for($pipeline)->create();
+    PipelineEntry::factory()->for($stage, 'pipelineStage')->create([
+        'assigned_to_id' => null,
+        'assigned_to_type' => null,
+    ]);
+
+    // Force a failure partway through the cascade (after the pipeline and stage
+    // rows have already been written, before the entry is archived).
+    PipelineEntry::archiving(function (): void {
+        throw new RuntimeException('boom');
+    });
+
+    try {
+        livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+            ->call('archivePipelineFromSwitcher', $pipeline->getKey());
+    } catch (Throwable) {
+        // Expected: the forced failure propagates out of the transaction.
+    }
+
+    expect($pipeline->refresh()->isArchived())->toBeFalse()
+        ->and($stage->refresh()->isArchived())->toBeFalse();
 });

--- a/app/Features/PipelineArchivingFeature.php
+++ b/app/Features/PipelineArchivingFeature.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class PipelineArchivingFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1371

### Technical Description

Moves pipeline management into the slide-over pipeline switcher and adds the ability to archive a pipeline, with the whole change gated behind the `PipelineArchivingFeature` flag.

**Archiving model**

- Adds an `archived_at` column to `pipelines` and `pipeline_stages` (via the `CanBeArchived` trait), so both are archivable.
- Archiving cascades along ownership: archiving a `Pipeline` archives its `PipelineStage`s, which archive their `PipelineEntry`s (tasks). Each entry then re-evaluates its linked `ProjectMilestone`s — a milestone is archived once it has no remaining active linked task. There is no user-facing unarchive flow, so the cascade is one-directional (archive only).
- `ProjectMilestone` gains a `reevaluateArchivedState()` invariant helper that owns this milestone-follows-its-tasks rule, using a quiet archive to avoid feedback loops.
- Ownership cascades iterate with `eachById()` so large graphs are chunked rather than loaded into memory all at once.

**Atomicity**

- The vendor `CanBeArchived::archive()` fires the cascade synchronously and is not itself transactional, so both archive entry points wrap it in `DB::transaction()` — the switcher footer action and the relation-manager row action — ensuring a mid-cascade failure rolls the whole graph back.

**UI**

- The pipeline switcher slide-over hides archived pipelines from its list, exposes an **Archive** footer action (confirmation modal), and clears the current selection / advances to the next pipeline when the active one is archived or none remain.
- Archived milestones and tasks are hidden from their list surfaces — the project milestones page and widget, and the pipeline task (kanban) board — consistent with the switcher and milestone-selector filtering.
- Archived milestones are excluded from the task form's milestone selector.
- The projects `PipelinesRelationManager` hides archived pipelines and gains an **Archive** row action (with an archive-box icon) consistent with the switcher.

All new behaviour resolves to the old path when the feature flag is inactive.

### Any deployment steps required?

No

### Cleanup Tasks

Yes, Feature Flag: `App\Features\PipelineArchivingFeature` — `.cleanup-tasks/2026_08_07_pipeline_archiving_cleanup.md`

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
