### PR TITLE
[AIDAPP-1384]: Update SLA management to exclude time in the waiting classification

### DIFF
--- a/.cleanup-tasks/2026_08_12_sla_waiting_exclusion_feature.md
+++ b/.cleanup-tasks/2026_08_12_sla_waiting_exclusion_feature.md
@@ -1,0 +1,20 @@
+---
+title: Sla Waiting Exclusion Feature
+created: 2026-08-12
+---
+
+## Feature Flags
+
+- App\Features\SlaWaitingExclusionFeature
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+<!--
+Only list cleanup that has no home in code. Do NOT restate obvious feature-flag
+removals (keep the active path, drop the inactive path), and do NOT include file
+paths or line numbers. For non-obvious changes, put a `TODO: Cleanup Task (<tag>)`
+comment at the change site and reference the tag here — e.g.
+"Search for `TODO: Cleanup Task (some-feature)`".
+-->

--- a/.cleanup-tasks/2026_08_12_sla_waiting_exclusion_feature.md
+++ b/.cleanup-tasks/2026_08_12_sla_waiting_exclusion_feature.md
@@ -9,6 +9,8 @@ created: 2026-08-12
 
 ## Temporary Migrations
 
+- app-modules/service-management/database/migrations/2026_08_12_163559_tmp_backfill_service_request_status_periods.php
+
 ## Additional Cleanup
 
 <!--

--- a/.cleanup-tasks/2026_08_12_sla_waiting_exclusion_feature.md
+++ b/.cleanup-tasks/2026_08_12_sla_waiting_exclusion_feature.md
@@ -1,0 +1,30 @@
+---
+title: Sla Waiting Exclusion Feature
+created: 2026-08-12
+---
+
+## Feature Flags
+
+- App\Features\SlaWaitingExclusionFeature
+
+## Temporary Migrations
+
+- app-modules/service-management/database/migrations/2026_08_12_163559_tmp_backfill_service_request_status_periods.php
+
+## Additional Cleanup
+
+- `app/Features/SlaWaitingExclusionFeature.php` — delete the whole file.
+
+- `app-modules/service-management/src/Models/ServiceRequest.php`
+    - In `getResolutionSeconds()`, remove the `if (SlaWaitingExclusionFeature::active())` guard so the `$seconds -= $this->getExcludedSecondsBetween(...)` subtraction (excluding `Waiting` and `Closed` time) always runs.
+    - In `responseSecondsBetween()`, remove the `if (SlaWaitingExclusionFeature::active())` guard so the `$seconds -= $this->getExcludedSecondsBetween(...)` subtraction (excluding `Waiting` time) always runs.
+    - Remove the `use App\Features\SlaWaitingExclusionFeature;` import.
+- `app-modules/service-management/src/Observers/ServiceRequestObserver.php`
+    - In `saving()`, drop the `SlaWaitingExclusionFeature::active() &&` part of the condition so it becomes `if ($serviceRequest->exists)`. Keep the `elseif (is_null($serviceRequest->time_to_resolution))` branch — it still handles the not-yet-persisted record case.
+    - Remove the `use App\Features\SlaWaitingExclusionFeature;` import.
+
+- Delete the tests that cover the inactive (pre-migration) branch, since that branch no longer exists. Each also needs its `use App\Features\SlaWaitingExclusionFeature;` import removed.
+    - `app-modules/service-management/tests/Tenant/Models/ServiceRequestTest.php` — `it('includes waiting and closed time in the resolution seconds when the feature is inactive')`.
+    - `app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/EditServiceRequestTest.php` — `test('check if time to resolution has correct value when status is changed')` (it calls `SlaWaitingExclusionFeature::deactivate()` to assert the legacy time-to-resolution calculation).
+
+- Delete this file (`.cleanup-tasks/2026_08_12_sla_waiting_exclusion_feature.md`) once all the above cleanup is complete.

--- a/app-modules/report/src/Filament/Widgets/ServiceRequestFeedbackTable.php
+++ b/app-modules/report/src/Filament/Widgets/ServiceRequestFeedbackTable.php
@@ -92,6 +92,7 @@ class ServiceRequestFeedbackTable extends BaseWidget
                         'serviceRequest.priority.sla',
                         'serviceRequest.respondent',
                         'serviceRequest.assignedTo.user',
+                        'serviceRequest.statusPeriods',
                     ])
                     ->when(
                         $startDate && $endDate,

--- a/app-modules/service-management/database/factories/ServiceRequestStatusFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestStatusFactory.php
@@ -106,6 +106,20 @@ class ServiceRequestStatusFactory extends Factory
         });
     }
 
+    /**
+     * @return Factory<ServiceRequestStatus>
+     */
+    public function waiting(): Factory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'classification' => SystemServiceRequestClassification::Waiting,
+                'name' => 'Waiting',
+                'color' => Color::Yellow,
+            ];
+        });
+    }
+
     public function getNewOrder(): int
     {
         return $this->maxOrder = $this->getMaxOrder() + 1;

--- a/app-modules/service-management/database/factories/ServiceRequestStatusPeriodFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestStatusPeriodFactory.php
@@ -34,29 +34,33 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Observers;
+namespace AidingApp\ServiceManagement\Database\Factories;
 
-use AidingApp\ServiceManagement\Jobs\RecordReclassifiedServiceRequestStatusPeriods;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Facades\DB;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatusPeriod;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-class ServiceRequestStatusObserver
+/**
+ * @extends Factory<ServiceRequestStatusPeriod>
+ */
+class ServiceRequestStatusPeriodFactory extends Factory
 {
-    public function creating(ServiceRequestStatus $serviceRequestStatus): void
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
     {
-        if (! isset($serviceRequestStatus->sort)) {
-            $serviceRequestStatus->setAttribute(
-                'sort',
-                DB::raw('(SELECT COALESCE(MAX(service_request_statuses.sort), 0) + 1 FROM service_request_statuses)')
-            );
-        }
-    }
-
-    public function updated(ServiceRequestStatus $serviceRequestStatus): void
-    {
-        if ($serviceRequestStatus->wasChanged('classification')) {
-            RecordReclassifiedServiceRequestStatusPeriods::dispatch($serviceRequestStatus, CarbonImmutable::now());
-        }
+        return [
+            'service_request_id' => ServiceRequest::factory(),
+            'classification' => fn () => $this->faker->randomElement(SystemServiceRequestClassification::cases()),
+            'service_request_status_id' => fn (array $attributes) => ServiceRequestStatus::factory()->state([
+                'classification' => $attributes['classification'],
+            ]),
+            'started_at' => now(),
+        ];
     }
 }

--- a/app-modules/service-management/database/factories/ServiceRequestStatusPeriodFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestStatusPeriodFactory.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AidingApp\ServiceManagement\Database\Factories;
+
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatusPeriod;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ServiceRequestStatusPeriod>
+ */
+class ServiceRequestStatusPeriodFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $status = ServiceRequestStatus::factory();
+
+        return [
+            'service_request_id' => ServiceRequest::factory(),
+            'service_request_status_id' => $status,
+            'classification' => $this->faker->randomElement(SystemServiceRequestClassification::cases()),
+            'started_at' => now(),
+        ];
+    }
+}

--- a/app-modules/service-management/database/migrations/2026_08_12_141947_create_service_request_status_periods_table.php
+++ b/app-modules/service-management/database/migrations/2026_08_12_141947_create_service_request_status_periods_table.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('service_request_status_periods', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->foreignUuid('service_request_id')->constrained('service_requests')->cascadeOnDelete();
+            $table->foreignUuid('service_request_status_id')->nullable()->constrained('service_request_statuses')->nullOnDelete();
+            $table->string('classification')->nullable();
+            $table->timestamp('started_at');
+
+            $table->timestamps();
+
+            $table->index(['service_request_id', 'started_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('service_request_status_periods');
+    }
+};

--- a/app-modules/service-management/database/migrations/2026_08_12_141947_create_service_request_status_periods_table.php
+++ b/app-modules/service-management/database/migrations/2026_08_12_141947_create_service_request_status_periods_table.php
@@ -34,29 +34,29 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Observers;
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
-use AidingApp\ServiceManagement\Jobs\RecordReclassifiedServiceRequestStatusPeriods;
-use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Facades\DB;
-
-class ServiceRequestStatusObserver
-{
-    public function creating(ServiceRequestStatus $serviceRequestStatus): void
+return new class () extends Migration {
+    public function up(): void
     {
-        if (! isset($serviceRequestStatus->sort)) {
-            $serviceRequestStatus->setAttribute(
-                'sort',
-                DB::raw('(SELECT COALESCE(MAX(service_request_statuses.sort), 0) + 1 FROM service_request_statuses)')
-            );
-        }
+        Schema::create('service_request_status_periods', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->foreignUuid('service_request_id')->constrained('service_requests')->cascadeOnDelete();
+            $table->foreignUuid('service_request_status_id')->nullable()->constrained('service_request_statuses')->nullOnDelete();
+            $table->string('classification')->nullable();
+            $table->timestamp('started_at');
+
+            $table->timestamps();
+
+            $table->index(['service_request_id', 'started_at']);
+        });
     }
 
-    public function updated(ServiceRequestStatus $serviceRequestStatus): void
+    public function down(): void
     {
-        if ($serviceRequestStatus->wasChanged('classification')) {
-            RecordReclassifiedServiceRequestStatusPeriods::dispatch($serviceRequestStatus, CarbonImmutable::now());
-        }
+        Schema::dropIfExists('service_request_status_periods');
     }
-}
+};

--- a/app-modules/service-management/database/migrations/2026_08_12_163559_tmp_backfill_service_request_status_periods.php
+++ b/app-modules/service-management/database/migrations/2026_08_12_163559_tmp_backfill_service_request_status_periods.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use App\Features\SlaWaitingExclusionFeature;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::transaction(function (): void {
+            $classifications = DB::table('service_request_statuses')
+                ->pluck('classification', 'id')
+                ->all();
+
+            DB::table('service_requests')
+                ->select(['id', 'status_id', 'created_at'])
+                ->whereNotExists(function (Builder $query): void {
+                    $query->select(DB::raw(1))
+                        ->from('service_request_status_periods')
+                        ->whereColumn('service_request_status_periods.service_request_id', 'service_requests.id');
+                })
+                ->orderBy('id')
+                ->chunkById(200, function (Collection $serviceRequests) use ($classifications): void {
+                    $rows = [];
+
+                    foreach ($serviceRequests as $serviceRequest) {
+                        $histories = DB::table('service_request_histories')
+                            ->where('service_request_id', $serviceRequest->id)
+                            ->whereNull('deleted_at')
+                            ->orderBy('created_at')
+                            ->orderBy('id')
+                            ->get(['new_values', 'original_values', 'created_at']);
+
+                        $periods = $this->buildPeriods($serviceRequest, $histories);
+
+                        $previousStatusId = null;
+
+                        foreach ($periods as $period) {
+                            if ($period['status_id'] === $previousStatusId) {
+                                continue;
+                            }
+
+                            $previousStatusId = $period['status_id'];
+
+                            // A status_id absent from the map was hard-deleted; record the period with an
+                            // unknown (null) classification so the span is not silently merged into the
+                            // previous period, and is treated as active/non-excluded time.
+                            $statusExists = array_key_exists($period['status_id'], $classifications);
+
+                            $rows[] = [
+                                'id' => (string) Str::uuid(),
+                                'service_request_id' => $serviceRequest->id,
+                                'service_request_status_id' => $statusExists ? $period['status_id'] : null,
+                                'classification' => $statusExists ? $classifications[$period['status_id']] : null,
+                                'started_at' => $period['started_at'],
+                                'created_at' => now(),
+                                'updated_at' => now(),
+                            ];
+                        }
+                    }
+
+                    if ($rows !== []) {
+                        DB::table('service_request_status_periods')->insert($rows);
+                    }
+                });
+
+            SlaWaitingExclusionFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        SlaWaitingExclusionFeature::deactivate();
+    }
+
+    /**
+     * @param Collection<int, stdClass> $histories
+     *
+     * @return array<int, array{status_id: string, started_at: mixed}>
+     */
+    private function buildPeriods(object $serviceRequest, Collection $histories): array
+    {
+        $periods = [];
+
+        $initialStatusId = $this->resolveInitialStatusId($histories, $serviceRequest->status_id);
+
+        if ($initialStatusId !== null) {
+            $periods[] = [
+                'status_id' => $initialStatusId,
+                'started_at' => $serviceRequest->created_at,
+            ];
+        }
+
+        foreach ($histories as $history) {
+            $originalValues = json_decode($history->original_values, true) ?? [];
+            $newValues = json_decode($history->new_values, true) ?? [];
+
+            // Empty `original_values` marks the creation event; its status is already the initial period.
+            if (empty($originalValues)) {
+                continue;
+            }
+
+            if (! array_key_exists('status_id', $newValues) || $newValues['status_id'] === null) {
+                continue;
+            }
+
+            $periods[] = [
+                'status_id' => $newValues['status_id'],
+                'started_at' => $history->created_at,
+            ];
+        }
+
+        return $periods;
+    }
+
+    /**
+     * @param Collection<int, stdClass> $histories
+     */
+    private function resolveInitialStatusId(Collection $histories, ?string $currentStatusId): ?string
+    {
+        foreach ($histories as $history) {
+            $originalValues = json_decode($history->original_values, true) ?? [];
+            $newValues = json_decode($history->new_values, true) ?? [];
+
+            if (empty($originalValues) && array_key_exists('status_id', $newValues)) {
+                return $newValues['status_id'];
+            }
+        }
+
+        foreach ($histories as $history) {
+            $originalValues = json_decode($history->original_values, true) ?? [];
+
+            if (array_key_exists('status_id', $originalValues) && $originalValues['status_id'] !== null) {
+                return $originalValues['status_id'];
+            }
+        }
+
+        return $currentStatusId;
+    }
+};

--- a/app-modules/service-management/database/migrations/2026_08_12_163559_tmp_backfill_service_request_status_periods.php
+++ b/app-modules/service-management/database/migrations/2026_08_12_163559_tmp_backfill_service_request_status_periods.php
@@ -116,7 +116,7 @@ return new class () extends Migration {
     }
 
     /**
-     * @param Collection<int, \stdClass> $histories
+     * @param Collection<int, stdClass> $histories
      *
      * @return array<int, array{status_id: string, started_at: mixed}>
      */
@@ -156,7 +156,7 @@ return new class () extends Migration {
     }
 
     /**
-     * @param Collection<int, \stdClass> $histories
+     * @param Collection<int, stdClass> $histories
      */
     private function resolveInitialStatusId(Collection $histories, ?string $currentStatusId): ?string
     {

--- a/app-modules/service-management/database/migrations/2026_08_12_163559_tmp_backfill_service_request_status_periods.php
+++ b/app-modules/service-management/database/migrations/2026_08_12_163559_tmp_backfill_service_request_status_periods.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use App\Features\SlaWaitingExclusionFeature;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class () extends Migration {
+    // @phpstan-ignore Common.multipleMigrationChangesNotWrappedInTransaction
+    public function up(): void
+    {
+        if (! Schema::hasTable('service_request_status_periods')) {
+            return;
+        }
+
+        DB::transaction(function (): void {
+            $classifications = DB::table('service_request_statuses')
+                ->pluck('classification', 'id')
+                ->all();
+
+            DB::table('service_requests')
+                ->select(['id', 'status_id', 'created_at'])
+                ->whereNotExists(function (Builder $query): void {
+                    $query->select(DB::raw(1))
+                        ->from('service_request_status_periods')
+                        ->whereColumn('service_request_status_periods.service_request_id', 'service_requests.id');
+                })
+                ->orderBy('id')
+                ->chunkById(200, function (Collection $serviceRequests) use ($classifications): void {
+                    $rows = [];
+
+                    foreach ($serviceRequests as $serviceRequest) {
+                        $histories = DB::table('service_request_histories')
+                            ->where('service_request_id', $serviceRequest->id)
+                            ->whereNull('deleted_at')
+                            ->orderBy('created_at')
+                            ->orderBy('id')
+                            ->get(['new_values', 'original_values', 'created_at']);
+
+                        $periods = $this->buildPeriods($serviceRequest, $histories);
+
+                        $previousStatusId = null;
+
+                        foreach ($periods as $period) {
+                            if ($period['status_id'] === $previousStatusId) {
+                                continue;
+                            }
+
+                            $previousStatusId = $period['status_id'];
+
+                            if (! array_key_exists($period['status_id'], $classifications)) {
+                                continue;
+                            }
+
+                            $rows[] = [
+                                'id' => (string) Str::uuid(),
+                                'service_request_id' => $serviceRequest->id,
+                                'service_request_status_id' => $period['status_id'],
+                                'classification' => $classifications[$period['status_id']],
+                                'started_at' => $period['started_at'],
+                                'created_at' => now(),
+                                'updated_at' => now(),
+                            ];
+                        }
+                    }
+
+                    if ($rows !== []) {
+                        DB::table('service_request_status_periods')->insert($rows);
+                    }
+                });
+
+            SlaWaitingExclusionFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        SlaWaitingExclusionFeature::deactivate();
+    }
+
+    /**
+     * @param Collection<int, \stdClass> $histories
+     *
+     * @return array<int, array{status_id: string, started_at: mixed}>
+     */
+    private function buildPeriods(object $serviceRequest, Collection $histories): array
+    {
+        $periods = [];
+
+        $initialStatusId = $this->resolveInitialStatusId($histories, $serviceRequest->status_id);
+
+        if ($initialStatusId !== null) {
+            $periods[] = [
+                'status_id' => $initialStatusId,
+                'started_at' => $serviceRequest->created_at,
+            ];
+        }
+
+        foreach ($histories as $history) {
+            $originalValues = json_decode($history->original_values, true) ?? [];
+            $newValues = json_decode($history->new_values, true) ?? [];
+
+            // Empty `original_values` marks the creation event; its status is already the initial period.
+            if (empty($originalValues)) {
+                continue;
+            }
+
+            if (! array_key_exists('status_id', $newValues) || $newValues['status_id'] === null) {
+                continue;
+            }
+
+            $periods[] = [
+                'status_id' => $newValues['status_id'],
+                'started_at' => $history->created_at,
+            ];
+        }
+
+        return $periods;
+    }
+
+    /**
+     * @param Collection<int, \stdClass> $histories
+     */
+    private function resolveInitialStatusId(Collection $histories, ?string $currentStatusId): ?string
+    {
+        foreach ($histories as $history) {
+            $originalValues = json_decode($history->original_values, true) ?? [];
+            $newValues = json_decode($history->new_values, true) ?? [];
+
+            if (empty($originalValues) && array_key_exists('status_id', $newValues)) {
+                return $newValues['status_id'];
+            }
+        }
+
+        foreach ($histories as $history) {
+            $originalValues = json_decode($history->original_values, true) ?? [];
+
+            if (array_key_exists('status_id', $originalValues) && $originalValues['status_id'] !== null) {
+                return $originalValues['status_id'];
+            }
+        }
+
+        return $currentStatusId;
+    }
+};

--- a/app-modules/service-management/src/Actions/RecordReclassifiedServiceRequestStatusPeriods.php
+++ b/app-modules/service-management/src/Actions/RecordReclassifiedServiceRequestStatusPeriods.php
@@ -34,29 +34,42 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Observers;
+namespace AidingApp\ServiceManagement\Actions;
 
-use AidingApp\ServiceManagement\Actions\RecordReclassifiedServiceRequestStatusPeriods;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Facades\DB;
+use Carbon\CarbonInterface;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 
-class ServiceRequestStatusObserver
+class RecordReclassifiedServiceRequestStatusPeriods implements ShouldQueue
 {
-    public function creating(ServiceRequestStatus $serviceRequestStatus): void
-    {
-        if (! isset($serviceRequestStatus->sort)) {
-            $serviceRequestStatus->setAttribute(
-                'sort',
-                DB::raw('(SELECT COALESCE(MAX(service_request_statuses.sort), 0) + 1 FROM service_request_statuses)')
-            );
-        }
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public ServiceRequestStatus $status,
+        public CarbonInterface $reclassifiedAt,
+    ) {
+        $this->afterCommit = true;
     }
 
-    public function updated(ServiceRequestStatus $serviceRequestStatus): void
+    public function handle(RecordServiceRequestStatusPeriod $recordServiceRequestStatusPeriod): void
     {
-        if ($serviceRequestStatus->wasChanged('classification')) {
-            RecordReclassifiedServiceRequestStatusPeriods::dispatch($serviceRequestStatus, CarbonImmutable::now());
-        }
+        ServiceRequest::query()
+            ->where('status_id', $this->status->getKey())
+            ->chunkById(200, function (Collection $serviceRequests) use ($recordServiceRequestStatusPeriod): void {
+                foreach ($serviceRequests as $serviceRequest) {
+                    $serviceRequest->setRelation('status', $this->status);
+
+                    $recordServiceRequestStatusPeriod->execute($serviceRequest, $this->reclassifiedAt);
+                }
+            });
     }
 }

--- a/app-modules/service-management/src/Actions/RecordServiceRequestStatusPeriod.php
+++ b/app-modules/service-management/src/Actions/RecordServiceRequestStatusPeriod.php
@@ -34,29 +34,38 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Observers;
+namespace AidingApp\ServiceManagement\Actions;
 
-use AidingApp\ServiceManagement\Jobs\RecordReclassifiedServiceRequestStatusPeriods;
-use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Facades\DB;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use Carbon\CarbonInterface;
 
-class ServiceRequestStatusObserver
+class RecordServiceRequestStatusPeriod
 {
-    public function creating(ServiceRequestStatus $serviceRequestStatus): void
+    public function execute(ServiceRequest $serviceRequest, CarbonInterface $startedAt): void
     {
-        if (! isset($serviceRequestStatus->sort)) {
-            $serviceRequestStatus->setAttribute(
-                'sort',
-                DB::raw('(SELECT COALESCE(MAX(service_request_statuses.sort), 0) + 1 FROM service_request_statuses)')
-            );
-        }
-    }
+        $status = $serviceRequest->status;
 
-    public function updated(ServiceRequestStatus $serviceRequestStatus): void
-    {
-        if ($serviceRequestStatus->wasChanged('classification')) {
-            RecordReclassifiedServiceRequestStatusPeriods::dispatch($serviceRequestStatus, CarbonImmutable::now());
+        if (! $status) {
+            return;
         }
+
+        $latestPeriod = $serviceRequest->statusPeriods()
+            ->orderByDesc('started_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        if (
+            $latestPeriod
+            && $latestPeriod->service_request_status_id === $status->getKey()
+            && $latestPeriod->classification === $status->classification
+        ) {
+            return;
+        }
+
+        $serviceRequest->statusPeriods()->create([
+            'service_request_status_id' => $status->getKey(),
+            'classification' => $status->classification,
+            'started_at' => $startedAt,
+        ]);
     }
 }

--- a/app-modules/service-management/src/Actions/RecordServiceRequestStatusPeriod.php
+++ b/app-modules/service-management/src/Actions/RecordServiceRequestStatusPeriod.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AidingApp\ServiceManagement\Actions;
+
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatusPeriod;
+use Carbon\CarbonInterface;
+
+class RecordServiceRequestStatusPeriod
+{
+    public function execute(ServiceRequest $serviceRequest, CarbonInterface $startedAt): void
+    {
+        $status = $serviceRequest->status;
+
+        if (! $status) {
+            return;
+        }
+
+        /** @var ServiceRequestStatusPeriod|null $latestPeriod */
+        $latestPeriod = $serviceRequest->statusPeriods()
+            ->orderByDesc('started_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        if (
+            $latestPeriod
+            && $latestPeriod->service_request_status_id === $status->getKey()
+            && $latestPeriod->classification === $status->classification
+        ) {
+            return;
+        }
+
+        $serviceRequest->statusPeriods()->create([
+            'service_request_status_id' => $status->getKey(),
+            'classification' => $status->classification,
+            'started_at' => $startedAt,
+        ]);
+    }
+}

--- a/app-modules/service-management/src/Jobs/RecordReclassifiedServiceRequestStatusPeriods.php
+++ b/app-modules/service-management/src/Jobs/RecordReclassifiedServiceRequestStatusPeriods.php
@@ -34,29 +34,43 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Observers;
+namespace AidingApp\ServiceManagement\Jobs;
 
-use AidingApp\ServiceManagement\Jobs\RecordReclassifiedServiceRequestStatusPeriods;
+use AidingApp\ServiceManagement\Actions\RecordServiceRequestStatusPeriod;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Facades\DB;
+use Carbon\CarbonInterface;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 
-class ServiceRequestStatusObserver
+class RecordReclassifiedServiceRequestStatusPeriods implements ShouldQueue
 {
-    public function creating(ServiceRequestStatus $serviceRequestStatus): void
-    {
-        if (! isset($serviceRequestStatus->sort)) {
-            $serviceRequestStatus->setAttribute(
-                'sort',
-                DB::raw('(SELECT COALESCE(MAX(service_request_statuses.sort), 0) + 1 FROM service_request_statuses)')
-            );
-        }
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public ServiceRequestStatus $status,
+        public CarbonInterface $reclassifiedAt,
+    ) {
+        $this->afterCommit = true;
     }
 
-    public function updated(ServiceRequestStatus $serviceRequestStatus): void
+    public function handle(RecordServiceRequestStatusPeriod $recordServiceRequestStatusPeriod): void
     {
-        if ($serviceRequestStatus->wasChanged('classification')) {
-            RecordReclassifiedServiceRequestStatusPeriods::dispatch($serviceRequestStatus, CarbonImmutable::now());
-        }
+        ServiceRequest::query()
+            ->withoutGlobalScope('excludeDrafts')
+            ->where('status_id', $this->status->getKey())
+            ->eachById(function (ServiceRequest $serviceRequest) use ($recordServiceRequestStatusPeriod): void {
+                // Every request here already has this status, so reuse the reclassified instance
+                // to avoid lazily reloading the status relation for each record.
+                $serviceRequest->setRelation('status', $this->status);
+
+                $recordServiceRequestStatusPeriod->execute($serviceRequest, $this->reclassifiedAt);
+            });
     }
 }

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -50,6 +50,7 @@ use AidingApp\ServiceManagement\Exceptions\ServiceRequestNumberExceededReRollsEx
 use AidingApp\ServiceManagement\Models\MediaCollections\UploadsMediaCollection;
 use AidingApp\ServiceManagement\Observers\ServiceRequestObserver;
 use AidingApp\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceRequestNumberGenerator;
+use App\Features\SlaWaitingExclusionFeature;
 use App\Models\BaseModel;
 use App\Models\Media;
 use App\Models\User;
@@ -268,6 +269,14 @@ class ServiceRequest extends BaseModel implements Auditable, HasMedia
     }
 
     /**
+     * @return HasMany<ServiceRequestStatusPeriod, $this>
+     */
+    public function statusPeriods(): HasMany
+    {
+        return $this->hasMany(ServiceRequestStatusPeriod::class);
+    }
+
+    /**
      * @return HasMany<ServiceRequestConversation, $this>
      */
     public function conversations(): HasMany
@@ -352,37 +361,84 @@ class ServiceRequest extends BaseModel implements Auditable, HasMedia
     public function getLatestResponseSeconds(): int
     {
         if (! $this->latestInboundServiceRequestUpdate) {
-            return (int) round($this->created_at->diffInSeconds(now()));
+            return $this->responseSecondsBetween($this->created_at, now());
         }
+
+        $inboundAt = $this->latestInboundServiceRequestUpdate->created_at;
 
         if (
             $this->isResolved() &&
-            ($resolvedAt = $this->getResolvedAt())->isAfter($this->latestInboundServiceRequestUpdate->created_at)
+            ($resolvedAt = $this->getResolvedAt())->isAfter($inboundAt)
         ) {
-            return (int) round($resolvedAt->diffInSeconds($this->latestInboundServiceRequestUpdate->created_at));
+            return $this->responseSecondsBetween($inboundAt, $resolvedAt);
         }
 
         if (
             $this->latestOutboundServiceRequestUpdate &&
-            $this->latestOutboundServiceRequestUpdate->created_at->isAfter(
-                $this->latestInboundServiceRequestUpdate->created_at,
-            )
+            $this->latestOutboundServiceRequestUpdate->created_at->isAfter($inboundAt)
         ) {
-            return (int) round($this->latestOutboundServiceRequestUpdate->created_at->diffInSeconds(
-                $this->latestInboundServiceRequestUpdate->created_at,
-            ));
+            return $this->responseSecondsBetween($inboundAt, $this->latestOutboundServiceRequestUpdate->created_at);
         }
 
-        return (int) round($this->latestInboundServiceRequestUpdate->created_at->diffInSeconds());
+        return $this->responseSecondsBetween($inboundAt, now());
     }
 
     public function getResolutionSeconds(): int
     {
-        if (! $this->isResolved()) {
-            return (int) round($this->created_at->diffInSeconds());
+        $end = $this->isResolved() ? $this->getResolvedAt() : now();
+
+        $seconds = (int) round($this->created_at->diffInSeconds($end));
+
+        if (SlaWaitingExclusionFeature::active()) {
+            $seconds -= $this->getExcludedSecondsBetween($this->created_at, $end, [
+                SystemServiceRequestClassification::Waiting,
+                SystemServiceRequestClassification::Closed,
+            ]);
         }
 
-        return (int) round($this->created_at->diffInSeconds($this->getResolvedAt()));
+        return max(0, $seconds);
+    }
+
+    /**
+     * Sum the seconds this request spent in any of the given classifications within [$start, $end].
+     *
+     * @param array<int, SystemServiceRequestClassification> $classifications
+     */
+    public function getExcludedSecondsBetween(CarbonInterface $start, CarbonInterface $end, array $classifications): int
+    {
+        $periods = $this->statusPeriods
+            ->sortBy([
+                ['started_at', 'asc'],
+                ['created_at', 'asc'],
+            ])
+            ->values();
+
+        if ($periods->isEmpty()) {
+            return 0;
+        }
+
+        $ongoingEnd = $this->isResolved() ? $this->getResolvedAt() : now();
+
+        $excludedSeconds = 0.0;
+
+        foreach ($periods as $index => $period) {
+            if (! in_array($period->classification, $classifications, true)) {
+                continue;
+            }
+
+            $periodStart = $period->started_at;
+            $nextPeriod = $periods->get($index + 1);
+            $periodEnd = $nextPeriod ? $nextPeriod->started_at : $ongoingEnd;
+
+            $overlapStart = $periodStart->greaterThan($start) ? $periodStart : $start;
+            $overlapEnd = $periodEnd->lessThan($end) ? $periodEnd : $end;
+
+            if ($overlapEnd->greaterThan($overlapStart)) {
+                $excludedSeconds += $overlapStart->diffInSeconds($overlapEnd);
+            }
+        }
+
+        return (int) round($excludedSeconds);
     }
 
     public function getSlaResponseSeconds(): ?int
@@ -514,5 +570,18 @@ class ServiceRequest extends BaseModel implements Auditable, HasMedia
     protected function serializeDate(DateTimeInterface $date): string
     {
         return $date->format(config('project.datetime_format') ?? 'Y-m-d H:i:s');
+    }
+
+    private function responseSecondsBetween(CarbonInterface $start, CarbonInterface $end): int
+    {
+        $seconds = (int) round($start->diffInSeconds($end));
+
+        if (SlaWaitingExclusionFeature::active()) {
+            $seconds -= $this->getExcludedSecondsBetween($start, $end, [
+                SystemServiceRequestClassification::Waiting,
+            ]);
+        }
+
+        return max(0, $seconds);
     }
 }

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -483,7 +483,33 @@ class ServiceRequest extends BaseModel implements Auditable, HasMedia
 
     public function getResolvedAt(): CarbonInterface
     {
-        return $this->status_updated_at ?? $this->updated_at ?? $this->created_at;
+        $legacyResolvedAt = $this->status_updated_at ?? $this->updated_at ?? $this->created_at;
+
+        if (! SlaWaitingExclusionFeature::active()) {
+            return $legacyResolvedAt;
+        }
+
+        $periods = $this->statusPeriods
+            ->sortBy([
+                ['started_at', 'asc'],
+                ['created_at', 'asc'],
+            ])
+            ->values();
+
+        // Anchor resolution to the start of the current trailing run of Closed periods, so moving
+        // between two closed statuses (e.g. Resolved -> Closed) doesn't push the resolved time forward,
+        // while a reopen (a non-closed period) correctly resets it to the most recent close.
+        $resolvedAt = null;
+
+        foreach ($periods->reverse() as $period) {
+            if ($period->classification !== SystemServiceRequestClassification::Closed) {
+                break;
+            }
+
+            $resolvedAt = $period->started_at;
+        }
+
+        return $resolvedAt ?? $legacyResolvedAt;
     }
 
     public function isResolved(): bool

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -50,6 +50,7 @@ use AidingApp\ServiceManagement\Exceptions\ServiceRequestNumberExceededReRollsEx
 use AidingApp\ServiceManagement\Models\MediaCollections\UploadsMediaCollection;
 use AidingApp\ServiceManagement\Observers\ServiceRequestObserver;
 use AidingApp\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceRequestNumberGenerator;
+use App\Features\SlaWaitingExclusionFeature;
 use App\Models\BaseModel;
 use App\Models\Media;
 use App\Models\User;
@@ -372,37 +373,82 @@ class ServiceRequest extends BaseModel implements Auditable, HasMedia
     public function getLatestResponseSeconds(): int
     {
         if (! $this->latestInboundServiceRequestUpdate) {
-            return (int) round($this->created_at->diffInSeconds(now()));
+            return $this->responseSecondsBetween($this->created_at, now());
         }
+
+        $inboundAt = $this->latestInboundServiceRequestUpdate->created_at;
 
         if (
             $this->isResolved() &&
-            ($resolvedAt = $this->getResolvedAt())->isAfter($this->latestInboundServiceRequestUpdate->created_at)
+            ($resolvedAt = $this->getResolvedAt())->isAfter($inboundAt)
         ) {
-            return (int) round($resolvedAt->diffInSeconds($this->latestInboundServiceRequestUpdate->created_at));
+            return $this->responseSecondsBetween($inboundAt, $resolvedAt);
         }
 
         if (
             $this->latestOutboundServiceRequestUpdate &&
-            $this->latestOutboundServiceRequestUpdate->created_at->isAfter(
-                $this->latestInboundServiceRequestUpdate->created_at,
-            )
+            $this->latestOutboundServiceRequestUpdate->created_at->isAfter($inboundAt)
         ) {
-            return (int) round($this->latestOutboundServiceRequestUpdate->created_at->diffInSeconds(
-                $this->latestInboundServiceRequestUpdate->created_at,
-            ));
+            return $this->responseSecondsBetween($inboundAt, $this->latestOutboundServiceRequestUpdate->created_at);
         }
 
-        return (int) round($this->latestInboundServiceRequestUpdate->created_at->diffInSeconds());
+        return $this->responseSecondsBetween($inboundAt, now());
     }
 
     public function getResolutionSeconds(): int
     {
-        if (! $this->isResolved()) {
-            return (int) round($this->created_at->diffInSeconds());
+        $end = $this->isResolved() ? $this->getResolvedAt() : now();
+
+        $seconds = (int) round($this->created_at->diffInSeconds($end));
+
+        if (SlaWaitingExclusionFeature::active()) {
+            $seconds -= $this->getExcludedSecondsBetween($this->created_at, $end, [
+                SystemServiceRequestClassification::Waiting,
+                SystemServiceRequestClassification::Closed,
+            ]);
         }
 
-        return (int) round($this->created_at->diffInSeconds($this->getResolvedAt()));
+        return max(0, $seconds);
+    }
+
+    /**
+     * Sum the seconds this request spent in any of the given classifications within [$start, $end].
+     *
+     * @param array<int, SystemServiceRequestClassification> $classifications
+     */
+    public function getExcludedSecondsBetween(CarbonInterface $start, CarbonInterface $end, array $classifications): int
+    {
+        $periods = $this->statusPeriods()
+            ->orderBy('started_at')
+            ->orderBy('created_at')
+            ->get();
+
+        if ($periods->isEmpty()) {
+            return 0;
+        }
+
+        $ongoingEnd = $this->isResolved() ? $this->getResolvedAt() : now();
+
+        $excludedSeconds = 0;
+
+        foreach ($periods as $index => $period) {
+            if (! in_array($period->classification, $classifications, true)) {
+                continue;
+            }
+
+            $periodStart = $period->started_at;
+            $nextPeriod = $periods->get($index + 1);
+            $periodEnd = $nextPeriod ? $nextPeriod->started_at : $ongoingEnd;
+
+            $overlapStart = $periodStart->greaterThan($start) ? $periodStart : $start;
+            $overlapEnd = $periodEnd->lessThan($end) ? $periodEnd : $end;
+
+            if ($overlapEnd->greaterThan($overlapStart)) {
+                $excludedSeconds += (int) round($overlapStart->diffInSeconds($overlapEnd));
+            }
+        }
+
+        return $excludedSeconds;
     }
 
     public function getSlaResponseSeconds(): ?int
@@ -534,5 +580,18 @@ class ServiceRequest extends BaseModel implements Auditable, HasMedia
     protected function serializeDate(DateTimeInterface $date): string
     {
         return $date->format(config('project.datetime_format') ?? 'Y-m-d H:i:s');
+    }
+
+    private function responseSecondsBetween(CarbonInterface $start, CarbonInterface $end): int
+    {
+        $seconds = (int) round($start->diffInSeconds($end));
+
+        if (SlaWaitingExclusionFeature::active()) {
+            $seconds -= $this->getExcludedSecondsBetween($start, $end, [
+                SystemServiceRequestClassification::Waiting,
+            ]);
+        }
+
+        return max(0, $seconds);
     }
 }

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -418,10 +418,12 @@ class ServiceRequest extends BaseModel implements Auditable, HasMedia
      */
     public function getExcludedSecondsBetween(CarbonInterface $start, CarbonInterface $end, array $classifications): int
     {
-        $periods = $this->statusPeriods()
-            ->orderBy('started_at')
-            ->orderBy('created_at')
-            ->get();
+        $periods = $this->statusPeriods
+            ->sortBy([
+                ['started_at', 'asc'],
+                ['created_at', 'asc'],
+            ])
+            ->values();
 
         if ($periods->isEmpty()) {
             return 0;

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -268,6 +268,26 @@ class ServiceRequest extends BaseModel implements Auditable, HasMedia
     }
 
     /**
+     * @return HasMany<ServiceRequestStatusPeriod, $this>
+     */
+    public function statusPeriods(): HasMany
+    {
+        return $this->hasMany(ServiceRequestStatusPeriod::class);
+    }
+
+    /**
+     * @return HasOne<ServiceRequestStatusPeriod, $this>
+     */
+    public function currentStatusPeriod(): HasOne
+    {
+        return $this->hasOne(ServiceRequestStatusPeriod::class)
+            ->ofMany([
+                'started_at' => 'max',
+                'created_at' => 'max',
+            ]);
+    }
+
+    /**
      * @return HasMany<ServiceRequestConversation, $this>
      */
     public function conversations(): HasMany

--- a/app-modules/service-management/src/Models/ServiceRequestStatusPeriod.php
+++ b/app-modules/service-management/src/Models/ServiceRequestStatusPeriod.php
@@ -34,29 +34,59 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Observers;
+namespace AidingApp\ServiceManagement\Models;
 
-use AidingApp\ServiceManagement\Jobs\RecordReclassifiedServiceRequestStatusPeriods;
-use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Facades\DB;
+use AidingApp\ServiceManagement\Database\Factories\ServiceRequestStatusPeriodFactory;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use App\Models\BaseModel;
+use DateTimeInterface;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class ServiceRequestStatusObserver
+/**
+ * @mixin IdeHelperServiceRequestStatusPeriod
+ */
+class ServiceRequestStatusPeriod extends BaseModel
 {
-    public function creating(ServiceRequestStatus $serviceRequestStatus): void
+    /** @use HasFactory<ServiceRequestStatusPeriodFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'service_request_id',
+        'service_request_status_id',
+        'classification',
+        'started_at',
+    ];
+
+    /**
+     * @return BelongsTo<ServiceRequest, $this>
+     */
+    public function serviceRequest(): BelongsTo
     {
-        if (! isset($serviceRequestStatus->sort)) {
-            $serviceRequestStatus->setAttribute(
-                'sort',
-                DB::raw('(SELECT COALESCE(MAX(service_request_statuses.sort), 0) + 1 FROM service_request_statuses)')
-            );
-        }
+        return $this->belongsTo(ServiceRequest::class);
     }
 
-    public function updated(ServiceRequestStatus $serviceRequestStatus): void
+    /**
+     * @return BelongsTo<ServiceRequestStatus, $this>
+     */
+    public function status(): BelongsTo
     {
-        if ($serviceRequestStatus->wasChanged('classification')) {
-            RecordReclassifiedServiceRequestStatusPeriods::dispatch($serviceRequestStatus, CarbonImmutable::now());
-        }
+        return $this->belongsTo(ServiceRequestStatus::class, 'service_request_status_id');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'classification' => SystemServiceRequestClassification::class,
+            'started_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected function serializeDate(DateTimeInterface $date): string
+    {
+        return $date->format(config('project.datetime_format') ?? 'Y-m-d H:i:s');
     }
 }

--- a/app-modules/service-management/src/Models/ServiceRequestStatusPeriod.php
+++ b/app-modules/service-management/src/Models/ServiceRequestStatusPeriod.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AidingApp\ServiceManagement\Models;
+
+use AidingApp\ServiceManagement\Database\Factories\ServiceRequestStatusPeriodFactory;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use App\Models\BaseModel;
+use DateTimeInterface;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @mixin IdeHelperServiceRequestStatusPeriod
+ */
+class ServiceRequestStatusPeriod extends BaseModel
+{
+    /** @use HasFactory<ServiceRequestStatusPeriodFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'service_request_id',
+        'service_request_status_id',
+        'classification',
+        'started_at',
+    ];
+
+    /**
+     * @return BelongsTo<ServiceRequest, $this>
+     */
+    public function serviceRequest(): BelongsTo
+    {
+        return $this->belongsTo(ServiceRequest::class);
+    }
+
+    /**
+     * @return BelongsTo<ServiceRequestStatus, $this>
+     */
+    public function status(): BelongsTo
+    {
+        return $this->belongsTo(ServiceRequestStatus::class, 'service_request_status_id');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'classification' => SystemServiceRequestClassification::class,
+            'started_at' => 'immutable_datetime',
+        ];
+    }
+
+    protected function serializeDate(DateTimeInterface $date): string
+    {
+        return $date->format(config('project.datetime_format') ?? 'Y-m-d H:i:s');
+    }
+}

--- a/app-modules/service-management/src/Observers/ServiceRequestObserver.php
+++ b/app-modules/service-management/src/Observers/ServiceRequestObserver.php
@@ -40,6 +40,7 @@ use AidingApp\Notification\Notifications\Channels\DatabaseChannel;
 use AidingApp\Notification\Notifications\Channels\MailChannel;
 use AidingApp\ServiceManagement\Actions\CreateServiceRequestHistory;
 use AidingApp\ServiceManagement\Actions\NotifyServiceRequestUsers;
+use AidingApp\ServiceManagement\Actions\RecordServiceRequestStatusPeriod;
 use AidingApp\ServiceManagement\Enums\ServiceRequestEmailTemplateType;
 use AidingApp\ServiceManagement\Enums\ServiceRequestNotificationChannel;
 use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
@@ -76,6 +77,8 @@ class ServiceRequestObserver
 
     public function created(ServiceRequest $serviceRequest): void
     {
+        app(RecordServiceRequestStatusPeriod::class)->execute($serviceRequest, $serviceRequest->created_at);
+
         if (! $serviceRequest->isDraft()) {
             $this->writeCreatedHistory($serviceRequest);
         }
@@ -119,6 +122,13 @@ class ServiceRequestObserver
 
     public function saved(ServiceRequest $serviceRequest): void
     {
+        if (! $serviceRequest->wasRecentlyCreated && $serviceRequest->wasChanged('status_id')) {
+            app(RecordServiceRequestStatusPeriod::class)->execute(
+                $serviceRequest,
+                $serviceRequest->status_updated_at,
+            );
+        }
+
         if (! $serviceRequest->isDraft() && ! $serviceRequest->wasRecentlyCreated) {
             $actor = $this->resolveActor();
 

--- a/app-modules/service-management/src/Observers/ServiceRequestObserver.php
+++ b/app-modules/service-management/src/Observers/ServiceRequestObserver.php
@@ -40,6 +40,7 @@ use AidingApp\Notification\Notifications\Channels\DatabaseChannel;
 use AidingApp\Notification\Notifications\Channels\MailChannel;
 use AidingApp\ServiceManagement\Actions\CreateServiceRequestHistory;
 use AidingApp\ServiceManagement\Actions\NotifyServiceRequestUsers;
+use AidingApp\ServiceManagement\Actions\RecordServiceRequestStatusPeriod;
 use AidingApp\ServiceManagement\Enums\ServiceRequestEmailTemplateType;
 use AidingApp\ServiceManagement\Enums\ServiceRequestNotificationChannel;
 use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
@@ -55,6 +56,7 @@ use AidingApp\ServiceManagement\Notifications\ServiceRequestClosed;
 use AidingApp\ServiceManagement\Notifications\ServiceRequestStatusChanged;
 use AidingApp\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceRequestNumberGenerator;
 use App\Enums\Feature;
+use App\Features\SlaWaitingExclusionFeature;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
@@ -76,6 +78,8 @@ class ServiceRequestObserver
 
     public function created(ServiceRequest $serviceRequest): void
     {
+        app(RecordServiceRequestStatusPeriod::class)->execute($serviceRequest, $serviceRequest->created_at);
+
         if (! $serviceRequest->isDraft()) {
             $this->writeCreatedHistory($serviceRequest);
         }
@@ -103,22 +107,42 @@ class ServiceRequestObserver
         if ($serviceRequest->isDirty('status_id')) {
             $serviceRequest->status_updated_at = CarbonImmutable::now();
 
-            if (
-                $serviceRequest->status->classification === SystemServiceRequestClassification::Closed &&
-                is_null($serviceRequest->time_to_resolution)
-            ) {
-                $createdTime = $serviceRequest->created_at;
-                $currentTime = Carbon::now();
+            // The status relation may still hold the previously loaded status, so reload it to match the new status_id.
+            $serviceRequest->unsetRelation('status');
 
-                // Calculate the difference in seconds
-                $secondsDifference = $createdTime ? (int) round($createdTime->diffInSeconds($currentTime)) : null;
-                $serviceRequest->time_to_resolution = $secondsDifference;
+            if ($serviceRequest->status->classification === SystemServiceRequestClassification::Closed) {
+                if (SlaWaitingExclusionFeature::active() && $serviceRequest->exists) {
+                    $end = $serviceRequest->status_updated_at;
+
+                    $seconds = (int) round($serviceRequest->created_at->diffInSeconds($end));
+
+                    $seconds -= $serviceRequest->getExcludedSecondsBetween($serviceRequest->created_at, $end, [
+                        SystemServiceRequestClassification::Waiting,
+                        SystemServiceRequestClassification::Closed,
+                    ]);
+
+                    $serviceRequest->time_to_resolution = max(0, $seconds);
+                } elseif (is_null($serviceRequest->time_to_resolution)) {
+                    $createdTime = $serviceRequest->created_at;
+                    $currentTime = Carbon::now();
+
+                    // Calculate the difference in seconds
+                    $secondsDifference = $createdTime ? (int) round($createdTime->diffInSeconds($currentTime)) : null;
+                    $serviceRequest->time_to_resolution = $secondsDifference;
+                }
             }
         }
     }
 
     public function saved(ServiceRequest $serviceRequest): void
     {
+        if (! $serviceRequest->wasRecentlyCreated && $serviceRequest->wasChanged('status_id')) {
+            app(RecordServiceRequestStatusPeriod::class)->execute(
+                $serviceRequest,
+                $serviceRequest->status_updated_at,
+            );
+        }
+
         if (! $serviceRequest->isDraft() && ! $serviceRequest->wasRecentlyCreated) {
             $actor = $this->resolveActor();
 

--- a/app-modules/service-management/src/Observers/ServiceRequestObserver.php
+++ b/app-modules/service-management/src/Observers/ServiceRequestObserver.php
@@ -108,7 +108,7 @@ class ServiceRequestObserver
             $serviceRequest->status_updated_at = CarbonImmutable::now();
 
             if ($serviceRequest->status->classification === SystemServiceRequestClassification::Closed) {
-                if (SlaWaitingExclusionFeature::active()) {
+                if (SlaWaitingExclusionFeature::active() && ! is_null($serviceRequest->created_at)) {
                     $end = $serviceRequest->status_updated_at;
 
                     $seconds = (int) round($serviceRequest->created_at->diffInSeconds($end));

--- a/app-modules/service-management/src/Observers/ServiceRequestObserver.php
+++ b/app-modules/service-management/src/Observers/ServiceRequestObserver.php
@@ -56,6 +56,7 @@ use AidingApp\ServiceManagement\Notifications\ServiceRequestClosed;
 use AidingApp\ServiceManagement\Notifications\ServiceRequestStatusChanged;
 use AidingApp\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceRequestNumberGenerator;
 use App\Enums\Feature;
+use App\Features\SlaWaitingExclusionFeature;
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
@@ -106,16 +107,26 @@ class ServiceRequestObserver
         if ($serviceRequest->isDirty('status_id')) {
             $serviceRequest->status_updated_at = CarbonImmutable::now();
 
-            if (
-                $serviceRequest->status->classification === SystemServiceRequestClassification::Closed &&
-                is_null($serviceRequest->time_to_resolution)
-            ) {
-                $createdTime = $serviceRequest->created_at;
-                $currentTime = Carbon::now();
+            if ($serviceRequest->status->classification === SystemServiceRequestClassification::Closed) {
+                if (SlaWaitingExclusionFeature::active()) {
+                    $end = $serviceRequest->status_updated_at;
 
-                // Calculate the difference in seconds
-                $secondsDifference = $createdTime ? (int) round($createdTime->diffInSeconds($currentTime)) : null;
-                $serviceRequest->time_to_resolution = $secondsDifference;
+                    $seconds = (int) round($serviceRequest->created_at->diffInSeconds($end));
+
+                    $seconds -= $serviceRequest->getExcludedSecondsBetween($serviceRequest->created_at, $end, [
+                        SystemServiceRequestClassification::Waiting,
+                        SystemServiceRequestClassification::Closed,
+                    ]);
+
+                    $serviceRequest->time_to_resolution = max(0, $seconds);
+                } elseif (is_null($serviceRequest->time_to_resolution)) {
+                    $createdTime = $serviceRequest->created_at;
+                    $currentTime = Carbon::now();
+
+                    // Calculate the difference in seconds
+                    $secondsDifference = $createdTime ? (int) round($createdTime->diffInSeconds($currentTime)) : null;
+                    $serviceRequest->time_to_resolution = $secondsDifference;
+                }
             }
         }
     }

--- a/app-modules/service-management/src/Observers/ServiceRequestObserver.php
+++ b/app-modules/service-management/src/Observers/ServiceRequestObserver.php
@@ -108,7 +108,7 @@ class ServiceRequestObserver
             $serviceRequest->status_updated_at = CarbonImmutable::now();
 
             if ($serviceRequest->status->classification === SystemServiceRequestClassification::Closed) {
-                if (SlaWaitingExclusionFeature::active() && ! is_null($serviceRequest->created_at)) {
+                if (SlaWaitingExclusionFeature::active() && $serviceRequest->exists) {
                     $end = $serviceRequest->status_updated_at;
 
                     $seconds = (int) round($serviceRequest->created_at->diffInSeconds($end));

--- a/app-modules/service-management/tests/Tenant/Actions/RecordReclassifiedServiceRequestStatusPeriodsTest.php
+++ b/app-modules/service-management/tests/Tenant/Actions/RecordReclassifiedServiceRequestStatusPeriodsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\ServiceManagement\Actions\RecordReclassifiedServiceRequestStatusPeriods;
+use AidingApp\ServiceManagement\Actions\RecordServiceRequestStatusPeriod;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Notification;
+
+it('appends a status period for every request currently in the reclassified status', function () {
+    Notification::fake();
+
+    $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+    $this->travelTo($start);
+
+    $status = ServiceRequestStatus::factory()->inProgress()->create();
+
+    $serviceRequests = ServiceRequest::factory()->count(2)->create(['status_id' => $status->getKey()]);
+
+    // Simulate the reclassification: the status now resolves to a different classification.
+    $status->classification = SystemServiceRequestClassification::Waiting;
+
+    $reclassifiedAt = $start->addSeconds(100);
+
+    (new RecordReclassifiedServiceRequestStatusPeriods($status, $reclassifiedAt))
+        ->handle(app(RecordServiceRequestStatusPeriod::class));
+
+    foreach ($serviceRequests as $serviceRequest) {
+        $latestPeriod = $serviceRequest->statusPeriods()
+            ->orderByDesc('started_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        expect($latestPeriod->service_request_status_id)->toBe($status->getKey())
+            ->and($latestPeriod->classification)->toBe(SystemServiceRequestClassification::Waiting)
+            ->and($latestPeriod->started_at->toDateTimeString())->toBe($reclassifiedAt->toDateTimeString());
+    }
+});

--- a/app-modules/service-management/tests/Tenant/Actions/RecordServiceRequestStatusPeriodTest.php
+++ b/app-modules/service-management/tests/Tenant/Actions/RecordServiceRequestStatusPeriodTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\ServiceManagement\Actions\RecordServiceRequestStatusPeriod;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Notification;
+
+it('records a status period for the current status', function () {
+    Notification::fake();
+
+    $status = ServiceRequestStatus::factory()->open()->create();
+    $serviceRequest = ServiceRequest::factory()->create(['status_id' => $status->getKey()]);
+
+    // The observer records an initial period on create; clear it to isolate the action.
+    $serviceRequest->statusPeriods()->delete();
+
+    $startedAt = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+    app(RecordServiceRequestStatusPeriod::class)->execute($serviceRequest, $startedAt);
+
+    $period = $serviceRequest->statusPeriods()->sole();
+
+    expect($period->service_request_status_id)->toBe($status->getKey())
+        ->and($period->classification)->toBe(SystemServiceRequestClassification::Open)
+        ->and($period->started_at->toDateTimeString())->toBe($startedAt->toDateTimeString());
+});
+
+it('does not record a consecutive duplicate status period', function () {
+    Notification::fake();
+
+    $status = ServiceRequestStatus::factory()->open()->create();
+    $serviceRequest = ServiceRequest::factory()->create(['status_id' => $status->getKey()]);
+
+    $serviceRequest->statusPeriods()->delete();
+
+    $action = app(RecordServiceRequestStatusPeriod::class);
+
+    $action->execute($serviceRequest, CarbonImmutable::parse('2026-01-01 00:00:00'));
+    $action->execute($serviceRequest, CarbonImmutable::parse('2026-01-01 01:00:00'));
+
+    expect($serviceRequest->statusPeriods()->count())->toBe(1);
+});

--- a/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/EditServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Resources/ServiceRequests/Pages/EditServiceRequestTest.php
@@ -51,6 +51,7 @@ use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use AidingApp\ServiceManagement\Models\ServiceRequestTypeEmailPreference;
 use AidingApp\ServiceManagement\Notifications\SendClosedServiceFeedbackNotification;
 use AidingApp\ServiceManagement\Tests\Tenant\RequestFactories\EditServiceRequestRequestFactory;
+use App\Features\SlaWaitingExclusionFeature;
 use App\Models\User;
 use App\Settings\LicenseSettings;
 use Illuminate\Support\Facades\Notification;
@@ -120,6 +121,8 @@ test('A successful action on the EditServiceRequest page', function () {
 });
 
 test('check if time to resolution has correct value when status is changed', function () {
+    SlaWaitingExclusionFeature::deactivate();
+
     travel(-10)->seconds();
 
     $serviceRequest = ServiceRequest::factory([

--- a/app-modules/service-management/tests/Tenant/Jobs/RecordReclassifiedServiceRequestStatusPeriodsTest.php
+++ b/app-modules/service-management/tests/Tenant/Jobs/RecordReclassifiedServiceRequestStatusPeriodsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\ServiceManagement\Actions\RecordServiceRequestStatusPeriod;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use AidingApp\ServiceManagement\Jobs\RecordReclassifiedServiceRequestStatusPeriods;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Notification;
+
+it('appends a status period for every request currently in the reclassified status', function () {
+    Notification::fake();
+
+    $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+    $this->travelTo($start);
+
+    $status = ServiceRequestStatus::factory()->inProgress()->create();
+
+    $serviceRequests = ServiceRequest::factory()->count(2)->create(['status_id' => $status->getKey()]);
+
+    // Simulate the reclassification: the status now resolves to a different classification.
+    $status->classification = SystemServiceRequestClassification::Waiting;
+
+    $reclassifiedAt = $start->addSeconds(100);
+
+    (new RecordReclassifiedServiceRequestStatusPeriods($status, $reclassifiedAt))
+        ->handle(app(RecordServiceRequestStatusPeriod::class));
+
+    foreach ($serviceRequests as $serviceRequest) {
+        $latestPeriod = $serviceRequest->statusPeriods()
+            ->orderByDesc('started_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        expect($latestPeriod->service_request_status_id)->toBe($status->getKey())
+            ->and($latestPeriod->classification)->toBe(SystemServiceRequestClassification::Waiting)
+            ->and($latestPeriod->started_at->toDateTimeString())->toBe($reclassifiedAt->toDateTimeString());
+    }
+});
+
+it('splits the sla calculation at the reclassification boundary', function () {
+    Notification::fake();
+
+    $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+    $this->travelTo($start);
+
+    $status = ServiceRequestStatus::factory()->open()->create();
+
+    $serviceRequest = ServiceRequest::factory()->create(['status_id' => $status->getKey()]);
+
+    // The status is reclassified from Open to Waiting 100 seconds after the request was created.
+    $status->classification = SystemServiceRequestClassification::Waiting;
+
+    $reclassifiedAt = $start->addSeconds(100);
+
+    (new RecordReclassifiedServiceRequestStatusPeriods($status, $reclassifiedAt))
+        ->handle(app(RecordServiceRequestStatusPeriod::class));
+
+    $this->travelTo($start->addSeconds(300));
+
+    $serviceRequest->load('statusPeriods');
+
+    // The 100s before the reclassification stays Open (not excluded); the 200s after is Waiting (excluded).
+    expect($serviceRequest->getExcludedSecondsBetween($start, $start->addSeconds(300), [SystemServiceRequestClassification::Waiting]))
+        ->toBe(200)
+        ->and($serviceRequest->getExcludedSecondsBetween($start, $start->addSeconds(300), [SystemServiceRequestClassification::Open]))
+        ->toBe(100);
+});

--- a/app-modules/service-management/tests/Tenant/Models/ServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Models/ServiceRequestTest.php
@@ -249,4 +249,29 @@ describe('SLA waiting exclusion', function () {
         // The raw 180s exceeds the 150s SLA, but excluding the 50s waiting span brings it to 130s.
         expect($serviceRequest->fresh()->getResolutionSlaComplianceStatus())->toBe(SlaComplianceStatus::Compliant);
     });
+
+    it('excludes time spent closed before a reopen from the resolution seconds when the feature is active', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        $this->travelTo($start->addSeconds(200));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(300));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // The 300s window excludes the 100s the request spent closed before it was reopened.
+        expect($serviceRequest->fresh()->getResolutionSeconds())->toBe(200);
+    });
 });

--- a/app-modules/service-management/tests/Tenant/Models/ServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Models/ServiceRequestTest.php
@@ -36,10 +36,17 @@
 
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Contact\Models\Organization;
+use AidingApp\ServiceManagement\Enums\SlaComplianceStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
+use AidingApp\ServiceManagement\Models\Sla;
+use App\Features\SlaWaitingExclusionFeature;
 use App\Models\User;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
 
 if (! function_exists('recentUpdateCreatorInfo')) {
@@ -107,4 +114,139 @@ it('appends the file-attachment note when the update has uploads', function () {
 
     expect((string) $serviceRequest->getRecentUpdateFormatted())
         ->toContain('<br><br>Note: Files were attached with this update. Please login the service portal to see the files.');
+});
+
+describe('SLA waiting exclusion', function () {
+    it('excludes waiting and closed time from the resolution seconds when the feature is active', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(180));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // Total window is 180s; the 50s waiting span is excluded, the closed span is zero-length.
+        expect($serviceRequest->fresh()->getResolutionSeconds())->toBe(130);
+    });
+
+    it('includes waiting and closed time in the resolution seconds when the feature is inactive', function () {
+        Notification::fake();
+        SlaWaitingExclusionFeature::deactivate();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(180));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        expect($serviceRequest->fresh()->getResolutionSeconds())->toBe(180);
+    });
+
+    it('excludes waiting time from the latest response seconds when the feature is active', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        // Window is 150s with no inbound update; the 50s waiting span is excluded.
+        expect($serviceRequest->fresh()->getLatestResponseSeconds())->toBe(100);
+    });
+
+    it('recomputes the stored time to resolution from the ledger on close when the feature is active', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // 150s window minus the 50s waiting span.
+        expect($serviceRequest->fresh()->time_to_resolution)->toBe(100);
+    });
+
+    it('reports the resolution SLA as compliant once waiting time is excluded', function () {
+        Notification::fake();
+
+        $sla = Sla::create([
+            'name' => 'Test SLA',
+            'response_seconds' => 60,
+            'resolution_seconds' => 150,
+        ]);
+
+        $priority = ServiceRequestPriority::factory()->create(['sla_id' => $sla->getKey()]);
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create([
+            'status_id' => $open->getKey(),
+            'priority_id' => $priority->getKey(),
+        ]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(180));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // The raw 180s exceeds the 150s SLA, but excluding the 50s waiting span brings it to 130s.
+        expect($serviceRequest->fresh()->getResolutionSlaComplianceStatus())->toBe(SlaComplianceStatus::Compliant);
+    });
 });

--- a/app-modules/service-management/tests/Tenant/Models/ServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Models/ServiceRequestTest.php
@@ -36,10 +36,17 @@
 
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Contact\Models\Organization;
+use AidingApp\ServiceManagement\Enums\SlaComplianceStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
+use AidingApp\ServiceManagement\Models\Sla;
+use App\Features\SlaWaitingExclusionFeature;
 use App\Models\User;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
 
 if (! function_exists('recentUpdateCreatorInfo')) {
@@ -107,4 +114,189 @@ it('appends the file-attachment note when the update has uploads', function () {
 
     expect((string) $serviceRequest->getRecentUpdateFormatted())
         ->toContain('<br><br>Note: Files were attached with this update. Please login the service portal to see the files.');
+});
+
+describe('SLA waiting exclusion', function () {
+    it('excludes waiting and closed time from the resolution seconds when the feature is active', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(180));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // Total window is 180s; the 50s waiting span is excluded, the closed span is zero-length.
+        expect($serviceRequest->fresh()->getResolutionSeconds())->toBe(130);
+    });
+
+    it('includes waiting and closed time in the resolution seconds when the feature is inactive', function () {
+        Notification::fake();
+        SlaWaitingExclusionFeature::deactivate();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(180));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        expect($serviceRequest->fresh()->getResolutionSeconds())->toBe(180);
+    });
+
+    it('excludes waiting time from the latest response seconds when the feature is active', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        // Window is 150s with no inbound update; the 50s waiting span is excluded.
+        expect($serviceRequest->fresh()->getLatestResponseSeconds())->toBe(100);
+    });
+
+    it('recomputes the stored time to resolution from the ledger on close when the feature is active', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // 150s window minus the 50s waiting span.
+        expect($serviceRequest->fresh()->time_to_resolution)->toBe(100);
+    });
+
+    it('reports the resolution SLA as compliant once waiting time is excluded', function () {
+        Notification::fake();
+
+        $sla = Sla::create([
+            'name' => 'Test SLA',
+            'response_seconds' => 60,
+            'resolution_seconds' => 150,
+        ]);
+
+        $priority = ServiceRequestPriority::factory()->create(['sla_id' => $sla->getKey()]);
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create([
+            'status_id' => $open->getKey(),
+            'priority_id' => $priority->getKey(),
+        ]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(180));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // The raw 180s exceeds the 150s SLA, but excluding the 50s waiting span brings it to 130s.
+        expect($serviceRequest->fresh()->getResolutionSlaComplianceStatus())->toBe(SlaComplianceStatus::Compliant);
+    });
+
+    it('excludes time spent closed before a reopen from the resolution seconds when the feature is active', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        $this->travelTo($start->addSeconds(200));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(300));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // The 300s window excludes the 100s the request spent closed before it was reopened.
+        expect($serviceRequest->fresh()->getResolutionSeconds())->toBe(200);
+    });
+
+    it('persists the excluded time to resolution column after a reopen and re-close cycle', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        $this->travelTo($start->addSeconds(200));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(300));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // Re-close persists 300s elapsed minus the 100s spent closed before the reopen.
+        expect((int) $serviceRequest->fresh()->time_to_resolution)->toBe(200);
+    });
 });

--- a/app-modules/service-management/tests/Tenant/Models/ServiceRequestTest.php
+++ b/app-modules/service-management/tests/Tenant/Models/ServiceRequestTest.php
@@ -37,6 +37,7 @@
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Contact\Models\Organization;
 use AidingApp\ServiceManagement\Enums\SlaComplianceStatus;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
@@ -298,5 +299,127 @@ describe('SLA waiting exclusion', function () {
 
         // Re-close persists 300s elapsed minus the 100s spent closed before the reopen.
         expect((int) $serviceRequest->fresh()->time_to_resolution)->toBe(200);
+    });
+
+    it('accounts for every second across all classifications (the ledger tiles the timeline)', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $waiting = ServiceRequestStatus::factory()->waiting()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $waiting->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(180));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        $serviceRequest = $serviceRequest->fresh();
+
+        $end = $start->addSeconds(180);
+
+        $classifications = [
+            SystemServiceRequestClassification::Open,
+            SystemServiceRequestClassification::Waiting,
+            SystemServiceRequestClassification::InProgress,
+            SystemServiceRequestClassification::Closed,
+        ];
+
+        $sumOfParts = array_sum(array_map(
+            fn (SystemServiceRequestClassification $classification): int => $serviceRequest->getExcludedSecondsBetween($start, $end, [$classification]),
+            $classifications,
+        ));
+
+        // Every second between creation and resolution belongs to exactly one classification span, and
+        // the union equals the sum of the parts — no gaps, no overlaps, no double counting.
+        expect($sumOfParts)->toBe(180)
+            ->and($serviceRequest->getExcludedSecondsBetween($start, $end, $classifications))->toBe(180);
+    });
+
+    it('anchors the resolved time to the first status change of the trailing closed run', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $resolved = ServiceRequestStatus::factory()->closed()->state(['name' => 'Resolved'])->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $resolved->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // Both trailing statuses are Closed-classified, so resolution stays at the first close (100s), not 150s.
+        expect($serviceRequest->fresh()->getResolvedAt()->toDateTimeString())
+            ->toBe($start->addSeconds(100)->toDateTimeString());
+    });
+
+    it('resets the resolved time to the latest close when a request was reopened', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $inProgress = ServiceRequestStatus::factory()->inProgress()->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        $this->travelTo($start->addSeconds(200));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $inProgress->getKey()]);
+
+        $this->travelTo($start->addSeconds(300));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // The intervening reopen breaks the earlier closed run, so resolution is the final close (300s).
+        expect($serviceRequest->fresh()->getResolvedAt()->toDateTimeString())
+            ->toBe($start->addSeconds(300)->toDateTimeString());
+    });
+
+    it('caps the response seconds at the first close when moving between two closed statuses', function () {
+        Notification::fake();
+
+        $open = ServiceRequestStatus::factory()->open()->create();
+        $resolved = ServiceRequestStatus::factory()->closed()->state(['name' => 'Resolved'])->create();
+        $closed = ServiceRequestStatus::factory()->closed()->create();
+
+        $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+        $this->travelTo($start);
+        $serviceRequest = ServiceRequest::factory()->create(['status_id' => $open->getKey()]);
+
+        $this->travelTo($start->addSeconds(50));
+        ServiceRequestUpdate::factory()
+            ->for($serviceRequest)
+            ->for(Contact::factory()->create(), 'createdBy')
+            ->create(['internal' => false]);
+
+        $this->travelTo($start->addSeconds(100));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $resolved->getKey()]);
+
+        $this->travelTo($start->addSeconds(150));
+        ServiceRequest::query()->findOrFail($serviceRequest->getKey())->update(['status_id' => $closed->getKey()]);
+
+        // Response runs from the inbound update (50s) to the first close (100s); the trailing
+        // Closed -> Closed hop from 100s to 150s must not inflate it.
+        expect($serviceRequest->fresh()->getLatestResponseSeconds())->toBe(50);
     });
 });

--- a/app/Features/SlaWaitingExclusionFeature.php
+++ b/app/Features/SlaWaitingExclusionFeature.php
@@ -34,29 +34,14 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\ServiceManagement\Observers;
+namespace App\Features;
 
-use AidingApp\ServiceManagement\Jobs\RecordReclassifiedServiceRequestStatusPeriods;
-use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
-use Carbon\CarbonImmutable;
-use Illuminate\Support\Facades\DB;
+use App\Support\AbstractFeatureFlag;
 
-class ServiceRequestStatusObserver
+class SlaWaitingExclusionFeature extends AbstractFeatureFlag
 {
-    public function creating(ServiceRequestStatus $serviceRequestStatus): void
+    public function resolve(mixed $scope): mixed
     {
-        if (! isset($serviceRequestStatus->sort)) {
-            $serviceRequestStatus->setAttribute(
-                'sort',
-                DB::raw('(SELECT COALESCE(MAX(service_request_statuses.sort), 0) + 1 FROM service_request_statuses)')
-            );
-        }
-    }
-
-    public function updated(ServiceRequestStatus $serviceRequestStatus): void
-    {
-        if ($serviceRequestStatus->wasChanged('classification')) {
-            RecordReclassifiedServiceRequestStatusPeriods::dispatch($serviceRequestStatus, CarbonImmutable::now());
-        }
+        return false;
     }
 }

--- a/app/Features/SlaWaitingExclusionFeature.php
+++ b/app/Features/SlaWaitingExclusionFeature.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class SlaWaitingExclusionFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Filament/Widgets/ListServiceRequestTableWidgets.php
+++ b/app/Filament/Widgets/ListServiceRequestTableWidgets.php
@@ -70,6 +70,7 @@ class ListServiceRequestTableWidgets extends BaseWidget
                         'sla',
                     ],
                     'status',
+                    'statusPeriods',
                 ])
             )
             ->columns([

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -37,8 +37,33 @@
 use AidingApp\Contact\Models\Organization;
 use AidingApp\Contact\Models\OrganizationIndustry;
 use AidingApp\Contact\Models\OrganizationType;
+use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
+use AidingApp\ServiceManagement\Models\ServiceRequest;
+use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+if (! function_exists('recordServiceRequestHistory')) {
+    /**
+     * @param array<string, mixed> $originalValues
+     * @param array<string, mixed> $newValues
+     */
+    function recordServiceRequestHistory(ServiceRequest $serviceRequest, array $originalValues, array $newValues, CarbonInterface $createdAt): void
+    {
+        DB::table('service_request_histories')->insert([
+            'id' => (string) Str::uuid(),
+            'service_request_id' => $serviceRequest->getKey(),
+            'original_values' => json_encode($originalValues),
+            'new_values' => json_encode($newValues),
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ]);
+    }
+}
 
 describe('2026_08_24_000001_convert_organizations_name_to_citext_and_enforce_unique', function () {
     $migrationPath = 'app-modules/contact/database/migrations/2026_08_24_000001_convert_organizations_name_to_citext_and_enforce_unique.php';
@@ -142,6 +167,82 @@ describe('2026_08_24_000002_convert_organization_type_and_industry_name_to_citex
 });
 
 // Example migration test, leave commented out for future use as a template/example
+describe('2026_08_12_163559_tmp_backfill_service_request_status_periods', function () {
+    $migrationName = '2026_08_12_163559_tmp_backfill_service_request_status_periods';
+    $migrationPath = "app-modules/service-management/database/migrations/{$migrationName}.php";
+
+    it('backfills a status period ledger from the service request history', function () use ($migrationName, $migrationPath) {
+        isolatedMigration($migrationName, function () use ($migrationPath) {
+            $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+            $open = ServiceRequestStatus::factory()->open()->create();
+            $waiting = ServiceRequestStatus::factory()->waiting()->create();
+            $closed = ServiceRequestStatus::factory()->closed()->create();
+
+            $serviceRequest = ServiceRequest::factory()->create([
+                'status_id' => $closed->getKey(),
+                'created_at' => $start,
+            ]);
+
+            // Start from a clean slate: drop any ledger and history the observers recorded on create.
+            DB::table('service_request_status_periods')->delete();
+            DB::table('service_request_histories')->delete();
+
+            recordServiceRequestHistory($serviceRequest, [], ['status_id' => $open->getKey()], $start);
+            recordServiceRequestHistory($serviceRequest, ['status_id' => $open->getKey()], ['status_id' => $waiting->getKey()], $start->addSeconds(100));
+            recordServiceRequestHistory($serviceRequest, ['status_id' => $waiting->getKey()], ['status_id' => $closed->getKey()], $start->addSeconds(200));
+
+            expect(Artisan::call('migrate', ['--path' => $migrationPath]))->toBe(Command::SUCCESS);
+
+            $periods = DB::table('service_request_status_periods')
+                ->where('service_request_id', $serviceRequest->getKey())
+                ->orderBy('started_at')
+                ->get();
+
+            expect($periods)->toHaveCount(3)
+                ->and($periods[0]->service_request_status_id)->toBe($open->getKey())
+                ->and($periods[0]->classification)->toBe(SystemServiceRequestClassification::Open->value)
+                ->and($periods[1]->service_request_status_id)->toBe($waiting->getKey())
+                ->and($periods[1]->classification)->toBe(SystemServiceRequestClassification::Waiting->value)
+                ->and($periods[2]->service_request_status_id)->toBe($closed->getKey())
+                ->and($periods[2]->classification)->toBe(SystemServiceRequestClassification::Closed->value);
+        });
+    });
+
+    it('records a null classification period when a historical status was hard-deleted', function () use ($migrationName, $migrationPath) {
+        isolatedMigration($migrationName, function () use ($migrationPath) {
+            $start = CarbonImmutable::parse('2026-01-01 00:00:00');
+
+            $open = ServiceRequestStatus::factory()->open()->create();
+            $deletedStatusId = (string) Str::uuid();
+
+            $serviceRequest = ServiceRequest::factory()->create([
+                'status_id' => $open->getKey(),
+                'created_at' => $start,
+            ]);
+
+            DB::table('service_request_status_periods')->delete();
+            DB::table('service_request_histories')->delete();
+
+            recordServiceRequestHistory($serviceRequest, [], ['status_id' => $open->getKey()], $start);
+            recordServiceRequestHistory($serviceRequest, ['status_id' => $open->getKey()], ['status_id' => $deletedStatusId], $start->addSeconds(100));
+
+            expect(Artisan::call('migrate', ['--path' => $migrationPath]))->toBe(Command::SUCCESS);
+
+            $periods = DB::table('service_request_status_periods')
+                ->where('service_request_id', $serviceRequest->getKey())
+                ->orderBy('started_at')
+                ->get();
+
+            expect($periods)->toHaveCount(2)
+                ->and($periods[0]->service_request_status_id)->toBe($open->getKey())
+                ->and($periods[0]->classification)->toBe(SystemServiceRequestClassification::Open->value)
+                ->and($periods[1]->service_request_status_id)->toBeNull()
+                ->and($periods[1]->classification)->toBeNull();
+        });
+    });
+});
+
 //describe('2025_01_01_165527_tmp_data_do_a_thing', function () {
 //    it('properly changed the data', function () {
 //        isolatedMigration(


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1384

### Technical Description

- Added a `service_request_status_periods` ledger (model, factory, migrations) and observers/actions to record periods on create, status changes, and status reclassification.
- Updated `ServiceRequest` SLA timing calculations (`getResolutionSeconds`(), `getLatestResponseSeconds`(), and stored time_to_resolution on close) to subtract excluded classifications when `SlaWaitingExclusionFeature` is active.
- Added/updated tests covering waiting/closed exclusion behavior and period-recording behaviors, plus backfill + feature activation via a temporary migration.
### Any deployment steps required?

 NO

### Cleanup Tasks

- Feature Flag Cleanup: .cleanup-tasks/2026_08_12_sla_waiting_exclusion_feature.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
