### PR TITLE
[AIDAPP-1396]: Improve the way users can select project task details

### DIFF
--- a/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidget.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidget.php
@@ -39,6 +39,7 @@ namespace AidingApp\Project\Filament\Resources\Projects\Widgets;
 use AidingApp\Project\Enums\PipelineStageClassification;
 use AidingApp\Project\Filament\Concerns\HasPipelineSwitcherAction;
 use AidingApp\Project\Filament\Resources\Pipelines\Actions\EditPipelineEntryAction;
+use AidingApp\Project\Filament\Resources\Pipelines\Actions\ViewPipelineEntryAction;
 use AidingApp\Project\Filament\Resources\Pipelines\Forms\PipelineEntryForm;
 use AidingApp\Project\Filament\Resources\Pipelines\PipelineResource;
 use AidingApp\Project\Models\Pipeline;
@@ -128,7 +129,11 @@ class ProjectWorkPipelineWidget extends TableWidget
                 TextColumn::make('name')
                     ->label('Task Name')
                     ->searchable(['pipeline_entries.name'])
-                    ->sortable(),
+                    ->sortable()
+                    ->extraAttributes(['class' => 'underline'])
+                    ->action(function (PipelineEntry $record): void {
+                        $this->openPipelineEntry($record);
+                    }),
                 ViewColumn::make('milestones')
                     ->label('Milestones')
                     ->view('project::filament.tables.columns.pipeline-entry.milestones'),
@@ -155,15 +160,6 @@ class ProjectWorkPipelineWidget extends TableWidget
                     ->label('Stage')
                     ->collapsible(),
             )
-            ->recordActions([
-                EditPipelineEntryAction::make(
-                    $pipeline,
-                    after: function (): void {
-                        $this->dispatch('projectPipelineUpdated');
-                    },
-                )
-                    ->authorize(fn (): bool => auth()->user()->can('update', $this->record)),
-            ])
             ->emptyStateHeading($pipeline ? 'No pipeline tasks' : 'No pipeline selected')
             ->emptyStateDescription(
                 $pipeline
@@ -215,6 +211,34 @@ class ProjectWorkPipelineWidget extends TableWidget
             ]);
     }
 
+    public function openPipelineEntry(PipelineEntry $record): void
+    {
+        $entry = $this->resolvePipelineEntry($record->getKey());
+
+        $this->mountAction(
+            auth()->user()->can('update', $this->record) ? 'editPipelineEntry' : 'viewPipelineEntry',
+            ['entry' => $entry->getKey()],
+        );
+    }
+
+    public function viewPipelineEntryAction(): Action
+    {
+        return ViewPipelineEntryAction::make('viewPipelineEntry')
+            ->authorize(fn (): bool => auth()->user()->can('view', $this->record))
+            ->record(fn (array $arguments): PipelineEntry => $this->resolvePipelineEntry($arguments['entry'] ?? null));
+    }
+
+    public function editPipelineEntryAction(): Action
+    {
+        return EditPipelineEntryAction::make(
+            $this->getSelectedPipeline(),
+            'editPipelineEntry',
+            after: fn () => $this->dispatch('projectPipelineUpdated'),
+        )
+            ->authorize(fn (): bool => auth()->user()->can('update', $this->record))
+            ->record(fn (array $arguments): PipelineEntry => $this->resolvePipelineEntry($arguments['entry'] ?? null));
+    }
+
     public function createPipelineAction(): Action
     {
         return Action::make('createPipeline')
@@ -262,6 +286,24 @@ class ProjectWorkPipelineWidget extends TableWidget
     protected function entryFormSchema(?Pipeline $pipeline): array
     {
         return PipelineEntryForm::components($pipeline);
+    }
+
+    protected function resolvePipelineEntry(?string $entryId): PipelineEntry
+    {
+        $pipeline = $this->getSelectedPipeline();
+
+        if ($pipeline === null) {
+            abort(404);
+        }
+
+        return $pipeline
+            ->entries()
+            ->when(
+                PipelineArchivingFeature::active(),
+                fn (Builder $query): Builder => $query->withoutArchived(),
+            )
+            ->whereKey($entryId)
+            ->firstOrFail();
     }
 
     /**

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
@@ -488,14 +488,16 @@ it('clears related milestones, assets, and service requests on the widget edit a
     livewire(ProjectWorkPipelineWidget::class, [
         'record' => $project,
     ])
-        ->callTableAction('edit', $entry, data: [
+        ->mountAction('editPipelineEntry', ['entry' => $entry->getKey()])
+        ->setActionData([
             'name' => $entry->name,
             'pipeline_stage_id' => $stage->getKey(),
             'milestones_type' => 'none',
             'assets_type' => 'none',
             'service_requests_type' => 'none',
         ])
-        ->assertHasNoTableActionErrors();
+        ->callMountedAction()
+        ->assertHasNoActionErrors();
 
     $entry->refresh();
 

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
@@ -155,7 +155,7 @@ it('excludes archived tasks from the pipeline board', function () {
         ->assertCanNotSeeTableRecords([$archived]);
 });
 
-it('does not display a row-level edit action for pipeline tasks', function () {
+it('does not provide a row-level edit action because task editing is accessed through the name column', function () {
     $project = Project::factory()->create();
     $pipeline = Pipeline::factory()->for($project)->create();
     $stage = PipelineStage::factory()->for($pipeline)->create();

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/Widgets/ProjectWorkPipelineWidgetTest.php
@@ -155,6 +155,16 @@ it('excludes archived tasks from the pipeline board', function () {
         ->assertCanNotSeeTableRecords([$archived]);
 });
 
+it('does not display a row-level edit action for pipeline tasks', function () {
+    $project = Project::factory()->create();
+    $pipeline = Pipeline::factory()->for($project)->create();
+    $stage = PipelineStage::factory()->for($pipeline)->create();
+    $entry = PipelineEntry::factory()->for($stage, 'pipelineStage')->create();
+
+    livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+        ->assertTableActionDoesNotExist('edit', record: $entry);
+});
+
 describe('feature flag inactive', function () {
     it('keeps archived pipelines in the switcher list when the flag is inactive', function () {
         PipelineArchivingFeature::deactivate();
@@ -227,5 +237,51 @@ describe('archive authorization', function () {
         livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
             ->mountAction('selectPipeline')
             ->assertActionHidden('archivePipeline');
+    });
+});
+
+describe('task access authorization', function () {
+    it('opens pipeline task details for a project auditor', function () {
+        $auditor = User::factory()->create();
+        $auditor->givePermissionTo('project.*.view');
+        $auditor->refresh();
+
+        $project = Project::factory()->create();
+        $project->auditorUsers()->attach($auditor);
+        $pipeline = Pipeline::factory()->for($project)->create();
+        $stage = PipelineStage::factory()->for($pipeline)->create();
+        $entry = PipelineEntry::factory()->for($stage, 'pipelineStage')->create(['name' => 'View-only task']);
+
+        actingAs($auditor);
+
+        livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+            ->callTableColumnAction('name', $entry)
+            ->assertActionMounted('viewPipelineEntry')
+            ->assertSchemaStateSet(['name' => 'View-only task'])
+            ->unmountAction()
+            ->assertActionHidden('editPipelineEntry');
+    });
+
+    it('opens an editable pipeline task form for a project manager', function () {
+        $manager = User::factory()->create();
+        $manager->givePermissionTo(['project.*.view', 'project.*.update']);
+        $manager->refresh();
+
+        $project = Project::factory()->create();
+        $project->managerUsers()->attach($manager);
+        $pipeline = Pipeline::factory()->for($project)->create();
+        $stage = PipelineStage::factory()->for($pipeline)->create();
+        $entry = PipelineEntry::factory()->for($stage, 'pipelineStage')->create(['description' => 'Original description.']);
+
+        actingAs($manager);
+
+        livewire(ProjectWorkPipelineWidget::class, ['record' => $project])
+            ->callTableColumnAction('name', $entry)
+            ->assertActionMounted('editPipelineEntry')
+            ->setActionData(['description' => 'Updated description.'])
+            ->callMountedAction()
+            ->assertHasNoActionErrors();
+
+        expect($entry->refresh()->description)->toBe('Updated description.');
     });
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1396

### Technical Description

> Improve the way users can select project task details

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
