### PR TITLE
[AIDAPP-1336]: Introduce support for organization defined landing page tab in the portal for the knowledge base

### DIFF
--- a/.cleanup-tasks/2026_08_18_knowledge_base_category_tab_order_feature.md
+++ b/.cleanup-tasks/2026_08_18_knowledge_base_category_tab_order_feature.md
@@ -1,0 +1,8 @@
+---
+title: Knowledge Base Category Tab Order Feature Cleanup
+created: 2026-08-18
+---
+
+## Feature Flags
+
+- App\Features\KnowledgeBaseCategoryTabOrderFeature

--- a/app-modules/knowledge-base/database/migrations/2026_08_18_084600_create_knowledge_base_portal_settings.php
+++ b/app-modules/knowledge-base/database/migrations/2026_08_18_084600_create_knowledge_base_portal_settings.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use App\Features\KnowledgeBaseCategoryTabOrderFeature;
+use Illuminate\Support\Facades\DB;
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        DB::transaction(function () {
+            try {
+                $this->migrator->add('knowledge_base_portal.category_tab_order', 'all_articles_featured_most_viewed');
+            } catch (SettingAlreadyExists) {
+            }
+
+            KnowledgeBaseCategoryTabOrderFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            KnowledgeBaseCategoryTabOrderFeature::deactivate();
+
+            $this->migrator->deleteIfExists('knowledge_base_portal.category_tab_order');
+        });
+    }
+};

--- a/app-modules/knowledge-base/src/Enums/KnowledgeBaseCategoryTabOrder.php
+++ b/app-modules/knowledge-base/src/Enums/KnowledgeBaseCategoryTabOrder.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AidingApp\KnowledgeBase\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum KnowledgeBaseCategoryTabOrder: string implements HasLabel
+{
+    case AllArticlesFeaturedMostViewed = 'all_articles_featured_most_viewed';
+
+    case AllArticlesMostViewedFeatured = 'all_articles_most_viewed_featured';
+
+    case FeaturedAllArticlesMostViewed = 'featured_all_articles_most_viewed';
+
+    case FeaturedMostViewedAllArticles = 'featured_most_viewed_all_articles';
+
+    case MostViewedAllArticlesFeatured = 'most_viewed_all_articles_featured';
+
+    case MostViewedFeaturedAllArticles = 'most_viewed_featured_all_articles';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::AllArticlesFeaturedMostViewed => 'All Articles, Featured, Most Viewed',
+            self::AllArticlesMostViewedFeatured => 'All Articles, Most Viewed, Featured',
+            self::FeaturedAllArticlesMostViewed => 'Featured, All Articles, Most Viewed',
+            self::FeaturedMostViewedAllArticles => 'Featured, Most Viewed, All Articles',
+            self::MostViewedAllArticlesFeatured => 'Most Viewed, All Articles, Featured',
+            self::MostViewedFeaturedAllArticles => 'Most Viewed, Featured, All Articles',
+        };
+    }
+
+    /**
+     * The order in which the portal's category browsing tabs should be
+     * displayed, matching the tab identifiers used by the knowledge
+     * management portal frontend.
+     *
+     * @return array<string>
+     */
+    public function tabs(): array
+    {
+        return match ($this) {
+            self::AllArticlesFeaturedMostViewed => ['all-articles', 'featured', 'most-viewed'],
+            self::AllArticlesMostViewedFeatured => ['all-articles', 'most-viewed', 'featured'],
+            self::FeaturedAllArticlesMostViewed => ['featured', 'all-articles', 'most-viewed'],
+            self::FeaturedMostViewedAllArticles => ['featured', 'most-viewed', 'all-articles'],
+            self::MostViewedAllArticlesFeatured => ['most-viewed', 'all-articles', 'featured'],
+            self::MostViewedFeaturedAllArticles => ['most-viewed', 'featured', 'all-articles'],
+        };
+    }
+}

--- a/app-modules/knowledge-base/src/Filament/Pages/ManageKnowledgeBasePortalSettings.php
+++ b/app-modules/knowledge-base/src/Filament/Pages/ManageKnowledgeBasePortalSettings.php
@@ -53,7 +53,7 @@ class ManageKnowledgeBasePortalSettings extends SettingsPage
 {
     protected static ?string $navigationLabel = 'Portal';
 
-    protected static ?int $navigationSort = 5;
+    protected static ?int $navigationSort = 50;
 
     protected static string $settings = KnowledgeBasePortalSettings::class;
 
@@ -81,7 +81,7 @@ class ManageKnowledgeBasePortalSettings extends SettingsPage
                     ->schema([
                         Select::make('category_tab_order')
                             ->label('Category Tabs')
-                            ->helperText('Choose the order in which the All Articles, Featured, and Most Viewed tabs are displayed on the knowledge base category pages.')
+                            ->aboveContent('When customers browse a category or subcategory in the self-service portal, tabs organize the available articles. Use the options below to choose the order in which these tabs appear. The first tab in the selected order will be displayed by default when the page loads.')
                             ->options(KnowledgeBaseCategoryTabOrder::class)
                             ->enum(KnowledgeBaseCategoryTabOrder::class)
                             ->required(),

--- a/app-modules/knowledge-base/src/Filament/Pages/ManageKnowledgeBasePortalSettings.php
+++ b/app-modules/knowledge-base/src/Filament/Pages/ManageKnowledgeBasePortalSettings.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AidingApp\KnowledgeBase\Filament\Pages;
+
+use AidingApp\KnowledgeBase\Enums\KnowledgeBaseCategoryTabOrder;
+use AidingApp\KnowledgeBase\Settings\KnowledgeBasePortalSettings;
+use App\Enums\Feature;
+use App\Filament\Clusters\KnowledgeManagement;
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Forms\Components\Select;
+use Filament\Pages\SettingsPage;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Gate;
+
+class ManageKnowledgeBasePortalSettings extends SettingsPage
+{
+    protected static ?string $navigationLabel = 'Portal';
+
+    protected static ?int $navigationSort = 5;
+
+    protected static string $settings = KnowledgeBasePortalSettings::class;
+
+    protected static ?string $title = 'Portal';
+
+    protected static ?string $cluster = KnowledgeManagement::class;
+
+    public static function canAccess(): bool
+    {
+        if (! Gate::check(Feature::KnowledgeManagement->getGateName())) {
+            return false;
+        }
+
+        /** @var User $user */
+        $user = auth()->user();
+
+        return $user->can(['settings.view-any']);
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Configuration Options')
+                    ->schema([
+                        Select::make('category_tab_order')
+                            ->label('Category Tabs')
+                            ->helperText('Choose the order in which the All Articles, Featured, and Most Viewed tabs are displayed on the knowledge base category pages.')
+                            ->options(KnowledgeBaseCategoryTabOrder::class)
+                            ->enum(KnowledgeBaseCategoryTabOrder::class)
+                            ->required(),
+                    ]),
+            ])
+            ->disabled(! auth()->user()->can('settings.*.update'));
+    }
+
+    public function save(): void
+    {
+        if (! auth()->user()->can('settings.*.update')) {
+            return;
+        }
+
+        parent::save();
+    }
+
+    /**
+     * @return array<Action|ActionGroup>
+     */
+    public function getFormActions(): array
+    {
+        if (! auth()->user()->can('settings.*.update')) {
+            return [];
+        }
+
+        return parent::getFormActions();
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app-modules/knowledge-base/src/KnowledgeBasePlugin.php
+++ b/app-modules/knowledge-base/src/KnowledgeBasePlugin.php
@@ -49,10 +49,15 @@ class KnowledgeBasePlugin implements Plugin
 
     public function register(Panel $panel): void
     {
-        $panel->discoverResources(
-            in: __DIR__ . '/Filament/Resources',
-            for: 'AidingApp\\KnowledgeBase\\Filament\\Resources'
-        )
+        $panel
+            ->discoverResources(
+                in: __DIR__ . '/Filament/Resources',
+                for: 'AidingApp\\KnowledgeBase\\Filament\\Resources'
+            )
+            ->discoverPages(
+                in: __DIR__ . '/Filament/Pages',
+                for: 'AidingApp\\KnowledgeBase\\Filament\\Pages'
+            )
             ->livewireComponents([KnowledgeBaseItemConcernsTable::class]);
     }
 

--- a/app-modules/knowledge-base/src/Settings/KnowledgeBasePortalSettings.php
+++ b/app-modules/knowledge-base/src/Settings/KnowledgeBasePortalSettings.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AidingApp\KnowledgeBase\Settings;
+
+use AidingApp\KnowledgeBase\Enums\KnowledgeBaseCategoryTabOrder;
+use Spatie\LaravelSettings\Settings;
+
+class KnowledgeBasePortalSettings extends Settings
+{
+    public KnowledgeBaseCategoryTabOrder $category_tab_order = KnowledgeBaseCategoryTabOrder::AllArticlesFeaturedMostViewed;
+
+    public static function group(): string
+    {
+        return 'knowledge_base_portal';
+    }
+}

--- a/app-modules/knowledge-base/tests/Tenant/Enums/KnowledgeBaseCategoryTabOrderTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/Enums/KnowledgeBaseCategoryTabOrderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\KnowledgeBase\Enums\KnowledgeBaseCategoryTabOrder;
+
+it('has a human readable label for each case', function (KnowledgeBaseCategoryTabOrder $case, string $label) {
+    expect($case->getLabel())->toBe($label);
+})->with([
+    [KnowledgeBaseCategoryTabOrder::AllArticlesFeaturedMostViewed, 'All Articles, Featured, Most Viewed'],
+    [KnowledgeBaseCategoryTabOrder::AllArticlesMostViewedFeatured, 'All Articles, Most Viewed, Featured'],
+    [KnowledgeBaseCategoryTabOrder::FeaturedAllArticlesMostViewed, 'Featured, All Articles, Most Viewed'],
+    [KnowledgeBaseCategoryTabOrder::FeaturedMostViewedAllArticles, 'Featured, Most Viewed, All Articles'],
+    [KnowledgeBaseCategoryTabOrder::MostViewedAllArticlesFeatured, 'Most Viewed, All Articles, Featured'],
+    [KnowledgeBaseCategoryTabOrder::MostViewedFeaturedAllArticles, 'Most Viewed, Featured, All Articles'],
+]);
+
+it('returns the ordered tab identifiers for each case', function (KnowledgeBaseCategoryTabOrder $case, array $tabs) {
+    expect($case->tabs())->toBe($tabs);
+})->with([
+    [KnowledgeBaseCategoryTabOrder::AllArticlesFeaturedMostViewed, ['all-articles', 'featured', 'most-viewed']],
+    [KnowledgeBaseCategoryTabOrder::AllArticlesMostViewedFeatured, ['all-articles', 'most-viewed', 'featured']],
+    [KnowledgeBaseCategoryTabOrder::FeaturedAllArticlesMostViewed, ['featured', 'all-articles', 'most-viewed']],
+    [KnowledgeBaseCategoryTabOrder::FeaturedMostViewedAllArticles, ['featured', 'most-viewed', 'all-articles']],
+    [KnowledgeBaseCategoryTabOrder::MostViewedAllArticlesFeatured, ['most-viewed', 'all-articles', 'featured']],
+    [KnowledgeBaseCategoryTabOrder::MostViewedFeaturedAllArticles, ['most-viewed', 'featured', 'all-articles']],
+]);

--- a/app-modules/knowledge-base/tests/Tenant/Filament/Pages/ManageKnowledgeBasePortalSettingsTest.php
+++ b/app-modules/knowledge-base/tests/Tenant/Filament/Pages/ManageKnowledgeBasePortalSettingsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\KnowledgeBase\Enums\KnowledgeBaseCategoryTabOrder;
+use AidingApp\KnowledgeBase\Filament\Pages\ManageKnowledgeBasePortalSettings;
+use AidingApp\KnowledgeBase\Settings\KnowledgeBasePortalSettings;
+use App\Models\User;
+use App\Settings\LicenseSettings;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+it('is gated with proper access control', function () {
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->knowledgeManagement = false;
+    $settings->save();
+
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    livewire(ManageKnowledgeBasePortalSettings::class)->assertForbidden();
+
+    $user->givePermissionTo('settings.view-any');
+    $user->refresh();
+
+    livewire(ManageKnowledgeBasePortalSettings::class)->assertForbidden();
+
+    $settings->data->addons->knowledgeManagement = true;
+    $settings->save();
+
+    livewire(ManageKnowledgeBasePortalSettings::class)->assertOk();
+});
+
+it('updates the category tab order', function () {
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->knowledgeManagement = true;
+    $settings->save();
+
+    $user = User::factory()->create();
+    $user->givePermissionTo(['settings.view-any', 'settings.*.update']);
+
+    actingAs($user);
+
+    livewire(ManageKnowledgeBasePortalSettings::class)
+        ->fillForm(['category_tab_order' => KnowledgeBaseCategoryTabOrder::FeaturedMostViewedAllArticles->value])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(app(KnowledgeBasePortalSettings::class)->category_tab_order)
+        ->toBe(KnowledgeBaseCategoryTabOrder::FeaturedMostViewedAllArticles);
+});
+
+it('disables the form for users without update permission', function () {
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->knowledgeManagement = true;
+    $settings->save();
+
+    $user = User::factory()->create();
+    $user->givePermissionTo(['settings.view-any']);
+
+    actingAs($user);
+
+    livewire(ManageKnowledgeBasePortalSettings::class)
+        ->assertOk()
+        ->assertFormFieldIsDisabled('category_tab_order');
+});

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalController.php
@@ -37,9 +37,12 @@
 namespace AidingApp\Portal\Http\Controllers\KnowledgeManagementPortal;
 
 use AidingApp\Ai\Settings\AiSupportAssistantSettings;
+use AidingApp\KnowledgeBase\Enums\KnowledgeBaseCategoryTabOrder;
+use AidingApp\KnowledgeBase\Settings\KnowledgeBasePortalSettings;
 use AidingApp\Portal\Actions\ResolvePortalDisplayTimezone;
 use AidingApp\Portal\Models\PortalGuest;
 use AidingApp\Portal\Settings\PortalSettings;
+use App\Features\KnowledgeBaseCategoryTabOrderFeature;
 use App\Http\Controllers\Controller;
 use App\Settings\LicenseSettings;
 use Filament\Support\Colors\Color;
@@ -79,6 +82,9 @@ class KnowledgeManagementPortalController extends Controller
                 ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                 ->all(),
             'rounding' => $settings->knowledge_management_portal_rounding,
+            'category_tab_order' => KnowledgeBaseCategoryTabOrderFeature::active()
+                ? app(KnowledgeBasePortalSettings::class)->category_tab_order->tabs()
+                : KnowledgeBaseCategoryTabOrder::AllArticlesFeaturedMostViewed->tabs(),
             'requires_authentication' => $settings->knowledge_management_portal_requires_authentication,
             'service_management_enabled' => $settings->knowledge_management_portal_service_management && $addons?->serviceManagement,
             'service_monitoring_enabled' => $addons?->serviceMonitoring,

--- a/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalControllerTest.php
+++ b/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\KnowledgeBase\Enums\KnowledgeBaseCategoryTabOrder;
+use AidingApp\KnowledgeBase\Settings\KnowledgeBasePortalSettings;
+use AidingApp\Portal\Settings\PortalSettings;
+use App\Features\KnowledgeBaseCategoryTabOrderFeature;
+
+use function Pest\Laravel\getJson;
+
+it('returns the configured category tab order', function () {
+    $portalSettings = app(PortalSettings::class);
+    $portalSettings->knowledge_management_portal_enabled = true;
+    $portalSettings->save();
+
+    $knowledgeBasePortalSettings = app(KnowledgeBasePortalSettings::class);
+    $knowledgeBasePortalSettings->category_tab_order = KnowledgeBaseCategoryTabOrder::MostViewedFeaturedAllArticles;
+    $knowledgeBasePortalSettings->save();
+
+    $response = getJson(route('api.portal.define'));
+
+    $response->assertOk();
+
+    expect($response->json('category_tab_order'))->toBe(['most-viewed', 'featured', 'all-articles']);
+});
+
+it('falls back to the default category tab order when the feature is inactive', function () {
+    $portalSettings = app(PortalSettings::class);
+    $portalSettings->knowledge_management_portal_enabled = true;
+    $portalSettings->save();
+
+    $knowledgeBasePortalSettings = app(KnowledgeBasePortalSettings::class);
+    $knowledgeBasePortalSettings->category_tab_order = KnowledgeBaseCategoryTabOrder::MostViewedFeaturedAllArticles;
+    $knowledgeBasePortalSettings->save();
+
+    KnowledgeBaseCategoryTabOrderFeature::deactivate();
+
+    $response = getJson(route('api.portal.define'));
+
+    $response->assertOk();
+
+    expect($response->json('category_tab_order'))->toBe(['all-articles', 'featured', 'most-viewed']);
+});

--- a/app/Features/KnowledgeBaseCategoryTabOrderFeature.php
+++ b/app/Features/KnowledgeBaseCategoryTabOrderFeature.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class KnowledgeBaseCategoryTabOrderFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/portals/knowledge-management/src/Composables/useKnowledgeManagementSearch.js
+++ b/portals/knowledge-management/src/Composables/useKnowledgeManagementSearch.js
@@ -44,6 +44,8 @@ export const searchFilterTabs = [
     { label: 'Most Viewed', value: 'most-viewed' },
 ];
 
+const searchFilterTabLabels = Object.fromEntries(searchFilterTabs.map((tab) => [tab.value, tab.label]));
+
 /**
  * Shared knowledge management search behaviour, used by both the homepage and the
  * category page: keeps `searchQuery`, `selectedTags`, `filter` and `page` in sync
@@ -60,6 +62,13 @@ export function useKnowledgeManagementSearch() {
     const route = useRoute();
     const router = useRouter();
     const config = useConfigStore();
+
+    // Filter tabs ordered per the organization's configured `category_tab_order`
+    // setting (defaults to All Articles, Featured, Most Viewed), shared by every
+    // search-results view so tab order stays consistent with category browsing.
+    const orderedFilterTabs = computed(() =>
+        config.categoryTabOrder.map((value) => ({ label: searchFilterTabLabels[value] ?? value, value })),
+    );
 
     const searchQuery = ref('');
     const activeSearchQuery = ref('');
@@ -170,7 +179,7 @@ export function useKnowledgeManagementSearch() {
                 page: currentPage.value > 1 ? currentPage.value : undefined,
                 search: activeSearchQuery.value || undefined,
                 tags: activeTags.value.join(',') || undefined,
-                filter: filter.value && filter.value !== 'all-articles' ? filter.value : undefined,
+                filter: filter.value && filter.value !== orderedFilterTabs.value[0]?.value ? filter.value : undefined,
             },
         });
 
@@ -246,7 +255,7 @@ export function useKnowledgeManagementSearch() {
         const initialSearch = route.query.search || '';
         const initialTags = route.query.tags ? route.query.tags.split(',') : [];
 
-        filter.value = route.query.filter || 'all-articles';
+        filter.value = route.query.filter || orderedFilterTabs.value[0]?.value || 'all-articles';
         currentPage.value = parseInt(route.query.page) || 1;
 
         if (initialSearch || initialTags.length > 0) {
@@ -266,6 +275,7 @@ export function useKnowledgeManagementSearch() {
         loadingResults,
         globalSearchInput,
         isSearchActive,
+        orderedFilterTabs,
         searchResultArticles,
         searchResultCategories,
         currentPage,

--- a/portals/knowledge-management/src/Pages/Home.vue
+++ b/portals/knowledge-management/src/Pages/Home.vue
@@ -38,7 +38,7 @@
     import Page from '@common/portal/Page.vue';
     import SearchResults from '@common/portal/SearchResults.vue';
     import { computed } from 'vue';
-    import { searchFilterTabs, useKnowledgeManagementSearch } from '../Composables/useKnowledgeManagementSearch.js';
+    import { useKnowledgeManagementSearch } from '../Composables/useKnowledgeManagementSearch.js';
     import { useCategoriesData, useTagsData } from './loaders.js';
 
     const { data: categories } = useCategoriesData();
@@ -59,6 +59,7 @@
         loadingResults,
         globalSearchInput,
         isSearchActive,
+        orderedFilterTabs,
         toggleTag,
         changeSearchFilter,
         searchResultArticles,
@@ -100,7 +101,7 @@
             :articles="searchResultArticles"
             :categories="searchResultCategories"
             :loadingResults="loadingResults"
-            :filter-tabs="searchFilterTabs"
+            :filter-tabs="orderedFilterTabs"
             @change-filter="changeSearchFilter"
             :selected-filter="filter"
             :currentPage="currentPage"

--- a/portals/knowledge-management/src/Pages/ViewCategory.vue
+++ b/portals/knowledge-management/src/Pages/ViewCategory.vue
@@ -48,22 +48,12 @@
     import { useQuery } from '@pinia/colada';
     import { computed, ref, watch } from 'vue';
     import { useRoute, useRouter } from 'vue-router';
-    import { searchFilterTabs, useKnowledgeManagementSearch } from '../Composables/useKnowledgeManagementSearch.js';
+    import { useKnowledgeManagementSearch } from '../Composables/useKnowledgeManagementSearch.js';
     import { apiGet } from '../Services/api.js';
-    import { useConfigStore } from '../Stores/config.js';
     import { useCategoryData, useTagsData } from './loaders.js';
 
     const route = useRoute();
     const router = useRouter();
-    const configStore = useConfigStore();
-
-    const tabLabels = Object.fromEntries(searchFilterTabs.map((tab) => [tab.value, tab.label]));
-
-    // Category browsing tabs, ordered per the organization's configured
-    // `category_tab_order` setting (defaults to All Articles, Featured, Most Viewed).
-    const categoryTabs = computed(() =>
-        configStore.categoryTabOrder.map((value) => ({ label: tabLabels[value] ?? value, value })),
-    );
 
     const { data: categoryResponse } = useCategoryData();
     const { data: tags } = useTagsData();
@@ -104,6 +94,7 @@
         loadingResults: loadingSearchResults,
         globalSearchInput,
         isSearchActive,
+        orderedFilterTabs: categoryTabs,
         toggleTag,
         changeSearchFilter,
         searchResultArticles,
@@ -279,7 +270,7 @@
                         :articles="searchResultArticles"
                         :categories="searchResultCategories"
                         :loadingResults="loadingSearchResults"
-                        :filter-tabs="searchFilterTabs"
+                        :filter-tabs="categoryTabs"
                         @change-filter="changeSearchFilter"
                         :selected-filter="searchFilter"
                         :currentPage="searchCurrentPage"

--- a/portals/knowledge-management/src/Pages/ViewCategory.vue
+++ b/portals/knowledge-management/src/Pages/ViewCategory.vue
@@ -50,10 +50,20 @@
     import { useRoute, useRouter } from 'vue-router';
     import { searchFilterTabs, useKnowledgeManagementSearch } from '../Composables/useKnowledgeManagementSearch.js';
     import { apiGet } from '../Services/api.js';
+    import { useConfigStore } from '../Stores/config.js';
     import { useCategoryData, useTagsData } from './loaders.js';
 
     const route = useRoute();
     const router = useRouter();
+    const configStore = useConfigStore();
+
+    const tabLabels = Object.fromEntries(searchFilterTabs.map((tab) => [tab.value, tab.label]));
+
+    // Category browsing tabs, ordered per the organization's configured
+    // `category_tab_order` setting (defaults to All Articles, Featured, Most Viewed).
+    const categoryTabs = computed(() =>
+        configStore.categoryTabOrder.map((value) => ({ label: tabLabels[value] ?? value, value })),
+    );
 
     const { data: categoryResponse } = useCategoryData();
     const { data: tags } = useTagsData();
@@ -118,7 +128,7 @@
 
     // Tab filter for browsing a category's own articles. Page 1 of every filter tab
     // arrives together via the route data loader; any other page is fetched client-side.
-    const activeFilter = computed(() => route.query.filter || 'all-articles');
+    const activeFilter = computed(() => route.query.filter || categoryTabs.value[0]?.value || 'all-articles');
     const currentPage = computed(() => parseInt(route.query.page) || 1);
 
     const pageQuery = useQuery({
@@ -202,7 +212,7 @@
             query: {
                 ...route.query,
                 page,
-                filter: filter === 'all-articles' ? undefined : filter,
+                filter: filter === categoryTabs.value[0]?.value ? undefined : filter,
             },
         });
     }
@@ -295,7 +305,7 @@
                         ></SubCategories>
                         <div class="flex flex-col overflow-hidden rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5">
                             <Tabs
-                                :tabs="searchFilterTabs"
+                                :tabs="categoryTabs"
                                 :modelValue="activeFilter"
                                 @update:modelValue="changeFilter"
                                 :contained="true"

--- a/portals/knowledge-management/src/Stores/config.js
+++ b/portals/knowledge-management/src/Stores/config.js
@@ -59,6 +59,8 @@ export const useConfigStore = defineStore('config', () => {
     const primaryColor = ref('');
     const rounding = ref(roundingScales.md);
 
+    const categoryTabOrder = ref(['all-articles', 'featured', 'most-viewed']);
+
     const authenticationRequestUrl = ref(null);
 
     const assistantWidgetLoaderUrl = ref(null);
@@ -79,6 +81,8 @@ export const useConfigStore = defineStore('config', () => {
         primaryColor.value = data.primary_color ?? '';
         rounding.value = roundingScales[data.rounding ?? 'md'] ?? roundingScales.md;
 
+        categoryTabOrder.value = data.category_tab_order ?? ['all-articles', 'featured', 'most-viewed'];
+
         authenticationRequestUrl.value = data.authentication_url ?? null;
 
         assistantWidgetLoaderUrl.value = data.assistant_widget_loader_url ?? null;
@@ -98,6 +102,7 @@ export const useConfigStore = defineStore('config', () => {
         favicon,
         primaryColor,
         rounding,
+        categoryTabOrder,
         authenticationRequestUrl,
         assistantWidgetLoaderUrl,
         assistantWidgetConfigUrl,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1336

### Technical Description

Adds a `KnowledgeBaseCategoryTabOrder` enum defining the 6 possible display orders of the self-service knowledge base portal's category-browsing tabs (All Articles, Featured, Most Viewed). A new `KnowledgeBasePortalSettings` (spatie/laravel-settings) class stores the organization's chosen order, managed via a new `ManageKnowledgeBasePortalSettings` Filament settings page in the Knowledge Management cluster (added last in nav order). The portal's bootstrap config and `KnowledgeManagementPortalController` now expose `category_tab_order`, and the Vue `ViewCategory` page renders/orders the category tabs accordingly, defaulting to the first tab in the configured order as the active tab. Gated behind the `KnowledgeBaseCategoryTabOrderFeature` flag for zero-downtime rollout.

### Any deployment steps required?

No.

### Cleanup Tasks

Cleanup task added: `.cleanup-tasks/2026_08_18_knowledge_base_category_tab_order_feature.md` (tracks removal of `App\Features\KnowledgeBaseCategoryTabOrderFeature` post-deploy).

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
