### PR TITLE
[AIDAPP-1393]: Improve support for presenting recent updates and getting support throughout the product

### DIFF
--- a/.cleanup-tasks/2026_08_18_theme_profile_menu_and_login_home_settings_cleanup.md
+++ b/.cleanup-tasks/2026_08_18_theme_profile_menu_and_login_home_settings_cleanup.md
@@ -1,0 +1,12 @@
+---
+title: Theme Profile Menu And Login Home Settings Cleanup
+created: 2026-08-18
+---
+
+## Feature Flags
+
+## Temporary Migrations
+
+- database/migrations/2026_08_18_130641_tmp_seed_profile_menu_and_login_home_theme_settings_for_existing_tenants.php
+
+## Additional Cleanup

--- a/app-modules/authorization/resources/views/login.blade.php
+++ b/app-modules/authorization/resources/views/login.blade.php
@@ -31,6 +31,20 @@
     
     </COPYRIGHT>
 --}}
+@php
+    use AidingApp\Theme\Settings\ThemeSettings;
+
+    $themeSettings = app(ThemeSettings::class);
+
+    $themeChangelogUrl = filled($themeSettings->changelog_url)
+        ? $themeSettings->changelog_url
+        : ThemeSettings::DEFAULT_CHANGELOG_URL;
+
+    $productResourceHubUrl = filled($themeSettings->product_resource_hub_url)
+        ? $themeSettings->product_resource_hub_url
+        : ThemeSettings::DEFAULT_PRODUCT_RESOURCE_HUB_URL;
+@endphp
+
 <div class="flex w-full flex-col items-center justify-center gap-8 lg:flex-row">
     <div class="w-full lg:w-1/2 lg:pr-8">
         @if (filament()->hasRegistration())
@@ -57,7 +71,7 @@
     </div>
 
     <div class="flex w-full flex-col gap-6 lg:w-1/2">
-        <x-version-card theme-changelog-url="https://github.com/canyongbs/aidingapp/releases" />
-        <x-resource-portal-card product-resource-hub-url="https://canyongbs.aiding.app/portal" />
+        <x-version-card :theme-changelog-url="$themeChangelogUrl" />
+        <x-resource-portal-card :product-resource-hub-url="$productResourceHubUrl" />
     </div>
 </div>

--- a/app-modules/theme/database/migrations/2026_08_18_130125_add_profile_menu_and_login_home_settings_to_theme_settings.php
+++ b/app-modules/theme/database/migrations/2026_08_18_130125_add_profile_menu_and_login_home_settings_to_theme_settings.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Support\Facades\DB;
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        DB::transaction(function () {
+            try {
+                $this->migrator->add('theme.is_support_url_enabled', false);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('theme.support_url', null);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('theme.is_recent_updates_url_enabled', false);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('theme.recent_updates_url', null);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('theme.changelog_url', null);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('theme.product_resource_hub_url', null);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            $this->migrator->deleteIfExists('theme.is_support_url_enabled');
+            $this->migrator->deleteIfExists('theme.support_url');
+            $this->migrator->deleteIfExists('theme.is_recent_updates_url_enabled');
+            $this->migrator->deleteIfExists('theme.recent_updates_url');
+            $this->migrator->deleteIfExists('theme.changelog_url');
+            $this->migrator->deleteIfExists('theme.product_resource_hub_url');
+        });
+    }
+};

--- a/app-modules/theme/database/seeders/ThemeSettingsSeeder.php
+++ b/app-modules/theme/database/seeders/ThemeSettingsSeeder.php
@@ -34,44 +34,24 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Theme\Settings;
+namespace AidingApp\Theme\Database\Seeders;
 
-use AidingApp\Theme\Settings\SettingsProperties\ThemeSettingsProperty;
-use App\Settings\SettingsWithMedia;
+use AidingApp\Theme\Settings\ThemeSettings;
+use Illuminate\Database\Seeder;
 
-class ThemeSettings extends SettingsWithMedia
+class ThemeSettingsSeeder extends Seeder
 {
-    public const DEFAULT_SUPPORT_URL = 'https://canyongbs.aiding.app/portal';
-
-    public const DEFAULT_RECENT_UPDATES_URL = 'https://canyongbs.com/aiding-app/changelog/';
-
-    public const DEFAULT_CHANGELOG_URL = 'https://canyongbs.com/aiding-app/changelog/';
-
-    public const DEFAULT_PRODUCT_RESOURCE_HUB_URL = 'https://canyongbs.aiding.app/portal';
-
-    public bool $is_logo_active = false;
-
-    public bool $is_favicon_active = false;
-
-    public bool $is_support_url_enabled = true;
-
-    public ?string $support_url = null;
-
-    public bool $is_recent_updates_url_enabled = true;
-
-    public ?string $recent_updates_url = null;
-
-    public ?string $changelog_url = null;
-
-    public ?string $product_resource_hub_url = null;
-
-    public static function group(): string
+    public function run(): void
     {
-        return 'theme';
-    }
+        $settings = app(ThemeSettings::class);
 
-    public static function getSettingsPropertyModelClass(): string
-    {
-        return ThemeSettingsProperty::class;
+        $settings->is_support_url_enabled = true;
+        $settings->support_url = ThemeSettings::DEFAULT_SUPPORT_URL;
+        $settings->is_recent_updates_url_enabled = true;
+        $settings->recent_updates_url = ThemeSettings::DEFAULT_RECENT_UPDATES_URL;
+        $settings->changelog_url = ThemeSettings::DEFAULT_CHANGELOG_URL;
+        $settings->product_resource_hub_url = ThemeSettings::DEFAULT_PRODUCT_RESOURCE_HUB_URL;
+
+        $settings->save();
     }
 }

--- a/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
+++ b/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
@@ -40,6 +40,7 @@ use AidingApp\Theme\Settings\ThemeSettings;
 use App\Enums\NavigationGroup;
 use App\Models\User;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Components\Section;
@@ -116,6 +117,54 @@ class ManageBrandConfigurationSettings extends SettingsPage
                         Toggle::make('is_logo_active')
                             ->label('Active')
                             ->hidden(fn (Get $get): bool => blank($get('logo'))),
+                    ]),
+                Section::make('Profile Menu Links')
+                    ->aside()
+                    ->schema([
+                        Section::make('Support')
+                            ->schema([
+                                Toggle::make('is_support_url_enabled')
+                                    ->label('Enable Support URL')
+                                    ->live()
+                                    ->columnSpanFull(),
+                                TextInput::make('support_url')
+                                    ->label('Support URL')
+                                    ->url()
+                                    ->maxLength(255)
+                                    ->placeholder(ThemeSettings::DEFAULT_SUPPORT_URL)
+                                    ->visible(fn (Get $get): bool => (bool) $get('is_support_url_enabled'))
+                                    ->columnSpanFull(),
+                            ]),
+                        Section::make('Recent Updates')
+                            ->schema([
+                                Toggle::make('is_recent_updates_url_enabled')
+                                    ->label('Enable Recent Updates URL')
+                                    ->live()
+                                    ->columnSpanFull(),
+                                TextInput::make('recent_updates_url')
+                                    ->label('Recent Updates URL')
+                                    ->url()
+                                    ->maxLength(255)
+                                    ->placeholder(ThemeSettings::DEFAULT_RECENT_UPDATES_URL)
+                                    ->visible(fn (Get $get): bool => (bool) $get('is_recent_updates_url_enabled'))
+                                    ->columnSpanFull(),
+                            ]),
+                    ]),
+                Section::make('Login and Home Targets')
+                    ->aside()
+                    ->schema([
+                        TextInput::make('changelog_url')
+                            ->label('Changelog URL')
+                            ->url()
+                            ->maxLength(255)
+                            ->placeholder(ThemeSettings::DEFAULT_CHANGELOG_URL)
+                            ->columnSpanFull(),
+                        TextInput::make('product_resource_hub_url')
+                            ->label('Product Resource Hub URL')
+                            ->url()
+                            ->maxLength(255)
+                            ->placeholder(ThemeSettings::DEFAULT_PRODUCT_RESOURCE_HUB_URL)
+                            ->columnSpanFull(),
                     ]),
             ]);
     }

--- a/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
+++ b/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
@@ -74,7 +74,6 @@ class ManageBrandConfigurationSettings extends SettingsPage
         return $schema
             ->components([
                 Section::make('Favicon')
-                    ->aside()
                     ->schema([
                         SpatieMediaLibraryFileUpload::make('favicon')
                             ->disk('s3')
@@ -92,7 +91,6 @@ class ManageBrandConfigurationSettings extends SettingsPage
                             ->hidden(fn (Get $get): bool => blank($get('favicon'))),
                     ]),
                 Section::make('Logo')
-                    ->aside()
                     ->schema([
                         SpatieMediaLibraryFileUpload::make('logo')
                             ->disk('s3-public')
@@ -119,7 +117,6 @@ class ManageBrandConfigurationSettings extends SettingsPage
                             ->hidden(fn (Get $get): bool => blank($get('logo'))),
                     ]),
                 Section::make('Profile Menu Links')
-                    ->aside()
                     ->schema([
                         Section::make('Support')
                             ->schema([
@@ -151,7 +148,6 @@ class ManageBrandConfigurationSettings extends SettingsPage
                             ]),
                     ]),
                 Section::make('Login and Home Targets')
-                    ->aside()
                     ->schema([
                         TextInput::make('changelog_url')
                             ->label('Changelog URL')

--- a/app-modules/theme/tests/Tenant/Filament/Pages/ManageBrandConfigurationSettingsTest.php
+++ b/app-modules/theme/tests/Tenant/Filament/Pages/ManageBrandConfigurationSettingsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Theme\Filament\Pages\ManageBrandConfigurationSettings;
+use AidingApp\Theme\Settings\ThemeSettings;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('allows a super admin to access the branding page', function () {
+    asSuperAdmin();
+
+    get(ManageBrandConfigurationSettings::getUrl())
+        ->assertSuccessful();
+});
+
+it('can update the profile menu link and login and home target settings', function () {
+    asSuperAdmin();
+
+    livewire(ManageBrandConfigurationSettings::class)
+        ->fillForm([
+            'is_support_url_enabled' => true,
+            'support_url' => 'https://example.com/support',
+            'is_recent_updates_url_enabled' => true,
+            'recent_updates_url' => 'https://example.com/updates',
+            'changelog_url' => 'https://example.com/changelog',
+            'product_resource_hub_url' => 'https://example.com/hub',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $settings = app(ThemeSettings::class);
+    $settings->refresh();
+
+    expect($settings->is_support_url_enabled)->toBeTrue()
+        ->and($settings->support_url)->toBe('https://example.com/support')
+        ->and($settings->is_recent_updates_url_enabled)->toBeTrue()
+        ->and($settings->recent_updates_url)->toBe('https://example.com/updates')
+        ->and($settings->changelog_url)->toBe('https://example.com/changelog')
+        ->and($settings->product_resource_hub_url)->toBe('https://example.com/hub');
+});
+
+it('hides the support url input when the support toggle is disabled', function () {
+    asSuperAdmin();
+
+    livewire(ManageBrandConfigurationSettings::class)
+        ->fillForm(['is_support_url_enabled' => true])
+        ->assertFormFieldVisible('support_url')
+        ->fillForm(['is_support_url_enabled' => false])
+        ->assertFormFieldHidden('support_url');
+});
+
+it('hides the recent updates url input when the recent updates toggle is disabled', function () {
+    asSuperAdmin();
+
+    livewire(ManageBrandConfigurationSettings::class)
+        ->fillForm(['is_recent_updates_url_enabled' => true])
+        ->assertFormFieldVisible('recent_updates_url')
+        ->fillForm(['is_recent_updates_url_enabled' => false])
+        ->assertFormFieldHidden('recent_updates_url');
+});
+
+describe('authorization', function () {
+    it('denies access to the branding page for a non super admin', function () {
+        actingAs(User::factory()->create());
+
+        get(ManageBrandConfigurationSettings::getUrl())
+            ->assertForbidden();
+    });
+});

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -161,6 +161,28 @@ class AdminPanelProvider extends PanelProvider
                             && $user->managedContact()->exists();
                     }),
                 MenuItem::make()
+                    ->label('Recent Updates')
+                    ->url(fn (): string => app(ThemeSettings::class)->recent_updates_url ?? '')
+                    ->icon(Heroicon::Megaphone)
+                    ->openUrlInNewTab()
+                    ->visible(function (): bool {
+                        $themeSettings = app(ThemeSettings::class);
+
+                        return $themeSettings->is_recent_updates_url_enabled
+                            && filled($themeSettings->recent_updates_url);
+                    }),
+                MenuItem::make()
+                    ->label('Get Support')
+                    ->url(fn (): string => app(ThemeSettings::class)->support_url ?? '')
+                    ->icon(Heroicon::Lifebuoy)
+                    ->openUrlInNewTab()
+                    ->visible(function (): bool {
+                        $themeSettings = app(ThemeSettings::class);
+
+                        return $themeSettings->is_support_url_enabled
+                            && filled($themeSettings->support_url);
+                    }),
+                MenuItem::make()
                     ->label('Profile Settings')
                     ->url(fn () => ProfileSettings::getUrl())
                     ->icon('heroicon-s-cog-6-tooth'),

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -161,6 +161,18 @@ class AdminPanelProvider extends PanelProvider
                             && $user->managedContact()->exists();
                     }),
                 MenuItem::make()
+                    ->label('Profile Settings')
+                    ->url(fn () => ProfileSettings::getUrl())
+                    ->icon('heroicon-s-cog-6-tooth'),
+                Action::make('about')
+                    ->label('About')
+                    ->modalHeading('Aiding App® by Canyon GBS')
+                    ->modalDescription('Version ' . config('sentry.release'))
+                    ->modalContent(fn () => view('components.about-modal'))
+                    ->modalFooterActions([])
+                    ->modalWidth(Width::Small)
+                    ->icon('heroicon-s-information-circle'),
+                MenuItem::make()
                     ->label('Recent Updates')
                     ->url(fn (): string => app(ThemeSettings::class)->recent_updates_url ?? '')
                     ->icon(Heroicon::Megaphone)
@@ -182,18 +194,6 @@ class AdminPanelProvider extends PanelProvider
                         return $themeSettings->is_support_url_enabled
                             && filled($themeSettings->support_url);
                     }),
-                MenuItem::make()
-                    ->label('Profile Settings')
-                    ->url(fn () => ProfileSettings::getUrl())
-                    ->icon('heroicon-s-cog-6-tooth'),
-                Action::make('about')
-                    ->label('About')
-                    ->modalHeading('Aiding App® by Canyon GBS')
-                    ->modalDescription('Version ' . config('sentry.release'))
-                    ->modalContent(fn () => view('components.about-modal'))
-                    ->modalFooterActions([])
-                    ->modalWidth(Width::Small)
-                    ->icon('heroicon-s-information-circle'),
             ])
             ->renderHook(
                 PanelsRenderHook::TOPBAR_AFTER,

--- a/database/migrations/2026_08_18_130641_tmp_seed_profile_menu_and_login_home_theme_settings_for_existing_tenants.php
+++ b/database/migrations/2026_08_18_130641_tmp_seed_profile_menu_and_login_home_theme_settings_for_existing_tenants.php
@@ -34,44 +34,42 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Theme\Settings;
+use AidingApp\Theme\Settings\ThemeSettings;
+use Illuminate\Support\Facades\DB;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
-use AidingApp\Theme\Settings\SettingsProperties\ThemeSettingsProperty;
-use App\Settings\SettingsWithMedia;
-
-class ThemeSettings extends SettingsWithMedia
-{
-    public const DEFAULT_SUPPORT_URL = 'https://canyongbs.aiding.app/portal';
-
-    public const DEFAULT_RECENT_UPDATES_URL = 'https://canyongbs.com/aiding-app/changelog/';
-
-    public const DEFAULT_CHANGELOG_URL = 'https://canyongbs.com/aiding-app/changelog/';
-
-    public const DEFAULT_PRODUCT_RESOURCE_HUB_URL = 'https://canyongbs.aiding.app/portal';
-
-    public bool $is_logo_active = false;
-
-    public bool $is_favicon_active = false;
-
-    public bool $is_support_url_enabled = true;
-
-    public ?string $support_url = null;
-
-    public bool $is_recent_updates_url_enabled = true;
-
-    public ?string $recent_updates_url = null;
-
-    public ?string $changelog_url = null;
-
-    public ?string $product_resource_hub_url = null;
-
-    public static function group(): string
+return new class () extends SettingsMigration {
+    public function up(): void
     {
-        return 'theme';
+        DB::transaction(function () {
+            $this->migrator->update('theme.is_support_url_enabled', fn (): bool => true);
+
+            $this->migrator->update(
+                'theme.support_url',
+                fn ($value) => filled($value) ? $value : ThemeSettings::DEFAULT_SUPPORT_URL,
+            );
+
+            $this->migrator->update('theme.is_recent_updates_url_enabled', fn (): bool => true);
+
+            $this->migrator->update(
+                'theme.recent_updates_url',
+                fn ($value) => filled($value) ? $value : ThemeSettings::DEFAULT_RECENT_UPDATES_URL,
+            );
+
+            $this->migrator->update(
+                'theme.changelog_url',
+                fn ($value) => filled($value) ? $value : ThemeSettings::DEFAULT_CHANGELOG_URL,
+            );
+
+            $this->migrator->update(
+                'theme.product_resource_hub_url',
+                fn ($value) => filled($value) ? $value : ThemeSettings::DEFAULT_PRODUCT_RESOURCE_HUB_URL,
+            );
+        });
     }
 
-    public static function getSettingsPropertyModelClass(): string
+    public function down(): void
     {
-        return ThemeSettingsProperty::class;
+        // This is a one-time data seed for existing tenants and is not reversible.
     }
-}
+};

--- a/database/seeders/NewTenantSeeder.php
+++ b/database/seeders/NewTenantSeeder.php
@@ -51,6 +51,7 @@ use AidingApp\ServiceManagement\Database\Seeders\ChangeRequestTypeSeeder;
 use AidingApp\ServiceManagement\Database\Seeders\ServiceRequestNotificationAutomationSettingsSeeder;
 use AidingApp\ServiceManagement\Database\Seeders\ServiceRequestStatusSeeder;
 use AidingApp\ServiceManagement\Database\Seeders\ServiceRequestTypeSeeder;
+use AidingApp\Theme\Database\Seeders\ThemeSettingsSeeder;
 use App\Models\Authenticatable;
 use Illuminate\Database\Seeder;
 
@@ -90,6 +91,9 @@ class NewTenantSeeder extends Seeder
 
             // Service Request Notification Automation
             ServiceRequestNotificationAutomationSettingsSeeder::class,
+
+            // Theme
+            ThemeSettingsSeeder::class,
         ]);
     }
 }

--- a/resources/views/filament/pages/dashboard.blade.php
+++ b/resources/views/filament/pages/dashboard.blade.php
@@ -32,10 +32,21 @@
     </COPYRIGHT>
 --}}
 @php
+    use AidingApp\Theme\Settings\ThemeSettings;
     use App\Filament\Widgets\Notifications;
     use App\Settings\DisplaySettings;
 
     $timezone = app(DisplaySettings::class)->getTimezone();
+
+    $themeSettings = app(ThemeSettings::class);
+
+    $themeChangelogUrl = filled($themeSettings->changelog_url)
+        ? $themeSettings->changelog_url
+        : ThemeSettings::DEFAULT_CHANGELOG_URL;
+
+    $productResourceHubUrl = filled($themeSettings->product_resource_hub_url)
+        ? $themeSettings->product_resource_hub_url
+        : ThemeSettings::DEFAULT_PRODUCT_RESOURCE_HUB_URL;
 @endphp
 
 <x-filament-panels::page class="@container">
@@ -55,8 +66,8 @@
             </div>
         </div>
 
-        <x-version-card theme-changelog-url="https://github.com/canyongbs/aidingapp/releases" />
-        <x-resource-portal-card product-resource-hub-url="https://canyongbs.aiding.app/portal" />
+        <x-version-card :theme-changelog-url="$themeChangelogUrl" />
+        <x-resource-portal-card :product-resource-hub-url="$productResourceHubUrl" />
     </div>
 
     @livewire(Notifications::class)

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -41,6 +41,7 @@ use AidingApp\Engagement\Models\EngagementBatch;
 use AidingApp\ServiceManagement\Models\ServiceRequestCustomEmailTemplate;
 use AidingApp\ServiceManagement\Models\ServiceRequestNotificationAutomationEmailTemplate;
 use AidingApp\ServiceManagement\Models\ServiceRequestTypeEmailTemplate;
+use AidingApp\Theme\Settings\ThemeSettings;
 use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
@@ -222,6 +223,63 @@ describe('2026_07_30_182417_tmp_data_convert_literal_merge_tags_in_service_reque
             expect($migrate)->toBe(Command::SUCCESS);
 
             expect($typeTemplate->refresh()->body)->toEqual(richContentText('Hello {{ not a merge tag }}!'));
+        });
+    });
+});
+
+describe('2026_08_18_130641_tmp_seed_profile_menu_and_login_home_theme_settings_for_existing_tenants', function () {
+    $migrationName = '2026_08_18_130641_tmp_seed_profile_menu_and_login_home_theme_settings_for_existing_tenants';
+    $migrationPath = "database/migrations/{$migrationName}.php";
+
+    it('seeds the default profile menu and login and home target settings for existing tenants', function () use ($migrationName, $migrationPath) {
+        isolatedMigration($migrationName, function () use ($migrationPath) {
+            $settings = app(ThemeSettings::class);
+            $settings->refresh();
+
+            expect($settings->is_support_url_enabled)->toBeFalse()
+                ->and($settings->support_url)->toBeNull()
+                ->and($settings->is_recent_updates_url_enabled)->toBeFalse()
+                ->and($settings->recent_updates_url)->toBeNull()
+                ->and($settings->changelog_url)->toBeNull()
+                ->and($settings->product_resource_hub_url)->toBeNull();
+
+            $migrate = Artisan::call('migrate', ['--path' => $migrationPath]);
+
+            expect($migrate)->toBe(Command::SUCCESS);
+
+            $settings->refresh();
+
+            expect($settings->is_support_url_enabled)->toBeTrue()
+                ->and($settings->support_url)->toBe(ThemeSettings::DEFAULT_SUPPORT_URL)
+                ->and($settings->is_recent_updates_url_enabled)->toBeTrue()
+                ->and($settings->recent_updates_url)->toBe(ThemeSettings::DEFAULT_RECENT_UPDATES_URL)
+                ->and($settings->changelog_url)->toBe(ThemeSettings::DEFAULT_CHANGELOG_URL)
+                ->and($settings->product_resource_hub_url)->toBe(ThemeSettings::DEFAULT_PRODUCT_RESOURCE_HUB_URL);
+        });
+    });
+
+    it('preserves urls an admin has already configured', function () use ($migrationName, $migrationPath) {
+        isolatedMigration($migrationName, function () use ($migrationPath) {
+            $settings = app(ThemeSettings::class);
+            $settings->refresh();
+            $settings->support_url = 'https://example.com/custom-support';
+            $settings->recent_updates_url = 'https://example.com/custom-updates';
+            $settings->changelog_url = 'https://example.com/custom-changelog';
+            $settings->product_resource_hub_url = 'https://example.com/custom-hub';
+            $settings->save();
+
+            $migrate = Artisan::call('migrate', ['--path' => $migrationPath]);
+
+            expect($migrate)->toBe(Command::SUCCESS);
+
+            $settings->refresh();
+
+            expect($settings->support_url)->toBe('https://example.com/custom-support')
+                ->and($settings->recent_updates_url)->toBe('https://example.com/custom-updates')
+                ->and($settings->changelog_url)->toBe('https://example.com/custom-changelog')
+                ->and($settings->product_resource_hub_url)->toBe('https://example.com/custom-hub')
+                ->and($settings->is_support_url_enabled)->toBeTrue()
+                ->and($settings->is_recent_updates_url_enabled)->toBeTrue();
         });
     });
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1393

### Technical Description

- Added Recent Updates (megaphone) and Get Support (lifebuoy) items to the admin user menu, matching Advising App.
Both open in a new tab and only show when their enable toggle is on and the URL is set.
- Added Branding settings: Profile Menu Links (Support / Recent Updates) and Login and Home Targets (Changelog / Product Resource Hub) sections.
- Login page and Dashboard now render Changelog and Resource Hub links from these settings.
- Seeded defaults for new tenants (seeder) and existing tenants (tmp data migration, preserving admin-set values).
- Added tests for the Branding page and the data migration; cleanup task recorded for the tmp migration.

### Any deployment steps required?

No

### Cleanup Tasks

> Cleanup: .cleanup-tasks/2026_08_18_theme_profile_menu_and_login_home_settings_cleanup.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
