### PR TITLE
[AIDAPP-1407]: Some users have reported that in the help center, search results are not retained when using the browser back button

### DIFF
--- a/portals/knowledge-management/src/Composables/useKnowledgeManagementSearch.js
+++ b/portals/knowledge-management/src/Composables/useKnowledgeManagementSearch.js
@@ -183,7 +183,12 @@ export function useKnowledgeManagementSearch() {
             },
         });
 
-        history.replaceState(history.state, '', resolved.href);
+        const state = { ...history.state };
+        if (state.current) {
+            state.current = resolved.fullPath;
+        }
+
+        history.replaceState(state, '', resolved.href);
     }
 
     function toggleTag(tag) {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1407

### Technical Description

> Fixed browser Back button losing KB search results after opening an article.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
