### PR TITLE
[AIDAPP-1410]: Enhance project pipeline tasks kanban view by enhancing card navigation

### DIFF
--- a/app-modules/project/resources/views/components/entry-card.blade.php
+++ b/app-modules/project/resources/views/components/entry-card.blade.php
@@ -76,6 +76,8 @@
     }
 
     $dueTooltip = $entry->due?->format('M j, Y g:i A');
+
+    $canUpdatePipeline = auth()->user()->can('update', $pipeline);
 @endphp
 
 <div
@@ -86,46 +88,24 @@
     wire:key="pipeline-entry-{{ $entry->getKey() }}"
 >
     <div class="flex items-start justify-between gap-2">
-        <div class="min-w-0 break-words text-base font-semibold text-gray-900 dark:text-white">
+        <button
+            type="button"
+            class="min-w-0 wrap-break-word text-left text-base font-semibold text-gray-900 hover:underline dark:text-white"
+            wire:click="mountAction('{{ $canUpdatePipeline ? 'editPipelineEntry' : 'viewPipelineEntry' }}', { entry: '{{ $entry->getKey() }}' })"
+        >
             {{ $entry->name }}
-        </div>
+        </button>
 
-        <x-filament::dropdown placement="bottom-end">
-            <x-slot name="trigger">
-                <x-filament::icon-button
-                    class="shrink-0"
-                    icon="heroicon-m-ellipsis-horizontal"
-                    label="Actions"
-                    size="xs"
-                />
-            </x-slot>
-
-            <x-filament::dropdown.list>
-                <x-filament::dropdown.list.item
-                    icon="heroicon-m-eye"
-                    wire:click="mountAction('viewPipelineEntry', { entry: '{{ $entry->getKey() }}' })"
-                >
-                    View
-                </x-filament::dropdown.list.item>
-
-                @can('update', $pipeline)
-                    <x-filament::dropdown.list.item
-                        icon="heroicon-m-pencil"
-                        wire:click="mountAction('editPipelineEntry', { entry: '{{ $entry->getKey() }}' })"
-                    >
-                        Edit
-                    </x-filament::dropdown.list.item>
-
-                    <x-filament::dropdown.list.item
-                        icon="heroicon-m-trash"
-                        color="danger"
-                        wire:click="mountAction('removePipelineEntry', { entry: '{{ $entry->getKey() }}' })"
-                    >
-                        Remove
-                    </x-filament::dropdown.list.item>
-                @endcan
-            </x-filament::dropdown.list>
-        </x-filament::dropdown>
+        @can('update', $pipeline)
+            <x-filament::icon-button
+                class="shrink-0"
+                icon="heroicon-m-trash"
+                color="danger"
+                label="Remove"
+                size="xs"
+                wire:click="mountAction('removePipelineEntry', { entry: '{{ $entry->getKey() }}' })"
+            />
+        @endcan
     </div>
 
     <hr class="my-3 border-gray-200 dark:border-gray-700" />

--- a/app-modules/project/resources/views/components/entry-card.blade.php
+++ b/app-modules/project/resources/views/components/entry-card.blade.php
@@ -77,7 +77,9 @@
 
     $dueTooltip = $entry->due?->format('M j, Y g:i A');
 
-    $canUpdatePipeline = auth()->user()->can('update', $pipeline);
+    $canUpdatePipeline = auth()
+        ->user()
+        ->can('update', $pipeline);
 @endphp
 
 <div

--- a/app-modules/project/resources/views/components/entry-card.blade.php
+++ b/app-modules/project/resources/views/components/entry-card.blade.php
@@ -98,16 +98,17 @@
             {{ $entry->name }}
         </button>
 
-        @can('update', $pipeline)
+        @if ($canUpdatePipeline)
             <x-filament::icon-button
                 class="shrink-0"
                 icon="heroicon-m-trash"
                 color="danger"
                 label="Remove"
+                tooltip="Remove"
                 size="xs"
                 wire:click="mountAction('removePipelineEntry', { entry: '{{ $entry->getKey() }}' })"
             />
-        @endcan
+        @endif
     </div>
 
     <hr class="my-3 border-gray-200 dark:border-gray-700" />

--- a/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
+++ b/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
@@ -732,7 +732,37 @@ it('hides the remove action without pipeline update permission', function () {
         ->assertActionHidden('removePipelineEntry');
 });
 
-it('hides the edit action without pipeline update permission', function () {
+it('mounts the edit pipeline entry action from the card title with pipeline update permission', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    $project = Project::factory()->create();
+    $project->managerUsers()->attach($user);
+
+    $pipeline = Pipeline::factory()
+        ->for($project)
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    $entry = PipelineEntry::factory()->create([
+        'pipeline_stage_id' => $pipeline->stages->first()->getKey(),
+    ]);
+
+    $user->givePermissionTo('project.view-any');
+    $user->givePermissionTo('project.*.view');
+    $user->givePermissionTo('project.*.update');
+    $user->givePermissionTo('pipeline.view-any');
+    $user->refresh();
+
+    expect($user->can('update', $pipeline))->toBeTrue();
+
+    livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
+        ->assertSee("mountAction('editPipelineEntry', { entry: '{$entry->getKey()}' })", false)
+        ->assertDontSee("mountAction('viewPipelineEntry', { entry: '{$entry->getKey()}' })", false);
+});
+
+it('mounts the view pipeline entry action from the card title without pipeline update permission', function () {
     $user = User::factory()->create();
 
     actingAs($user);
@@ -755,37 +785,6 @@ it('hides the edit action without pipeline update permission', function () {
     expect($user->can('update', $pipeline))->toBeFalse();
 
     livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
-        ->assertActionVisible('viewPipelineEntry')
-        ->assertActionHidden('editPipelineEntry');
-});
-
-it('shows the view and edit actions with update permission on the pipeline\'s project', function () {
-    $user = User::factory()->create();
-
-    actingAs($user);
-
-    $project = Project::factory()->create();
-    $project->managerUsers()->attach($user);
-
-    $pipeline = Pipeline::factory()
-        ->for($project)
-        ->has(PipelineStage::factory()->count(1), 'stages')
-        ->create();
-
-    PipelineEntry::factory()->create([
-        'pipeline_stage_id' => $pipeline->stages->first()->getKey(),
-    ]);
-
-    $user->givePermissionTo('project.view-any');
-    $user->givePermissionTo('project.*.view');
-    $user->givePermissionTo('project.*.update');
-    $user->givePermissionTo('pipeline.view-any');
-    $user->refresh();
-
-    expect($user->can('view', $pipeline))->toBeTrue()
-        ->and($user->can('update', $pipeline))->toBeTrue();
-
-    livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
-        ->assertActionVisible('viewPipelineEntry')
-        ->assertActionVisible('editPipelineEntry');
+        ->assertSee("mountAction('viewPipelineEntry', { entry: '{$entry->getKey()}' })", false)
+        ->assertDontSee("mountAction('editPipelineEntry', { entry: '{$entry->getKey()}' })", false);
 });

--- a/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
+++ b/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
@@ -663,7 +663,7 @@ it('clears related milestone, assets, and service requests when the type is set 
         ->and($entry->serviceRequests->pluck('id')->all())->toBe([]);
 });
 
-it('can remove a pipeline entry through the dropdown', function () {
+it('can remove a pipeline entry', function () {
     asSuperAdmin();
 
     $pipeline = Pipeline::factory()

--- a/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
+++ b/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
@@ -758,8 +758,11 @@ it('mounts the edit pipeline entry action from the card title with pipeline upda
     expect($user->can('update', $pipeline))->toBeTrue();
 
     livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
-        ->assertSee("mountAction('editPipelineEntry', { entry: '{$entry->getKey()}' })", false)
-        ->assertDontSee("mountAction('viewPipelineEntry', { entry: '{$entry->getKey()}' })", false);
+        ->assertActionVisible('editPipelineEntry')
+        ->assertSeeHtml('editPipelineEntry')
+        ->assertDontSeeHtml('viewPipelineEntry')
+        ->mountAction('editPipelineEntry', ['entry' => $entry->getKey()])
+        ->assertActionMounted('editPipelineEntry');
 });
 
 it('mounts the view pipeline entry action from the card title without pipeline update permission', function () {
@@ -785,6 +788,9 @@ it('mounts the view pipeline entry action from the card title without pipeline u
     expect($user->can('update', $pipeline))->toBeFalse();
 
     livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
-        ->assertSee("mountAction('viewPipelineEntry', { entry: '{$entry->getKey()}' })", false)
-        ->assertDontSee("mountAction('editPipelineEntry', { entry: '{$entry->getKey()}' })", false);
+        ->assertActionHidden('editPipelineEntry')
+        ->assertSeeHtml('viewPipelineEntry')
+        ->assertDontSeeHtml('editPipelineEntry')
+        ->mountAction('viewPipelineEntry', ['entry' => $entry->getKey()])
+        ->assertActionMounted('viewPipelineEntry');
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1410

### Technical Description

> Remove three dots icon from kanban cards and put trash icon instead to delete tasks.
> On the click on title of the card, it should go into Edit or View mode depending on whether you are a manager or auditor respectively.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
