### PR TITLE
[AIDAPP-1414]: Replace the current methodology for selecting and associating a task with a milestone by using a dropdown with search capability

### DIFF
--- a/app-modules/project/src/Filament/Resources/Pipelines/Forms/PipelineEntryForm.php
+++ b/app-modules/project/src/Filament/Resources/Pipelines/Forms/PipelineEntryForm.php
@@ -236,7 +236,7 @@ class PipelineEntryForm
     {
         return $query
             ->when($pipeline, fn (Builder $query): Builder => $query->where('project_id', $pipeline->project_id))
-            ->withoutArchived()
+            ->withoutArchivedAndUnused()
             ->addSelect([
                 'tasks_count' => self::milestonePipelineEntriesQuery(),
                 'completed_tasks_count' => self::milestonePipelineEntriesQuery()

--- a/app-modules/project/src/Filament/Resources/Pipelines/Forms/PipelineEntryForm.php
+++ b/app-modules/project/src/Filament/Resources/Pipelines/Forms/PipelineEntryForm.php
@@ -37,18 +37,20 @@
 namespace AidingApp\Project\Filament\Resources\Pipelines\Forms;
 
 use AidingApp\Contact\Models\Contact;
+use AidingApp\Project\Enums\PipelineStageClassification;
 use AidingApp\Project\Filament\Tables\PipelineEntryAssetsTable;
 use AidingApp\Project\Filament\Tables\PipelineEntryAssignedToContactsTable;
 use AidingApp\Project\Filament\Tables\PipelineEntryAssignedToUsersTable;
-use AidingApp\Project\Filament\Tables\PipelineEntryMilestonesTable;
 use AidingApp\Project\Filament\Tables\PipelineEntryServiceRequestsTable;
 use AidingApp\Project\Filament\Tables\ProjectPipelinesStageTable;
 use AidingApp\Project\Models\Pipeline;
 use AidingApp\Project\Models\PipelineEntry;
+use AidingApp\Project\Models\ProjectMilestone;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use App\Models\User;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\ModalTableSelect;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TableSelect;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -78,20 +80,40 @@ class PipelineEntryForm
             Textarea::make('description')
                 ->label('Task Description')
                 ->maxLength(65535),
+            TableSelect::make('pipeline_stage_id')
+                ->label('Stage')
+                ->tableConfiguration(ProjectPipelinesStageTable::class)
+                ->tableArguments(['pipelineId' => $pipeline?->getKey()])
+                ->visible($isStageVisible)
+                ->required(),
+                Grid::make(2)
+                    ->schema([
+                        DateTimePicker::make('start_date')
+                            ->label('Start Date'),
+                        DateTimePicker::make('due')
+                            ->label('End Date'),
+                    ]),
             Grid::make(2)
                 ->schema([
-                    DateTimePicker::make('start_date')
-                        ->label('Start Date'),
-                    DateTimePicker::make('due')
-                        ->label('Due Date'),
-                ]),
-            Grid::make(2)
-                ->schema([
+                    Select::make('project_milestone_id')
+                        ->label('Relate To Milestone')
+                        ->relationship(
+                            name: 'milestone',
+                            titleAttribute: 'title',
+                            modifyQueryUsing: fn (Builder $query): Builder => self::milestoneOptionsQuery($query, $pipeline),
+                        )
+                        ->getOptionLabelFromRecordUsing(fn (ProjectMilestone $record): string => self::milestoneLabel($record))
+                        ->searchable()
+                        ->preload()
+                        ->optionsLimit(100)
+                        ->dehydrated()
+                        ->dehydratedWhenHidden(),
                     Toggle::make('is_visible_to_guests')
                         ->label('Visible to Guest')
                         ->default(true),
                     self::assignedToType(),
                 ]),
+            self::assignedToType(),
             ModalTableSelect::make('assigned_to_id')
                 ->label('Assigned To')
                 ->tableConfiguration(fn (Get $get): string => match (Relation::getMorphedModel((string) $get('assigned_to_type'))) {
@@ -115,53 +137,6 @@ class PipelineEntryForm
                 ->dehydrateStateUsing(fn (Get $get, mixed $state): mixed => (filled($get('assigned_to_type')) && $get('assigned_to_type') !== 'none') ? $state : null)
                 ->dehydrated()
                 ->dehydratedWhenHidden(),
-            TableSelect::make('pipeline_stage_id')
-                ->label('Stage')
-                ->tableConfiguration(ProjectPipelinesStageTable::class)
-                ->tableArguments(['pipelineId' => $pipeline?->getKey()])
-                ->visible($isStageVisible)
-                ->required(),
-
-            ToggleButtons::make('milestones_type')
-                ->label('Milestones Type')
-                ->options([
-                    'none' => 'None',
-                    'select' => 'Select',
-                ])
-                ->default('none')
-                ->inline()
-                ->live()
-                ->afterStateHydrated(function (Set $set, ?PipelineEntry $record) {
-                    $state = $record?->milestone()->exists();
-
-                    if ($state) {
-                        $set('milestones_type', 'select');
-                    } else {
-                        $set('milestones_type', 'none');
-                    }
-                })
-                ->dehydrated(false)
-                ->afterStateUpdated(function (?string $state, Set $set) {
-                    if ($state === 'none') {
-                        $set('project_milestone_id', null);
-                    }
-                }),
-            ModalTableSelect::make('project_milestone_id')
-                ->label('Related Milestone')
-                ->relationship(
-                    name: 'milestone',
-                    titleAttribute: 'title',
-                    modifyQueryUsing: $pipeline
-                        ? fn (Builder $query) => $query->where('project_id', $pipeline->project_id)
-                        : null,
-                )
-                ->tableConfiguration(PipelineEntryMilestonesTable::class)
-                ->tableArguments(['projectId' => $pipeline?->project_id])
-                ->tableSelect(fn (TableSelect $tableSelect): TableSelect => $tableSelect->relationshipName(null))
-                ->visible(fn (Get $get): bool => filled($get('milestones_type')) && $get('milestones_type') !== 'none')
-                ->dehydrated()
-                ->dehydratedWhenHidden(),
-
             ToggleButtons::make('assets_type')
                 ->label('Assets Type')
                 ->options([
@@ -237,6 +212,50 @@ class PipelineEntryForm
             : '';
 
         return "({$serviceRequest->service_request_number}){$title}";
+    }
+
+    public static function milestoneLabel(ProjectMilestone $milestone): string
+    {
+        $tasksCount = (int) ($milestone->tasks_count ?? 0);
+        $completedTasksCount = (int) ($milestone->completed_tasks_count ?? 0);
+
+        $percentComplete = $tasksCount === 0
+            ? 0
+            : (int) round(($completedTasksCount / $tasksCount) * 100);
+
+        $taskLabel = Str::plural('Task', $tasksCount);
+
+        return "{$milestone->title} ({$tasksCount} {$taskLabel}) {$percentComplete}% Complete";
+    }
+
+    /**
+     * @param Builder<ProjectMilestone> $query
+     *
+     * @return Builder<ProjectMilestone>
+     */
+    private static function milestoneOptionsQuery(Builder $query, ?Pipeline $pipeline): Builder
+    {
+        return $query
+            ->when($pipeline, fn (Builder $query): Builder => $query->where('project_id', $pipeline->project_id))
+            ->withoutArchived()
+            ->addSelect([
+                'tasks_count' => self::milestonePipelineEntriesQuery(),
+                'completed_tasks_count' => self::milestonePipelineEntriesQuery()
+                    ->where('pipeline_stages.classification', PipelineStageClassification::Complete->value),
+            ])
+            ->orderBy('title');
+    }
+
+    /**
+     * @return Builder<PipelineEntry>
+     */
+    private static function milestonePipelineEntriesQuery(): Builder
+    {
+        return PipelineEntry::query()
+            ->join('pipeline_stages', 'pipeline_stages.id', '=', 'pipeline_entries.pipeline_stage_id')
+            ->whereColumn('pipeline_entries.project_milestone_id', 'project_milestones.id')
+            ->withoutArchived()
+            ->selectRaw('count(*)');
     }
 
     private static function assignedToType(): ToggleButtons

--- a/app-modules/project/src/Filament/Resources/Pipelines/Forms/PipelineEntryForm.php
+++ b/app-modules/project/src/Filament/Resources/Pipelines/Forms/PipelineEntryForm.php
@@ -86,13 +86,13 @@ class PipelineEntryForm
                 ->tableArguments(['pipelineId' => $pipeline?->getKey()])
                 ->visible($isStageVisible)
                 ->required(),
-                    Grid::make(2)
-                        ->schema([
-                            DateTimePicker::make('start_date')
-                                ->label('Start Date'),
-                            DateTimePicker::make('due')
-                                ->label('Due Date'),
-                        ]),
+            Grid::make(2)
+                ->schema([
+                    DateTimePicker::make('start_date')
+                        ->label('Start Date'),
+                    DateTimePicker::make('due')
+                        ->label('Due Date'),
+                ]),
             Grid::make(2)
                 ->schema([
                     Select::make('project_milestone_id')
@@ -111,7 +111,6 @@ class PipelineEntryForm
                     Toggle::make('is_visible_to_guests')
                         ->label('Visible to Guest')
                         ->default(true),
-                    self::assignedToType(),
                 ]),
             self::assignedToType(),
             ModalTableSelect::make('assigned_to_id')

--- a/app-modules/project/src/Filament/Resources/Pipelines/Forms/PipelineEntryForm.php
+++ b/app-modules/project/src/Filament/Resources/Pipelines/Forms/PipelineEntryForm.php
@@ -86,13 +86,13 @@ class PipelineEntryForm
                 ->tableArguments(['pipelineId' => $pipeline?->getKey()])
                 ->visible($isStageVisible)
                 ->required(),
-                Grid::make(2)
-                    ->schema([
-                        DateTimePicker::make('start_date')
-                            ->label('Start Date'),
-                        DateTimePicker::make('due')
-                            ->label('End Date'),
-                    ]),
+                    Grid::make(2)
+                        ->schema([
+                            DateTimePicker::make('start_date')
+                                ->label('Start Date'),
+                            DateTimePicker::make('due')
+                                ->label('Due Date'),
+                        ]),
             Grid::make(2)
                 ->schema([
                     Select::make('project_milestone_id')

--- a/app-modules/project/src/Models/ProjectMilestone.php
+++ b/app-modules/project/src/Models/ProjectMilestone.php
@@ -42,6 +42,7 @@ use AidingApp\Project\Observers\ProjectMilestoneObserver;
 use App\Models\User;
 use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -118,5 +119,13 @@ class ProjectMilestone extends Model implements Auditable
         if (! $hasActiveTask && ! $this->isArchived()) {
             $this->archiveQuietly();
         }
+    }
+
+    /**
+     * @param Builder<ProjectMilestone> $query
+     */
+    public function used(Builder $query): void
+    {
+        $query->whereHas('pipelineEntries');
     }
 }

--- a/app-modules/project/tests/Tenant/Filament/Resources/Pipelines/Forms/PipelineEntryFormTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Pipelines/Forms/PipelineEntryFormTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Project\Enums\PipelineStageClassification;
+use AidingApp\Project\Filament\Resources\Pipelines\Forms\PipelineEntryForm;
+use AidingApp\Project\Livewire\PipelineEntryKanban;
+use AidingApp\Project\Models\Pipeline;
+use AidingApp\Project\Models\PipelineEntry;
+use AidingApp\Project\Models\PipelineStage;
+use AidingApp\Project\Models\Project;
+use AidingApp\Project\Models\ProjectMilestone;
+use Filament\Forms\Components\Select;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('formats the related milestone label with its task count and completion percentage', function (int $tasksCount, int $completedTasksCount, string $expected) {
+    $milestone = ProjectMilestone::factory()->make(['title' => 'Wash the Car']);
+    $milestone->tasks_count = $tasksCount;
+    $milestone->completed_tasks_count = $completedTasksCount;
+
+    expect(PipelineEntryForm::milestoneLabel($milestone))->toBe($expected);
+})->with([
+    'no tasks' => [0, 0, 'Wash the Car (0 Tasks) 0% Complete'],
+    'one task, none complete' => [1, 0, 'Wash the Car (1 Task) 0% Complete'],
+    'multiple tasks, some complete' => [4, 1, 'Wash the Car (4 Tasks) 25% Complete'],
+]);
+
+it('lists related milestone options preloaded, searchable, alphabetically ordered, and formatted with task counts and completion percentage', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $pipeline = Pipeline::factory()
+        ->for($project)
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    $inProgressStage = PipelineStage::factory()->create([
+        'pipeline_id' => $pipeline->getKey(),
+        'classification' => PipelineStageClassification::InProgress,
+    ]);
+
+    $completeStage = PipelineStage::factory()->create([
+        'pipeline_id' => $pipeline->getKey(),
+        'classification' => PipelineStageClassification::Complete,
+    ]);
+
+    $washTheCar = ProjectMilestone::factory()->create([
+        'project_id' => $project->getKey(),
+        'title' => 'Wash the Car',
+    ]);
+    PipelineEntry::factory()->create([
+        'pipeline_stage_id' => $completeStage->getKey(),
+        'project_milestone_id' => $washTheCar->getKey(),
+    ]);
+    PipelineEntry::factory()->count(3)->create([
+        'pipeline_stage_id' => $inProgressStage->getKey(),
+        'project_milestone_id' => $washTheCar->getKey(),
+    ]);
+
+    $buildTheSolution = ProjectMilestone::factory()->create([
+        'project_id' => $project->getKey(),
+        'title' => 'Build the Solution',
+    ]);
+    PipelineEntry::factory()->create([
+        'pipeline_stage_id' => $completeStage->getKey(),
+        'project_milestone_id' => $buildTheSolution->getKey(),
+    ]);
+    PipelineEntry::factory()->create([
+        'pipeline_stage_id' => $inProgressStage->getKey(),
+        'project_milestone_id' => $buildTheSolution->getKey(),
+    ]);
+
+    $buildTheHouse = ProjectMilestone::factory()->create([
+        'project_id' => $project->getKey(),
+        'title' => 'Build the House',
+    ]);
+
+    $otherProjectMilestone = ProjectMilestone::factory()->create(['title' => 'Zzz Other Project Milestone']);
+
+    $entry = PipelineEntry::factory()->create([
+        'pipeline_stage_id' => $inProgressStage->getKey(),
+    ]);
+
+    livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
+        ->mountAction('editPipelineEntry', ['entry' => $entry->getKey()])
+        ->assertFormFieldExists(
+            'project_milestone_id',
+            function (Select $select) use ($washTheCar, $buildTheSolution, $buildTheHouse, $otherProjectMilestone): bool {
+                $options = $select->getOptions();
+
+                expect($options)->toBe([
+                    $buildTheHouse->getKey() => 'Build the House (0 Tasks) 0% Complete',
+                    $buildTheSolution->getKey() => 'Build the Solution (2 Tasks) 50% Complete',
+                    $washTheCar->getKey() => 'Wash the Car (4 Tasks) 25% Complete',
+                ])->and($options)->not->toHaveKey($otherProjectMilestone->getKey());
+
+                return $select->isSearchable()
+                    && $select->isPreloaded()
+                    && $select->getOptionsLimit() === 100;
+            },
+        );
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/Pipelines/Forms/PipelineEntryFormTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Pipelines/Forms/PipelineEntryFormTest.php
@@ -135,3 +135,77 @@ it('lists related milestone options preloaded, searchable, alphabetically ordere
             },
         );
 });
+
+it('still resolves the label and keeps the option selectable for an archived milestone still related to an entry', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $pipeline = Pipeline::factory()
+        ->for($project)
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    $stage = PipelineStage::factory()->create([
+        'pipeline_id' => $pipeline->getKey(),
+        'classification' => PipelineStageClassification::Planning,
+    ]);
+
+    $archivedMilestone = ProjectMilestone::factory()->create([
+        'project_id' => $project->getKey(),
+        'title' => 'Archived Milestone',
+    ]);
+
+    $entry = PipelineEntry::factory()->create([
+        'pipeline_stage_id' => $stage->getKey(),
+        'project_milestone_id' => $archivedMilestone->getKey(),
+    ]);
+
+    $archivedMilestone->archive();
+
+    expect($archivedMilestone->isArchived())->toBeTrue();
+
+    livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
+        ->mountAction('editPipelineEntry', ['entry' => $entry->getKey()])
+        ->assertFormFieldExists(
+            'project_milestone_id',
+            function (Select $select) use ($archivedMilestone): bool {
+                $options = $select->getOptions();
+
+                return $select->getOptionLabel() === 'Archived Milestone (1 Task) 0% Complete'
+                    && array_key_exists($archivedMilestone->getKey(), $options);
+            },
+        );
+});
+
+it('excludes an archived milestone with no related entries from the options', function () {
+    asSuperAdmin();
+
+    $project = Project::factory()->create();
+
+    $pipeline = Pipeline::factory()
+        ->for($project)
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    $stage = PipelineStage::factory()->create(['pipeline_id' => $pipeline->getKey()]);
+
+    $unusedArchivedMilestone = ProjectMilestone::factory()->create([
+        'project_id' => $project->getKey(),
+        'title' => 'Unused Archived Milestone',
+    ]);
+    $unusedArchivedMilestone->archive();
+
+    $entry = PipelineEntry::factory()->create([
+        'pipeline_stage_id' => $stage->getKey(),
+    ]);
+
+    livewire(PipelineEntryKanban::class, ['pipeline' => $pipeline])
+        ->mountAction('editPipelineEntry', ['entry' => $entry->getKey()])
+        ->assertFormFieldExists(
+            'project_milestone_id',
+            function (Select $select) use ($unusedArchivedMilestone): bool {
+                return ! array_key_exists($unusedArchivedMilestone->getKey(), $select->getOptions());
+            },
+        );
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
@@ -691,7 +691,7 @@ it('clears related milestones, assets, and service requests on the widget edit a
         ->setActionData([
             'name' => $entry->name,
             'pipeline_stage_id' => $stage->getKey(),
-            'milestones_type' => 'none',
+            'project_milestone_id' => null,
             'assets_type' => 'none',
             'service_requests_type' => 'none',
         ])

--- a/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
+++ b/app-modules/project/tests/Tenant/Livewire/PipelineEntryKanbanTest.php
@@ -563,7 +563,7 @@ it('preserves related milestone, assets, and service requests when edited withou
         ->mountAction('editPipelineEntry', ['entry' => $entry->getKey()])
         ->assertActionMounted('editPipelineEntry')
         ->assertActionDataSet([
-            'milestones_type' => 'select',
+            'project_milestone_id' => $milestone->getKey(),
             'assets_type' => 'select',
             'service_requests_type' => 'select',
         ])
@@ -603,12 +603,12 @@ it('clears related milestone, assets, and service requests when the type is set 
         ->mountAction('editPipelineEntry', ['entry' => $entry->getKey()])
         ->assertActionMounted('editPipelineEntry')
         ->assertActionDataSet([
-            'milestones_type' => 'select',
+            'project_milestone_id' => $milestone->getKey(),
             'assets_type' => 'select',
             'service_requests_type' => 'select',
         ])
         ->setActionData([
-            'milestones_type' => 'none',
+            'project_milestone_id' => null,
             'assets_type' => 'none',
             'service_requests_type' => 'none',
         ])


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1414

### Technical Description

> Replace the current methodology for selecting and associating a task with a milestone by using a dropdown with search capability

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
