### PR TITLE
[AIDAPP-1443]: Assigners are not run when a Service Request is created by inbound email processing

### DIFF
--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -600,14 +600,16 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                 $contacts = $contacts->add($this->buildContactFromSender($effectiveSender, $effectiveSenderName, $organization));
             }
 
-            $contacts->each(function (Contact $contact) use ($serviceRequestType, $parser, $effectiveSubject, $effectiveBody) {
-                $serviceRequestStatus = ServiceRequestStatus::query()
-                    ->where('classification', SystemServiceRequestClassification::Open)
-                    ->where('name', 'New')
-                    ->where('is_system_protected', true)
-                    ->firstOrFail();
+            $serviceRequestStatus = ServiceRequestStatus::query()
+                ->where('classification', SystemServiceRequestClassification::Open)
+                ->where('name', 'New')
+                ->where('is_system_protected', true)
+                ->firstOrFail();
 
-                $serviceRequest = app(CreateServiceRequestAction::class)->execute(
+            $createServiceRequestAction = app(CreateServiceRequestAction::class);
+
+            $contacts->each(function (Contact $contact) use ($serviceRequestType, $parser, $effectiveSubject, $effectiveBody, $serviceRequestStatus, $createServiceRequestAction) {
+                $serviceRequest = $createServiceRequestAction->execute(
                     ServiceRequestDataObject::fromData([
                         'type_id' => $serviceRequestType->getKey(),
                         'respondent_id' => $contact->getKey(),

--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -47,7 +47,9 @@ use AidingApp\Engagement\Exceptions\UnableToRetrieveContentFromSesS3EmailPayload
 use AidingApp\Engagement\Models\UnmatchedInboundCommunication;
 use AidingApp\Engagement\Notifications\IneligibleContactSesS3InboundEmailServiceRequestNotification;
 use AidingApp\Notification\Models\OutboundEmailMessageId;
+use AidingApp\ServiceManagement\Actions\CreateServiceRequestAction;
 use AidingApp\ServiceManagement\Actions\ReopenServiceRequestAction;
+use AidingApp\ServiceManagement\DataTransferObjects\ServiceRequestDataObject;
 use AidingApp\ServiceManagement\Enums\EmailAutomaticCreationContactCreateCondition;
 use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
@@ -58,7 +60,6 @@ use Aws\Crypto\KmsMaterialsProviderV3;
 use Aws\Kms\KmsClient;
 use Aws\S3\Crypto\S3EncryptionClientV3;
 use Aws\S3\S3Client;
-use Carbon\CarbonImmutable;
 use Exception;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -600,26 +601,22 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
             }
 
             $contacts->each(function (Contact $contact) use ($serviceRequestType, $parser, $effectiveSubject, $effectiveBody) {
-                $serviceRequest = $contact->serviceRequests()
-                    ->make([
-                        'title' => $effectiveSubject,
-                        'close_details' => $effectiveBody,
-                    ]);
-
                 $serviceRequestStatus = ServiceRequestStatus::query()
                     ->where('classification', SystemServiceRequestClassification::Open)
                     ->where('name', 'New')
                     ->where('is_system_protected', true)
                     ->firstOrFail();
 
-                $serviceRequest->status()->associate($serviceRequestStatus);
-                $serviceRequest->status_updated_at = CarbonImmutable::now();
-
-                $serviceRequest->respondent()->associate($contact);
-
-                $serviceRequest->priority()->associate($serviceRequestType->email_automatic_creation_priority_id);
-
-                $serviceRequest->saveOrFail();
+                $serviceRequest = app(CreateServiceRequestAction::class)->execute(
+                    ServiceRequestDataObject::fromData([
+                        'type_id' => $serviceRequestType->getKey(),
+                        'respondent_id' => $contact->getKey(),
+                        'status_id' => $serviceRequestStatus->getKey(),
+                        'priority_id' => $serviceRequestType->email_automatic_creation_priority_id,
+                        'title' => $effectiveSubject,
+                        'close_details' => $effectiveBody,
+                    ])
+                );
 
                 foreach ($parser->getAttachments() as $attachment) {
                     try {

--- a/app-modules/engagement/tests/Landlord/Jobs/ProcessSesS3InboundEmailTest.php
+++ b/app-modules/engagement/tests/Landlord/Jobs/ProcessSesS3InboundEmailTest.php
@@ -47,6 +47,11 @@ use AidingApp\Engagement\Models\UnmatchedInboundCommunication;
 use AidingApp\Engagement\Notifications\IneligibleContactSesS3InboundEmailServiceRequestNotification;
 use AidingApp\Notification\Models\OutboundEmailMessageId;
 use AidingApp\ServiceManagement\Enums\EmailAutomaticCreationContactCreateCondition;
+use AidingApp\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
+use AidingApp\ServiceManagement\Enums\ServiceRequestEmailTemplateType;
+use AidingApp\ServiceManagement\Enums\ServiceRequestNotificationChannel;
+use AidingApp\ServiceManagement\Enums\ServiceRequestTypeAssignmentTypes;
+use AidingApp\ServiceManagement\Enums\ServiceRequestTypeEmailTemplateRole;
 use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestPriority;
@@ -54,8 +59,10 @@ use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
 use AidingApp\ServiceManagement\Models\ServiceRequestType;
 use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use AidingApp\ServiceManagement\Models\TenantServiceRequestTypeDomain;
+use AidingApp\ServiceManagement\Notifications\ServiceRequestCreated;
 use App\Actions\Paths\ModulePath;
 use App\Models\Tenant;
+use App\Models\User;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Mail\Events\MessageSending;
@@ -72,6 +79,8 @@ use function Pest\Laravel\partialMock;
 use function Pest\Laravel\seed;
 
 use Spatie\Multitenancy\Events\MadeTenantCurrentEvent;
+
+use function Tests\enablePreference;
 
 describe('Spam and virus detection', function () {
     it('handles spam verdict failure properly', function () {
@@ -998,6 +1007,242 @@ describe('Service Request Type Service Request creation from inbound email', fun
             ->and($serviceRequest->respondent->is($contact))->toBeTrue()
             ->and($serviceRequest->priority->is($assignedPriority))->toBeTrue()
             ->and($serviceRequest->priority->type->is($serviceRequestType))->toBeTrue();
+
+        $filesystem->assertMissing('s3_email');
+    });
+
+    it('round robin assigns the created service request to a manager of the type', function () {
+        $tenant = Tenant::query()->firstOrFail();
+
+        assert($tenant instanceof Tenant);
+
+        [$manager, $serviceRequestType] = $tenant->execute(function () {
+            Contact::factory()->create([
+                'email' => 'kevin.ullyott@canyongbs.com',
+            ]);
+
+            $manager = User::factory()->create();
+
+            $serviceRequestType = ServiceRequestType::factory()
+                ->has(
+                    TenantServiceRequestTypeDomain::factory()->state([
+                        'domain' => 'help',
+                    ]),
+                    'domain'
+                )
+                ->has(
+                    ServiceRequestPriority::factory()->count(3),
+                    'priorities'
+                )
+                ->create([
+                    'is_email_automatic_creation_enabled' => true,
+                    'is_email_automatic_creation_contact_create_enabled' => false,
+                    'assignment_type' => ServiceRequestTypeAssignmentTypes::RoundRobin,
+                ]);
+
+            $serviceRequestType->managerUsers()->attach($manager);
+
+            $serviceRequestType->update([
+                'email_automatic_creation_priority_id' => $serviceRequestType->priorities->first()->getKey(),
+            ]);
+
+            return [$manager, $serviceRequestType];
+        });
+
+        Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+
+        assert($filesystem instanceof FilesystemAdapter);
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', 'tests/Landlord/Fixtures/s3_email_for_service_request'));
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        $mock->handle();
+
+        $tenant->makeCurrent();
+
+        $serviceRequest = ServiceRequest::query()->sole();
+
+        expect($serviceRequest->assignedTo)->not->toBeNull()
+            ->and($serviceRequest->assignedTo->user_id)->toBe($manager->getKey())
+            ->and($serviceRequest->assignedTo->status)->toBe(ServiceRequestAssignmentStatus::Active)
+            ->and($serviceRequestType->fresh()->last_assigned_id)->toBe($manager->getKey());
+
+        $filesystem->assertMissing('s3_email');
+    });
+
+    it('individually assigns the created service request to the configured user', function () {
+        $tenant = Tenant::query()->firstOrFail();
+
+        assert($tenant instanceof Tenant);
+
+        [$individual, $serviceRequestType] = $tenant->execute(function () {
+            Contact::factory()->create([
+                'email' => 'kevin.ullyott@canyongbs.com',
+            ]);
+
+            $individual = User::factory()->create();
+
+            $serviceRequestType = ServiceRequestType::factory()
+                ->has(
+                    TenantServiceRequestTypeDomain::factory()->state([
+                        'domain' => 'help',
+                    ]),
+                    'domain'
+                )
+                ->has(
+                    ServiceRequestPriority::factory()->count(3),
+                    'priorities'
+                )
+                ->create([
+                    'is_email_automatic_creation_enabled' => true,
+                    'is_email_automatic_creation_contact_create_enabled' => false,
+                    'assignment_type' => ServiceRequestTypeAssignmentTypes::Individual,
+                    'assignment_type_individual_id' => $individual->getKey(),
+                ]);
+
+            $serviceRequestType->managerUsers()->attach($individual);
+
+            $serviceRequestType->update([
+                'email_automatic_creation_priority_id' => $serviceRequestType->priorities->first()->getKey(),
+            ]);
+
+            return [$individual, $serviceRequestType];
+        });
+
+        Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+
+        assert($filesystem instanceof FilesystemAdapter);
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', 'tests/Landlord/Fixtures/s3_email_for_service_request'));
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        $mock->handle();
+
+        $tenant->makeCurrent();
+
+        $serviceRequest = ServiceRequest::query()->sole();
+
+        expect($serviceRequest->assignedTo)->not->toBeNull()
+            ->and($serviceRequest->assignedTo->user_id)->toBe($individual->getKey())
+            ->and($serviceRequest->assignedTo->status)->toBe(ServiceRequestAssignmentStatus::Active);
+
+        $filesystem->assertMissing('s3_email');
+    });
+
+    it('notifies managers of the type when a service request is created from inbound email', function () {
+        $notificationFake = Notification::fake();
+
+        Event::listen(
+            MadeTenantCurrentEvent::class,
+            function (MadeTenantCurrentEvent $event) use ($notificationFake) {
+                Notification::swap($notificationFake);
+            }
+        );
+
+        $tenant = Tenant::query()->firstOrFail();
+
+        assert($tenant instanceof Tenant);
+
+        $manager = $tenant->execute(function () {
+            Contact::factory()->create([
+                'email' => 'kevin.ullyott@canyongbs.com',
+            ]);
+
+            $manager = User::factory()->create();
+
+            $serviceRequestType = ServiceRequestType::factory()
+                ->has(
+                    TenantServiceRequestTypeDomain::factory()->state([
+                        'domain' => 'help',
+                    ]),
+                    'domain'
+                )
+                ->has(
+                    ServiceRequestPriority::factory()->count(3),
+                    'priorities'
+                )
+                ->create([
+                    'is_email_automatic_creation_enabled' => true,
+                    'is_email_automatic_creation_contact_create_enabled' => false,
+                ]);
+
+            $serviceRequestType->managerUsers()->attach($manager);
+
+            enablePreference(
+                $serviceRequestType,
+                ServiceRequestEmailTemplateType::Created,
+                ServiceRequestTypeEmailTemplateRole::Manager,
+                ServiceRequestNotificationChannel::Notification,
+            );
+
+            $serviceRequestType->update([
+                'email_automatic_creation_priority_id' => $serviceRequestType->priorities->first()->getKey(),
+            ]);
+
+            return $manager;
+        });
+
+        Storage::fake('s3');
+        $filesystem = Storage::fake('s3-inbound-email');
+
+        assert($filesystem instanceof FilesystemAdapter);
+
+        $modulePath = resolve(ModulePath::class);
+
+        $content = file_get_contents($modulePath('engagement', 'tests/Landlord/Fixtures/s3_email_for_service_request'));
+
+        $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+        $filesystem->putFileAs('', $file, 's3_email');
+
+        /** @var ProcessSesS3InboundEmail $mock */
+        $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+            $mock
+                ->shouldAllowMockingProtectedMethods()
+                ->shouldReceive('getContent')
+                ->once()
+                ->andReturn($content);
+        });
+
+        invade($mock)->emailFilePath = 's3_email';
+
+        $mock->handle();
+
+        $notificationFake->assertSentTo($manager, ServiceRequestCreated::class);
 
         $filesystem->assertMissing('s3_email');
     });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1443

### Technical Description

## Why

Service Requests created from inbound email (the `{tenant}-sr-{type}` address flow in `ProcessSesS3InboundEmail`) were not being auto-assigned. Tickets landed on the correct Service Request Type, but the type's configured assigner (Round Robin / Individual / Workload) never ran, so no agent was assigned.

Root cause: the inbound-email job built and saved the `ServiceRequest` directly on the model (`$contact->serviceRequests()->make(...)->saveOrFail()`), bypassing `CreateServiceRequestAction`. Assignment (and manager/auditor creation notifications) only happen inside that action via `AssignServiceRequestToDepartment`, and it is not triggered by the `ServiceRequest` `created` observer event. So the email path silently skipped both.

## What

- Routed inbound-email SR creation through `CreateServiceRequestAction` so there is a single, unified place defining what happens when a Service Request is created.
  - `handleServiceRequestType()` now resolves the "New" open status and calls the action with a `ServiceRequestDataObject` (type, respondent, status, priority, title, close_details) instead of hand-building the model.
  - Removed the now-redundant manual `status_updated_at` assignment (the observer's `saving` hook sets it on status change) and the unused `CarbonImmutable` import.
- As a result, email-created tickets now get the two behaviors they were missing:
  - Auto-assignment per the type's assignment strategy (the reported bug).
  - Manager/auditor "created" notifications.

## Tests

Added coverage in `ProcessSesS3InboundEmailTest` for the unified creation path:
- Round Robin assignment triggers → assigns the type's manager and sets `last_assigned_id`.
- Individual assignment triggers → assigns the configured user.
- Manager "created" notification (`ServiceRequestCreated`) fires for an inbound-email-created SR.

Full test file passes (59 passed / 396 assertions); `composer format` clean; `composer lint` reports no new errors in the changed files.


### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
