### PR TITLE
[AIDAPP-1420]: Systems have reported that expired non-accessible Tenants are still processed by the scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ app-modules/**/resources/js/dist/*
 **/psysh_history
 .pdepend/
 .phpmd.result-cache.php
+storage/framework/lsp-*.php
 
 # BEGIN canyongbs/common (common:publish) — do not edit this block manually.
 /boost.json

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -55,6 +55,7 @@ use AidingApp\ServiceManagement\Jobs\SendClosedServiceRequestFeedbackReminders;
 use AidingApp\ServiceManagement\Jobs\ServiceMonitoringJob;
 use AidingApp\ServiceManagement\Jobs\ServiceMonitoringReportJob;
 use App\Models\HealthCheckResultHistoryItem;
+use App\Models\Scopes\ExcludeExpiredSubscriptions;
 use App\Models\Scopes\SetupIsComplete;
 use App\Models\Tenant;
 use App\Settings\LicenseSettings;
@@ -78,6 +79,7 @@ class Kernel extends ConsoleKernel
 
         Tenant::query()
             ->tap(new SetupIsComplete())
+            ->tap(new ExcludeExpiredSubscriptions())
             ->cursor()
             ->each(function (Tenant $tenant) use ($schedule) {
                 try {

--- a/app/Models/Scopes/ExcludeExpiredSubscriptions.php
+++ b/app/Models/Scopes/ExcludeExpiredSubscriptions.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Models\Scopes;
+
+use App\Enums\SubscriptionStatus;
+use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Builder;
+
+class ExcludeExpiredSubscriptions
+{
+    /**
+     * @param Builder<Tenant> $query
+     */
+    public function __invoke(Builder $query): void
+    {
+        $query->where('subscription_status', '!=', SubscriptionStatus::Expired->value);
+    }
+}

--- a/tests/Landlord/Console/KernelTest.php
+++ b/tests/Landlord/Console/KernelTest.php
@@ -36,8 +36,10 @@
 
 use AidingApp\ServiceManagement\Jobs\ServiceMonitoringJob;
 use AidingApp\ServiceManagement\Jobs\ServiceMonitoringReportJob;
+use App\Enums\SubscriptionStatus;
 use App\Models\Tenant;
 use App\Settings\LicenseSettings;
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Support\Facades\Queue;
 
 use function Pest\Laravel\artisan;
@@ -130,5 +132,31 @@ describe('ServiceMonitoringReportJob scheduling', function () {
         artisan('schedule:run');
 
         Queue::assertNotPushed(ServiceMonitoringReportJob::class);
+    });
+});
+
+describe('schedule', function () {
+    it('does not schedule tenant tasks for tenants with an expired subscription', function () {
+        $activeTenant = Tenant::factory()->create([
+            'domain' => 'active-subscription.aidingapp.local',
+            'setup_complete' => true,
+            'subscription_status' => SubscriptionStatus::Active,
+        ]);
+
+        $expiredTenant = Tenant::factory()->create([
+            'domain' => 'expired-subscription.aidingapp.local',
+            'setup_complete' => true,
+            'subscription_status' => SubscriptionStatus::Expired,
+        ]);
+
+        $summaries = collect(app(Kernel::class)->resolveConsoleSchedule()->events())
+            ->map(fn ($event) => $event->getSummaryForDisplay());
+
+        expect($summaries->contains(fn (string $summary) => str_contains($summary, $activeTenant->domain)))->toBeTrue()
+            ->and($summaries->contains(fn (string $summary) => str_contains($summary, $expiredTenant->domain)))->toBeFalse();
+
+        // Prevents the shared test tenant teardown from resolving one of these non-migratable tenants via Tenant::firstOrFail().
+        $activeTenant->delete();
+        $expiredTenant->delete();
     });
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1420

### Technical Description

Adds a scope and applies it to prevent running scheduled tasks for Tenants that are expired, which are made totally inaccessible anyways.

Also adds Laravel's new `lsp` files to gitignore.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
