### PR TITLE
[AIDAPP-1437]: Improve security by adding a rate-limit and retry limit to login by contacts via portal experiences

### DIFF
--- a/app-modules/ai/routes/widgets.php
+++ b/app-modules/ai/routes/widgets.php
@@ -83,11 +83,11 @@ Route::middleware([
                             ->name('config');
 
                         Route::post('authenticate/request', RequestAuthenticationController::class)
-                            ->middleware(['signed:relative'])
+                            ->middleware(['signed:relative', 'throttle:widget-authentication-request'])
                             ->name('authenticate.request');
 
                         Route::post('authenticate/{authentication}', AuthenticateController::class)
-                            ->middleware(['signed:relative'])
+                            ->middleware(['signed:relative', 'throttle:widget-authenticate'])
                             ->name('authenticate');
 
                         Route::post('messages', SendMessageController::class)

--- a/app-modules/ai/routes/widgets.php
+++ b/app-modules/ai/routes/widgets.php
@@ -83,11 +83,11 @@ Route::middleware([
                             ->name('config');
 
                         Route::post('authenticate/request', RequestAuthenticationController::class)
-                            ->middleware(['signed:relative', 'throttle:widget-authentication-request'])
+                            ->middleware(['signed:relative', 'throttle:authentication-code-request'])
                             ->name('authenticate.request');
 
                         Route::post('authenticate/{authentication}', AuthenticateController::class)
-                            ->middleware(['signed:relative', 'throttle:widget-authenticate'])
+                            ->middleware(['signed:relative', 'throttle:authentication-code-verify'])
                             ->name('authenticate');
 
                         Route::post('messages', SendMessageController::class)

--- a/app-modules/ai/src/Http/Controllers/AssistantWidget/AuthenticateController.php
+++ b/app-modules/ai/src/Http/Controllers/AssistantWidget/AuthenticateController.php
@@ -38,8 +38,8 @@ namespace AidingApp\Ai\Http\Controllers\AssistantWidget;
 
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Portal\Models\PortalAuthentication;
-use AidingApp\Portal\Rules\PortalAuthenticateCodeValidation;
 use App\Http\Controllers\Controller;
+use App\Rules\ValidAuthenticationCode;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -53,7 +53,7 @@ class AuthenticateController extends Controller
         }
 
         $request->validate([
-            'code' => ['required', 'integer', 'digits:6', new PortalAuthenticateCodeValidation()],
+            'code' => ['required', 'integer', 'digits:6', new ValidAuthenticationCode($authentication)],
         ]);
 
         /** @var Contact $contact */

--- a/app-modules/ai/src/Http/Controllers/AssistantWidget/RequestAuthenticationController.php
+++ b/app-modules/ai/src/Http/Controllers/AssistantWidget/RequestAuthenticationController.php
@@ -41,6 +41,7 @@ use AidingApp\Portal\Models\PortalAuthentication;
 use AidingApp\Portal\Notifications\AuthenticatePortalNotification;
 use App\Actions\ResolveEducatableFromEmail;
 use App\Http\Controllers\Controller;
+use App\Support\AuthenticationCodeRateLimiter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
@@ -50,7 +51,7 @@ use Illuminate\Validation\ValidationException;
 
 class RequestAuthenticationController extends Controller
 {
-    public function __invoke(Request $request, ResolveEducatableFromEmail $resolveEducatableFromEmail): JsonResponse
+    public function __invoke(Request $request, ResolveEducatableFromEmail $resolveEducatableFromEmail, AuthenticationCodeRateLimiter $rateLimiter): JsonResponse
     {
         $data = $request->validate([
             'email' => ['required', 'email'],
@@ -64,6 +65,10 @@ class RequestAuthenticationController extends Controller
             ]);
         }
 
+        $rateLimiter->ensureCanRequestCode($contact, 'assistant-widget');
+
+        PortalAuthentication::invalidateExistingCodesFor($contact, PortalType::KnowledgeManagement);
+
         $code = random_int(100000, 999999);
 
         $authentication = new PortalAuthentication();
@@ -75,6 +80,8 @@ class RequestAuthenticationController extends Controller
         Notification::route('mail', [
             $data['email'] => $contact->getAttributeValue($contact::displayNameKey()),
         ])->notify(new AuthenticatePortalNotification($authentication, $code));
+
+        $rateLimiter->recordCodeRequest($contact, 'assistant-widget');
 
         $authenticationUrl = URL::to(
             URL::signedRoute(

--- a/app-modules/ai/tests/Tenant/Http/Controllers/AssistantWidget/AuthenticateControllerTest.php
+++ b/app-modules/ai/tests/Tenant/Http/Controllers/AssistantWidget/AuthenticateControllerTest.php
@@ -34,91 +34,39 @@
 </COPYRIGHT>
 */
 
-use AidingApp\Ai\Settings\AiSupportAssistantSettings;
 use AidingApp\Contact\Models\Contact;
 use AidingApp\Portal\Enums\PortalType;
 use AidingApp\Portal\Models\PortalAuthentication;
-use AidingApp\Portal\Models\PortalGuest;
 use AidingApp\Portal\Settings\PortalSettings;
 use App\Support\AuthenticationCodeRateLimiter;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Testing\TestResponse;
 
 use function Pest\Laravel\postJson;
 
 beforeEach(function () {
-    $portalSettings = app(PortalSettings::class);
-    $portalSettings->knowledge_management_portal_enabled = true;
-    $portalSettings->knowledge_management_portal_service_management = false;
-    $portalSettings->ai_support_assistant = false;
-    $portalSettings->save();
-
-    $assistantSettings = app(AiSupportAssistantSettings::class);
-    $assistantSettings->is_enabled = false;
-    $assistantSettings->save();
+    $settings = app(PortalSettings::class);
+    $settings->knowledge_management_portal_enabled = true;
+    $settings->ai_support_assistant = true;
+    $settings->save();
 });
 
-test('it returns expired and creates guest session when authentication is expired', function () {
-    $plainCode = 123456;
-
-    $authentication = PortalAuthentication::factory()->create([
-        'portal_type' => PortalType::KnowledgeManagement,
-        'code' => Hash::make($plainCode),
-        'created_at' => now()->subDay()->subMinute(),
-    ]);
-
+function assistantAuthenticate(PortalAuthentication $authentication, array $body): TestResponse
+{
     $url = URL::signedRoute(
-        name: 'api.portal.authenticate.embedded',
+        name: 'widgets.assistant.api.authenticate',
         parameters: ['authentication' => $authentication],
         absolute: false,
     );
 
-    $response = postJson($url, [
-        'code' => $plainCode,
-    ]);
+    return postJson($url, $body, ['Origin' => config('app.url')]);
+}
 
-    $response
-        ->assertOk()
-        ->assertJsonPath('is_expired', true)
-        ->assertSessionHas('guest_id');
-
-    expect(PortalGuest::query()->count())->toBe(1);
-});
-
-test('it reuses existing guest session for expired authentication', function () {
-    $existingGuest = PortalGuest::factory()->create();
-
-    $plainCode = 223344;
-
-    $authentication = PortalAuthentication::factory()->create([
-        'portal_type' => PortalType::KnowledgeManagement,
-        'code' => Hash::make($plainCode),
-        'created_at' => now()->subDay()->subMinute(),
-    ]);
-
-    $url = URL::signedRoute(
-        name: 'api.portal.authenticate.embedded',
-        parameters: ['authentication' => $authentication],
-        absolute: false,
-    );
-
-    session(['guest_id' => $existingGuest->getKey()]);
-
-    $response = postJson($url, ['code' => $plainCode]);
-
-    $response
-        ->assertOk()
-        ->assertJsonPath('is_expired', true)
-        ->assertSessionHas('guest_id', $existingGuest->getKey());
-
-    expect(PortalGuest::query()->count())->toBe(1);
-});
-
-test('it authenticates contact and clears guest session when code is valid', function () {
+test('it authenticates the contact when the code is valid', function () {
     $contact = Contact::factory()->create();
-    $existingGuest = PortalGuest::factory()->create();
 
-    $plainCode = 654321;
+    $plainCode = 123456;
 
     $authentication = PortalAuthentication::factory()->create([
         'portal_type' => PortalType::KnowledgeManagement,
@@ -128,30 +76,17 @@ test('it authenticates contact and clears guest session when code is valid', fun
     $authentication->educatable()->associate($contact);
     $authentication->save();
 
-    $url = URL::signedRoute(
-        name: 'api.portal.authenticate.embedded',
-        parameters: ['authentication' => $authentication],
-        absolute: false,
-    );
-
-    session(['guest_id' => $existingGuest->getKey()]);
-
-    $response = postJson($url, ['code' => $plainCode]);
+    $response = assistantAuthenticate($authentication, ['code' => $plainCode]);
 
     $response
         ->assertOk()
-        ->assertJsonPath('success', true)
-        ->assertJsonPath('user.id', $contact->getKey())
-        ->assertJsonPath('assistant_enabled', false)
-        ->assertJsonPath('assistant_widget_loader_url', null)
-        ->assertJsonPath('assistant_widget_config_url', null)
-        ->assertSessionMissing('guest_id');
+        ->assertJsonPath('success', true);
 
     expect($response->json('token'))->not->toBeEmpty()
         ->and(auth('contact')->check())->toBeTrue();
 });
 
-test('it returns validation error when code is invalid', function () {
+test('it returns a validation error when the code is invalid', function () {
     $contact = Contact::factory()->create();
 
     $authentication = PortalAuthentication::factory()->create([
@@ -162,43 +97,31 @@ test('it returns validation error when code is invalid', function () {
     $authentication->educatable()->associate($contact);
     $authentication->save();
 
-    $url = URL::signedRoute(
-        name: 'api.portal.authenticate.embedded',
-        parameters: ['authentication' => $authentication],
-        absolute: false,
-    );
-
-    $response = postJson($url, [
-        'code' => 999999,
-    ]);
-
-    $response
+    assistantAuthenticate($authentication, ['code' => 999999])
         ->assertStatus(422)
         ->assertJsonValidationErrors(['code']);
+
+    expect(auth('contact')->check())->toBeFalse();
 });
 
-test('it returns validation error when code is missing', function () {
+test('it returns expired when the authentication has expired', function () {
     $contact = Contact::factory()->create();
+
+    $plainCode = 445566;
 
     $authentication = PortalAuthentication::factory()->create([
         'portal_type' => PortalType::KnowledgeManagement,
-        'code' => Hash::make(445566),
-        'created_at' => now(),
+        'code' => Hash::make($plainCode),
+        'created_at' => now()->subDay()->subMinute(),
     ]);
     $authentication->educatable()->associate($contact);
     $authentication->save();
 
-    $url = URL::signedRoute(
-        name: 'api.portal.authenticate.embedded',
-        parameters: ['authentication' => $authentication],
-        absolute: false,
-    );
-
-    $response = postJson($url, []);
-
-    $response
+    assistantAuthenticate($authentication, ['code' => $plainCode])
         ->assertStatus(422)
-        ->assertJsonValidationErrors(['code']);
+        ->assertJsonPath('is_expired', true);
+
+    expect(auth('contact')->check())->toBeFalse();
 });
 
 test('it locks the authentication after too many invalid code attempts and rejects even the correct code', function () {
@@ -214,19 +137,13 @@ test('it locks the authentication after too many invalid code attempts and rejec
     $authentication->educatable()->associate($contact);
     $authentication->save();
 
-    $url = URL::signedRoute(
-        name: 'api.portal.authenticate.embedded',
-        parameters: ['authentication' => $authentication],
-        absolute: false,
-    );
-
     foreach (range(1, AuthenticationCodeRateLimiter::MAX_ATTEMPTS) as $attempt) {
-        postJson($url, ['code' => 999999])
+        assistantAuthenticate($authentication, ['code' => 999999])
             ->assertStatus(422)
             ->assertJsonValidationErrors(['code' => 'The provided code is invalid.']);
     }
 
-    postJson($url, ['code' => $plainCode])
+    assistantAuthenticate($authentication, ['code' => $plainCode])
         ->assertStatus(422)
         ->assertJsonValidationErrors(['code' => 'Too many invalid attempts. Please request a new code.']);
 

--- a/app-modules/ai/tests/Tenant/Http/Controllers/AssistantWidget/RequestAuthenticationControllerTest.php
+++ b/app-modules/ai/tests/Tenant/Http/Controllers/AssistantWidget/RequestAuthenticationControllerTest.php
@@ -38,7 +38,9 @@ use AidingApp\Contact\Models\Contact;
 use AidingApp\Portal\Models\PortalAuthentication;
 use AidingApp\Portal\Notifications\AuthenticatePortalNotification;
 use AidingApp\Portal\Settings\PortalSettings;
+use App\Support\AuthenticationCodeRateLimiter;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Testing\TestResponse;
 
@@ -102,4 +104,42 @@ test('it returns a validation error when no contact matches the email', function
     $response
         ->assertStatus(422)
         ->assertJsonValidationErrors(['email']);
+});
+
+test('it throttles repeated assistant authentication requests for the same contact', function () {
+    $contact = Contact::factory()->create([
+        'email' => 'contact@example.com',
+    ]);
+
+    requestAssistantAuthentication(['email' => $contact->email])->assertOk();
+
+    requestAssistantAuthentication(['email' => $contact->email])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['email']);
+
+    expect(PortalAuthentication::query()->count())->toBe(1);
+});
+
+test('it invalidates a contact\'s prior authentication when a new assistant code is requested', function () {
+    Notification::fake();
+
+    $contact = Contact::factory()->create([
+        'email' => 'contact@example.com',
+    ]);
+
+    requestAssistantAuthentication(['email' => $contact->email])->assertOk();
+
+    $firstAuthentication = PortalAuthentication::query()->latest('id')->first();
+
+    expect($firstAuthentication)->not->toBeNull();
+
+    // Clear the per-target mint cooldown so a second request is allowed.
+    RateLimiter::clear(app(AuthenticationCodeRateLimiter::class)->codeRequestKey($contact, 'assistant-widget'));
+
+    requestAssistantAuthentication(['email' => $contact->email])->assertOk();
+
+    $authentications = PortalAuthentication::query()->where('educatable_id', $contact->getKey())->get();
+
+    expect($authentications)->toHaveCount(1)
+        ->and($authentications->first()->id)->not->toBe($firstAuthentication?->id);
 });

--- a/app-modules/authorization/routes/web.php
+++ b/app-modules/authorization/routes/web.php
@@ -58,5 +58,5 @@ Route::middleware('web')->group(function () {
 
     Route::post('/otp-code/{otpCode}/verify', VerifyOtpLoginCodeController::class)
         ->name('otp-code.verify')
-        ->middleware(['signed', 'throttle:widget-authenticate']);
+        ->middleware(['signed', 'throttle:authentication-code-verify']);
 });

--- a/app-modules/authorization/routes/web.php
+++ b/app-modules/authorization/routes/web.php
@@ -58,5 +58,5 @@ Route::middleware('web')->group(function () {
 
     Route::post('/otp-code/{otpCode}/verify', VerifyOtpLoginCodeController::class)
         ->name('otp-code.verify')
-        ->middleware('signed');
+        ->middleware(['signed', 'throttle:widget-authenticate']);
 });

--- a/app-modules/authorization/src/Http/Controllers/GenerateOtpLoginCodeController.php
+++ b/app-modules/authorization/src/Http/Controllers/GenerateOtpLoginCodeController.php
@@ -40,6 +40,7 @@ use AidingApp\Authorization\Http\Requests\GenerateLoginOtpCodeRequest;
 use AidingApp\Authorization\Models\OtpLoginCode;
 use AidingApp\Authorization\Notifications\OtpCodeNotification;
 use App\Models\User;
+use App\Support\AuthenticationCodeRateLimiter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -51,22 +52,24 @@ class GenerateOtpLoginCodeController
     /**
      * @throws Throwable
      */
-    public function __invoke(GenerateLoginOtpCodeRequest $request): JsonResponse
+    public function __invoke(GenerateLoginOtpCodeRequest $request, AuthenticationCodeRateLimiter $rateLimiter): JsonResponse
     {
+        $data = $request->validated();
+
+        $user = User::query()
+            ->where('email', $data['email'])
+            ->first();
+
+        if (! $user) {
+            return response()->json([
+                'error' => 'User not found.',
+            ], 422);
+        }
+
+        $rateLimiter->ensureCanRequestCode($user, 'otp-login');
+
         try {
             DB::beginTransaction();
-
-            $data = $request->validated();
-
-            $user = User::query()
-                ->where('email', $data['email'])
-                ->first();
-
-            if (! $user) {
-                return response()->json([
-                    'error' => 'User not found.',
-                ], 422);
-            }
 
             // Remove any existing OTPs for this user
             OtpLoginCode::query()
@@ -83,6 +86,8 @@ class GenerateOtpLoginCodeController
             DB::commit();
 
             $user->notify(new OtpCodeNotification($code));
+
+            $rateLimiter->recordCodeRequest($user, 'otp-login');
 
             return response()->json([
                 'link' => URL::temporarySignedRoute(

--- a/app-modules/authorization/tests/Tenant/Feature/Http/Controllers/GenerateOtpLoginCodeControllerTest.php
+++ b/app-modules/authorization/tests/Tenant/Feature/Http/Controllers/GenerateOtpLoginCodeControllerTest.php
@@ -179,3 +179,28 @@ it('requires valid data', function (GenerateOtpLoginCodeRequestFactory $data, ar
             ],
         ],
     );
+
+it('throttles repeated OTP code requests for the same user', function () {
+    $user = User::factory()->create();
+
+    withoutMiddleware(CheckOlympusKey::class)
+        ->postJson(
+            route('otp-code.generate'),
+            [
+                'email' => $user->email,
+            ]
+        )
+        ->assertOk();
+
+    withoutMiddleware(CheckOlympusKey::class)
+        ->postJson(
+            route('otp-code.generate'),
+            [
+                'email' => $user->email,
+            ]
+        )
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['email']);
+
+    assertDatabaseCount(OtpLoginCode::class, 1);
+});

--- a/app-modules/authorization/tests/Tenant/Feature/Http/Controllers/VerifyOtpLoginCodeControllerTest.php
+++ b/app-modules/authorization/tests/Tenant/Feature/Http/Controllers/VerifyOtpLoginCodeControllerTest.php
@@ -35,6 +35,7 @@
 */
 
 use AidingApp\Authorization\Models\OtpLoginCode;
+use App\Support\AuthenticationCodeRateLimiter;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\URL;
 
@@ -153,6 +154,42 @@ it('returns an error when the OTP code is incorrect', function () {
     ])
         ->assertRedirect()
         ->assertSessionHasErrors(['code']);
+
+    assertGuest($panel->getAuthGuard());
+
+    $otpCode->refresh();
+
+    expect($otpCode->used_at)->toBeNull();
+});
+
+it('locks the OTP code after too many invalid attempts and rejects even the correct code', function () {
+    $code = 123456;
+
+    $otpCode = OtpLoginCode::factory()->withCode($code)->create();
+
+    $signedUrl = URL::temporarySignedRoute(
+        name: 'otp-code.verify',
+        expiration: now()->addMinutes(20)->toImmutable(),
+        parameters: [
+            'otpCode' => $otpCode->getKey(),
+        ],
+    );
+
+    foreach (range(1, AuthenticationCodeRateLimiter::MAX_ATTEMPTS) as $attempt) {
+        post($signedUrl, [
+            'code' => '654321',
+        ])
+            ->assertRedirect()
+            ->assertSessionHasErrors(['code']);
+    }
+
+    post($signedUrl, [
+        'code' => (string) $code,
+    ])
+        ->assertRedirect()
+        ->assertSessionHasErrors(['code']);
+
+    $panel = Filament::getPanel('admin');
 
     assertGuest($panel->getAuthGuard());
 

--- a/app-modules/portal/routes/api.php
+++ b/app-modules/portal/routes/api.php
@@ -91,15 +91,15 @@ Route::prefix('api')
                     ->name('resources');
 
                 Route::post('/authenticate/request', KnowledgeManagementPortalRequestAuthenticationController::class)
-                    ->middleware(['signed:relative'])
+                    ->middleware(['signed:relative', 'throttle:widget-authentication-request'])
                     ->name('request-authentication');
 
                 Route::post('/authenticate/{authentication}', KnowledgeManagementPortalAuthenticateController::class)
-                    ->middleware(['signed:relative', EnsureFrontendRequestsAreStateful::class])
+                    ->middleware(['signed:relative', 'throttle:widget-authenticate', EnsureFrontendRequestsAreStateful::class])
                     ->name('authenticate.embedded');
 
                 Route::post('/register/{authentication}', KnowledgeManagementPortalRegisterController::class)
-                    ->middleware(['signed:relative', EnsureFrontendRequestsAreStateful::class])
+                    ->middleware(['signed:relative', 'throttle:widget-authenticate', EnsureFrontendRequestsAreStateful::class])
                     ->name('authenticate.register.embedded');
 
                 Route::post('/logout', KnowledgeManagementPortalLogoutController::class)

--- a/app-modules/portal/routes/api.php
+++ b/app-modules/portal/routes/api.php
@@ -91,15 +91,15 @@ Route::prefix('api')
                     ->name('resources');
 
                 Route::post('/authenticate/request', KnowledgeManagementPortalRequestAuthenticationController::class)
-                    ->middleware(['signed:relative', 'throttle:widget-authentication-request'])
+                    ->middleware(['signed:relative', 'throttle:authentication-code-request'])
                     ->name('request-authentication');
 
                 Route::post('/authenticate/{authentication}', KnowledgeManagementPortalAuthenticateController::class)
-                    ->middleware(['signed:relative', 'throttle:widget-authenticate', EnsureFrontendRequestsAreStateful::class])
+                    ->middleware(['signed:relative', 'throttle:authentication-code-verify', EnsureFrontendRequestsAreStateful::class])
                     ->name('authenticate.embedded');
 
                 Route::post('/register/{authentication}', KnowledgeManagementPortalRegisterController::class)
-                    ->middleware(['signed:relative', 'throttle:widget-authenticate', EnsureFrontendRequestsAreStateful::class])
+                    ->middleware(['signed:relative', 'throttle:authentication-code-verify', EnsureFrontendRequestsAreStateful::class])
                     ->name('authenticate.register.embedded');
 
                 Route::post('/logout', KnowledgeManagementPortalLogoutController::class)

--- a/app-modules/portal/routes/web.php
+++ b/app-modules/portal/routes/web.php
@@ -65,11 +65,11 @@ Route::prefix('portal')
             EnsureKnowledgeManagementPortalIsEmbeddableAndAuthorized::class,
         ])->group(function () {
             Route::post('/authenticate/{authentication}', KnowledgeManagementPortalAuthenticateController::class)
-                ->middleware(['signed:relative', EnsureFrontendRequestsAreStateful::class])
+                ->middleware(['signed:relative', 'throttle:widget-authenticate', EnsureFrontendRequestsAreStateful::class])
                 ->name('authenticate');
 
             Route::post('/register/{authentication}', KnowledgeManagementPortalRegisterController::class)
-                ->middleware(['signed:relative', EnsureFrontendRequestsAreStateful::class])
+                ->middleware(['signed:relative', 'throttle:widget-authenticate', EnsureFrontendRequestsAreStateful::class])
                 ->name('register');
 
             Route::get('/', RenderKnowledgeManagementPortal::class)

--- a/app-modules/portal/routes/web.php
+++ b/app-modules/portal/routes/web.php
@@ -65,11 +65,11 @@ Route::prefix('portal')
             EnsureKnowledgeManagementPortalIsEmbeddableAndAuthorized::class,
         ])->group(function () {
             Route::post('/authenticate/{authentication}', KnowledgeManagementPortalAuthenticateController::class)
-                ->middleware(['signed:relative', 'throttle:widget-authenticate', EnsureFrontendRequestsAreStateful::class])
+                ->middleware(['signed:relative', 'throttle:authentication-code-verify', EnsureFrontendRequestsAreStateful::class])
                 ->name('authenticate');
 
             Route::post('/register/{authentication}', KnowledgeManagementPortalRegisterController::class)
-                ->middleware(['signed:relative', 'throttle:widget-authenticate', EnsureFrontendRequestsAreStateful::class])
+                ->middleware(['signed:relative', 'throttle:authentication-code-verify', EnsureFrontendRequestsAreStateful::class])
                 ->name('register');
 
             Route::get('/', RenderKnowledgeManagementPortal::class)

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalRequestAuthenticationController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalRequestAuthenticationController.php
@@ -37,6 +37,7 @@
 namespace AidingApp\Portal\Http\Controllers\KnowledgeManagementPortal;
 
 use AidingApp\Contact\Models\Contact;
+use AidingApp\Contact\Models\Organization;
 use AidingApp\Portal\Actions\FindOrganizationByEmailDomain;
 use AidingApp\Portal\Enums\PortalType;
 use AidingApp\Portal\Http\Requests\KnowledgeManagementPortalAuthenticationRequest;
@@ -44,10 +45,13 @@ use AidingApp\Portal\Models\PortalAuthentication;
 use AidingApp\Portal\Notifications\AuthenticatePortalNotification;
 use App\Actions\ResolveEducatableFromEmail;
 use App\Http\Controllers\Controller;
+use App\Support\AuthenticationCodeRateLimiter;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 
 class KnowledgeManagementPortalRequestAuthenticationController extends Controller
@@ -55,7 +59,8 @@ class KnowledgeManagementPortalRequestAuthenticationController extends Controlle
     public function __invoke(
         KnowledgeManagementPortalAuthenticationRequest $request,
         ResolveEducatableFromEmail $resolveEducatableFromEmail,
-        FindOrganizationByEmailDomain $findOrganizationByEmailDomain
+        FindOrganizationByEmailDomain $findOrganizationByEmailDomain,
+        AuthenticationCodeRateLimiter $rateLimiter,
     ): JsonResponse {
         $email = $request->safe()->email;
 
@@ -65,7 +70,7 @@ class KnowledgeManagementPortalRequestAuthenticationController extends Controlle
             $organization = $findOrganizationByEmailDomain($email);
 
             if ($organization) {
-                $authenticationUrl = $this->createPortalAuthentication($request);
+                $authenticationUrl = $this->createPortalAuthentication($request, $rateLimiter, organization: $organization);
 
                 return response()->json([
                     'registrationAllowed' => true,
@@ -79,7 +84,7 @@ class KnowledgeManagementPortalRequestAuthenticationController extends Controlle
             ]);
         }
 
-        $authenticationUrl = $this->createPortalAuthentication($request, $educatable);
+        $authenticationUrl = $this->createPortalAuthentication($request, $rateLimiter, $educatable);
 
         return response()->json([
             'message' => "We've sent an authentication code to {$email}.",
@@ -87,8 +92,26 @@ class KnowledgeManagementPortalRequestAuthenticationController extends Controlle
         ]);
     }
 
-    protected function createPortalAuthentication(KnowledgeManagementPortalAuthenticationRequest $request, ?Contact $contact = null): string
-    {
+    protected function createPortalAuthentication(
+        KnowledgeManagementPortalAuthenticationRequest $request,
+        AuthenticationCodeRateLimiter $rateLimiter,
+        ?Contact $contact = null,
+        ?Organization $organization = null,
+    ): string {
+        $email = $request->safe()->email;
+
+        [$rateLimitTarget, $scope] = $contact
+            ? [$contact, 'km-portal']
+            : [$organization, 'km-portal-register:' . sha1(Str::lower($email))];
+
+        assert($rateLimitTarget instanceof Model);
+
+        $rateLimiter->ensureCanRequestCode($rateLimitTarget, $scope);
+
+        if ($contact) {
+            PortalAuthentication::invalidateExistingCodesFor($contact, PortalType::KnowledgeManagement);
+        }
+
         $code = random_int(100000, 999999);
 
         $authentication = new PortalAuthentication();
@@ -105,11 +128,13 @@ class KnowledgeManagementPortalRequestAuthenticationController extends Controlle
             'mail',
             ! is_null($contact)
                 ? [
-                    $request->safe()->email => $contact->getAttributeValue($contact::displayNameKey()),
+                    $email => $contact->getAttributeValue($contact::displayNameKey()),
                 ]
-                : $request->safe()->email
+                : $email
         )
             ->notify(new AuthenticatePortalNotification($authentication, $code));
+
+        $rateLimiter->recordCodeRequest($rateLimitTarget, $scope);
 
         $route = (! is_null($contact))
             ? (

--- a/app-modules/portal/src/Http/Requests/KnowledgeManagementPortalAuthenticateRequest.php
+++ b/app-modules/portal/src/Http/Requests/KnowledgeManagementPortalAuthenticateRequest.php
@@ -36,7 +36,8 @@
 
 namespace AidingApp\Portal\Http\Requests;
 
-use AidingApp\Portal\Rules\PortalAuthenticateCodeValidation;
+use AidingApp\Portal\Models\PortalAuthentication;
+use App\Rules\ValidAuthenticationCode;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -49,8 +50,12 @@ class KnowledgeManagementPortalAuthenticateRequest extends FormRequest
      */
     public function rules(): array
     {
+        $authentication = $this->route('authentication');
+
+        assert($authentication instanceof PortalAuthentication);
+
         return [
-            'code' => ['required', 'integer', 'digits:6', new PortalAuthenticateCodeValidation()],
+            'code' => ['required', 'integer', 'digits:6', new ValidAuthenticationCode($authentication)],
         ];
     }
 }

--- a/app-modules/portal/src/Http/Requests/KnowledgeManagementPortalRegisterRequest.php
+++ b/app-modules/portal/src/Http/Requests/KnowledgeManagementPortalRegisterRequest.php
@@ -37,7 +37,8 @@
 namespace AidingApp\Portal\Http\Requests;
 
 use AidingApp\Portal\Actions\FindOrganizationByEmailDomain;
-use AidingApp\Portal\Rules\PortalAuthenticateCodeValidation;
+use AidingApp\Portal\Models\PortalAuthentication;
+use App\Rules\ValidAuthenticationCode;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -54,6 +55,10 @@ class KnowledgeManagementPortalRegisterRequest extends FormRequest
      */
     public function rules(): array
     {
+        $authentication = $this->route('authentication');
+
+        assert($authentication instanceof PortalAuthentication);
+
         return [
             'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users', 'email')->where(fn (Builder $query) => $query->whereNotNull('deleted_at'))],
             'first_name' => ['required', 'string', 'max:255'],
@@ -62,7 +67,7 @@ class KnowledgeManagementPortalRegisterRequest extends FormRequest
             'mobile' => ['required', 'string', 'max:255'],
             'phone' => ['nullable', 'string', 'max:255'],
             'sms_opt_out' => ['required', 'boolean'],
-            'code' => ['required', 'integer', 'digits:6', new PortalAuthenticateCodeValidation()],
+            'code' => ['required', 'integer', 'digits:6', new ValidAuthenticationCode($authentication)],
         ];
     }
 }

--- a/app-modules/portal/src/Models/PortalAuthentication.php
+++ b/app-modules/portal/src/Models/PortalAuthentication.php
@@ -79,6 +79,18 @@ class PortalAuthentication extends BaseModel
     }
 
     /**
+     * Invalidate any prior, still-live authentication codes for the given
+     * educatable so a newly minted code is the only one that can be used.
+     */
+    public static function invalidateExistingCodesFor(Model $educatable, PortalType $portalType): void
+    {
+        static::query()
+            ->where('portal_type', $portalType)
+            ->whereMorphedTo('educatable', $educatable)
+            ->delete();
+    }
+
+    /**
      * @return MorphTo<Model, $this>
      */
     public function educatable(): MorphTo

--- a/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalRequestAuthenticationControllerTest.php
+++ b/app-modules/portal/tests/Tenant/Http/Controllers/KnowledgeManagementPortal/KnowledgeManagementPortalRequestAuthenticationControllerTest.php
@@ -39,7 +39,9 @@ use AidingApp\Contact\Models\Organization;
 use AidingApp\Portal\Models\PortalAuthentication;
 use AidingApp\Portal\Notifications\AuthenticatePortalNotification;
 use AidingApp\Portal\Settings\PortalSettings;
+use App\Support\AuthenticationCodeRateLimiter;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
 
 use function Pest\Laravel\postJson;
@@ -173,4 +175,46 @@ test('it returns validation error when contact and organization domain are not f
     $response
         ->assertStatus(422)
         ->assertJsonValidationErrors(['email']);
+});
+
+test('it throttles repeated authentication requests for the same contact', function () {
+    $contact = Contact::factory()->create([
+        'email' => 'contact@example.com',
+    ]);
+
+    $url = URL::signedRoute(name: 'api.portal.request-authentication', absolute: false);
+
+    postJson($url, ['email' => $contact->email])->assertOk();
+
+    postJson($url, ['email' => $contact->email])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['email']);
+
+    expect(PortalAuthentication::query()->count())->toBe(1);
+});
+
+test('it invalidates a contact\'s prior authentication when a new code is requested', function () {
+    Notification::fake();
+
+    $contact = Contact::factory()->create([
+        'email' => 'contact@example.com',
+    ]);
+
+    $url = URL::signedRoute(name: 'api.portal.request-authentication', absolute: false);
+
+    postJson($url, ['email' => $contact->email])->assertOk();
+
+    $firstAuthentication = PortalAuthentication::query()->latest('id')->first();
+
+    expect($firstAuthentication)->not->toBeNull();
+
+    // Clear the per-target mint cooldown so a second request is allowed.
+    RateLimiter::clear(app(AuthenticationCodeRateLimiter::class)->codeRequestKey($contact, 'km-portal'));
+
+    postJson($url, ['email' => $contact->email])->assertOk();
+
+    $authentications = PortalAuthentication::query()->where('educatable_id', $contact->getKey())->get();
+
+    expect($authentications)->toHaveCount(1)
+        ->and($authentications->first()->id)->not->toBe($firstAuthentication?->id);
 });

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -97,5 +97,13 @@ class RouteServiceProvider extends ServiceProvider
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(60)->by(optional($request->user())->id ?: ClientIp::resolve($request));
         });
+
+        RateLimiter::for('widget-authenticate', function (Request $request) {
+            return Limit::perMinute(10)->by(optional($request->user())->id ?: ClientIp::resolve($request));
+        });
+
+        RateLimiter::for('widget-authentication-request', function (Request $request) {
+            return Limit::perMinute(10)->by(optional($request->user())->id ?: ClientIp::resolve($request));
+        });
     }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -98,11 +98,11 @@ class RouteServiceProvider extends ServiceProvider
             return Limit::perMinute(60)->by(optional($request->user())->id ?: ClientIp::resolve($request));
         });
 
-        RateLimiter::for('widget-authenticate', function (Request $request) {
+        RateLimiter::for('authentication-code-verify', function (Request $request) {
             return Limit::perMinute(10)->by(optional($request->user())->id ?: ClientIp::resolve($request));
         });
 
-        RateLimiter::for('widget-authentication-request', function (Request $request) {
+        RateLimiter::for('authentication-code-request', function (Request $request) {
             return Limit::perMinute(10)->by(optional($request->user())->id ?: ClientIp::resolve($request));
         });
     }

--- a/app/Rules/ValidAuthenticationCode.php
+++ b/app/Rules/ValidAuthenticationCode.php
@@ -34,32 +34,43 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Portal\Rules;
+namespace App\Rules;
 
+use App\Support\AuthenticationCodeRateLimiter;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Translation\PotentiallyTranslatedString;
 
-class PortalAuthenticateCodeValidation implements ValidationRule
+class ValidAuthenticationCode implements ValidationRule
 {
+    public function __construct(
+        protected Model $authentication,
+        protected AuthenticationCodeRateLimiter $rateLimiter = new AuthenticationCodeRateLimiter(),
+    ) {}
+
     /**
-     * Run the validation rule.
-     *
-     * @param  Closure(string): PotentiallyTranslatedString $fail
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $request = request();
+        if ($this->rateLimiter->isLocked($this->authentication)) {
+            $fail('Too many invalid attempts. Please request a new code.');
 
-        $authentication = $request->route('authentication');
-
-        if (! $authentication) {
-            $fail('Could not find Authentication.');
+            return;
         }
 
-        if (! Hash::check($value, $authentication->code)) {
-            $fail('The provided code is invalid.');
+        $hashedCode = $this->authentication->getAttribute('code');
+
+        if (is_string($hashedCode) && is_scalar($value) && Hash::check((string) $value, $hashedCode)) {
+            $this->rateLimiter->clear($this->authentication);
+
+            return;
         }
+
+        $this->rateLimiter->recordFailedAttempt($this->authentication);
+
+        $fail('The provided code is invalid.');
     }
 }

--- a/app/Support/AuthenticationCodeRateLimiter.php
+++ b/app/Support/AuthenticationCodeRateLimiter.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Validation\ValidationException;
+
+class AuthenticationCodeRateLimiter
+{
+    public const MAX_ATTEMPTS = 5;
+
+    public const DECAY_SECONDS = 86400;
+
+    public const MAX_CODE_REQUESTS = 1;
+
+    public const CODE_REQUEST_DECAY_SECONDS = 60;
+
+    public function isLocked(Model $authentication): bool
+    {
+        return RateLimiter::tooManyAttempts($this->key($authentication), self::MAX_ATTEMPTS);
+    }
+
+    public function recordFailedAttempt(Model $authentication): void
+    {
+        RateLimiter::hit($this->key($authentication), self::DECAY_SECONDS);
+    }
+
+    public function clear(Model $authentication): void
+    {
+        RateLimiter::clear($this->key($authentication));
+    }
+
+    public function key(Model $authentication): string
+    {
+        return 'authentication-code:' . $authentication::class . ':' . $authentication->getKey();
+    }
+
+    /**
+     * Enforce a per-target cooldown so a fresh code cannot be minted repeatedly to
+     * bypass the per-record guess lockout by rotating authentication records.
+     */
+    public function ensureCanRequestCode(Model $author, string $scope): void
+    {
+        if (RateLimiter::tooManyAttempts($this->codeRequestKey($author, $scope), self::MAX_CODE_REQUESTS)) {
+            throw ValidationException::withMessages([
+                'email' => 'A code was recently sent to this email address. Please wait a moment before requesting another.',
+            ]);
+        }
+    }
+
+    public function recordCodeRequest(Model $author, string $scope): void
+    {
+        RateLimiter::hit($this->codeRequestKey($author, $scope), self::CODE_REQUEST_DECAY_SECONDS);
+    }
+
+    public function codeRequestKey(Model $author, string $scope): string
+    {
+        return 'authentication-code-request:' . $author::class . ':' . $author->getKey() . ':' . $scope;
+    }
+}

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -906,12 +906,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/app-modules/portal/src/Models/PortalGuest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot access property \\$code on object\\|string\\.$#',
-    'identifier' => 'property.nonObject',
-    'count' => 1,
-    'path' => __DIR__ . '/app-modules/portal/src/Rules/PortalAuthenticateCodeValidation.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Property AidingApp\\\\Portal\\\\Settings\\\\PortalSettings\\:\\:\\$gdpr_banner_text type has no value type specified in iterable type array\\.$#',
     'identifier' => 'missingType.iterableValue',
     'count' => 1,

--- a/routes/api.php
+++ b/routes/api.php
@@ -55,5 +55,7 @@ Route::middleware([
     Route::get('/utilization-metrics', UtilizationMetricsApiController::class)
         ->name('utilization-metrics');
 
-    Route::post('/otp-code', GenerateOtpLoginCodeController::class)->name('otp-code.generate');
+    Route::post('/otp-code', GenerateOtpLoginCodeController::class)
+        ->middleware(['throttle:widget-authentication-request'])
+        ->name('otp-code.generate');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -56,6 +56,6 @@ Route::middleware([
         ->name('utilization-metrics');
 
     Route::post('/otp-code', GenerateOtpLoginCodeController::class)
-        ->middleware(['throttle:widget-authentication-request'])
+        ->middleware(['throttle:authentication-code-request'])
         ->name('otp-code.generate');
 });

--- a/tests/Tenant/Unit/Rules/ValidAuthenticationCodeTest.php
+++ b/tests/Tenant/Unit/Rules/ValidAuthenticationCodeTest.php
@@ -80,12 +80,15 @@ it('clears the failed-attempt counter after a successful validation', function (
     $authentication = OtpLoginCode::factory()->withCode(123456)->create();
 
     foreach (range(1, AuthenticationCodeRateLimiter::MAX_ATTEMPTS - 1) as $attempt) {
-        validateAuthenticationCode($authentication, '654321');
+        expect(validateAuthenticationCode($authentication, '654321')->passes())->toBeFalse();
     }
 
     expect(validateAuthenticationCode($authentication, '123456')->passes())->toBeTrue();
 
-    $validator = validateAuthenticationCode($authentication, '654321');
+    foreach (range(1, AuthenticationCodeRateLimiter::MAX_ATTEMPTS - 1) as $attempt) {
+        $validator = validateAuthenticationCode($authentication, '654321');
 
-    expect($validator->errors()->first('code'))->toBe('The provided code is invalid.');
+        expect($validator->passes())->toBeFalse();
+        expect($validator->errors()->first('code'))->toBe('The provided code is invalid.');
+    }
 });

--- a/tests/Tenant/Unit/Rules/ValidAuthenticationCodeTest.php
+++ b/tests/Tenant/Unit/Rules/ValidAuthenticationCodeTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Aiding App® is licensed under the Elastic License 2.0. For more details,
+    see <https://github.com/canyongbs/aidingapp/blob/main/LICENSE.>
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Aiding App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    <https://www.canyongbs.com> or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AidingApp\Authorization\Models\OtpLoginCode;
+use App\Rules\ValidAuthenticationCode;
+use App\Support\AuthenticationCodeRateLimiter;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Validator as ValidatorInstance;
+
+function validateAuthenticationCode(OtpLoginCode $authentication, string $code): ValidatorInstance
+{
+    return Validator::make(
+        ['code' => $code],
+        ['code' => [new ValidAuthenticationCode($authentication)]],
+    );
+}
+
+it('passes for the correct code', function () {
+    $authentication = OtpLoginCode::factory()->withCode(123456)->create();
+
+    expect(validateAuthenticationCode($authentication, '123456')->passes())->toBeTrue();
+});
+
+it('fails for an incorrect code', function () {
+    $authentication = OtpLoginCode::factory()->withCode(123456)->create();
+
+    $validator = validateAuthenticationCode($authentication, '654321');
+
+    expect($validator->passes())->toBeFalse();
+    expect($validator->errors()->first('code'))->toBe('The provided code is invalid.');
+});
+
+it('locks the record after the maximum failed attempts and then rejects even the correct code', function () {
+    $authentication = OtpLoginCode::factory()->withCode(123456)->create();
+
+    foreach (range(1, AuthenticationCodeRateLimiter::MAX_ATTEMPTS) as $attempt) {
+        expect(validateAuthenticationCode($authentication, '654321')->passes())->toBeFalse();
+    }
+
+    $validator = validateAuthenticationCode($authentication, '123456');
+
+    expect($validator->passes())->toBeFalse();
+    expect($validator->errors()->first('code'))->toBe('Too many invalid attempts. Please request a new code.');
+});
+
+it('clears the failed-attempt counter after a successful validation', function () {
+    $authentication = OtpLoginCode::factory()->withCode(123456)->create();
+
+    foreach (range(1, AuthenticationCodeRateLimiter::MAX_ATTEMPTS - 1) as $attempt) {
+        validateAuthenticationCode($authentication, '654321');
+    }
+
+    expect(validateAuthenticationCode($authentication, '123456')->passes())->toBeTrue();
+
+    $validator = validateAuthenticationCode($authentication, '654321');
+
+    expect($validator->errors()->first('code'))->toBe('The provided code is invalid.');
+});

--- a/tests/Tenant/Unit/Support/AuthenticationCodeRateLimiterTest.php
+++ b/tests/Tenant/Unit/Support/AuthenticationCodeRateLimiterTest.php
@@ -34,49 +34,33 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\Authorization\Http\Controllers;
+use App\Models\User;
+use App\Support\AuthenticationCodeRateLimiter;
+use Illuminate\Validation\ValidationException;
 
-use AidingApp\Authorization\Models\OtpLoginCode;
-use App\Rules\ValidAuthenticationCode;
-use Filament\Facades\Filament;
-use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Auth;
-use Throwable;
+it('allows the first code request and blocks a rapid second request for the same target', function () {
+    $rateLimiter = new AuthenticationCodeRateLimiter();
 
-class VerifyOtpLoginCodeController
-{
-    /**
-     * @throws Throwable
-     */
-    public function __invoke(Request $request, OtpLoginCode $otpCode): RedirectResponse|Response
-    {
-        if ($request->getMethod() === 'HEAD') {
-            // Protection against link scanning bots, like Microsoft Outlook.
-            return response()->noContent();
-        }
+    $user = User::factory()->create();
 
-        abort_if(
-            boolean: now()->greaterThanOrEqualTo($otpCode->created_at->addMinutes(20))
-                || $otpCode->used_at !== null,
-            code: 403,
-            message: 'This OTP code has already been used or has expired. Please request a new one.'
-        );
+    $rateLimiter->ensureCanRequestCode($user, 'otp-login');
+    $rateLimiter->recordCodeRequest($user, 'otp-login');
 
-        $request->validate([
-            'code' => ['required', 'digits:6', new ValidAuthenticationCode($otpCode)],
-        ]);
+    expect(fn () => $rateLimiter->ensureCanRequestCode($user, 'otp-login'))
+        ->toThrow(ValidationException::class);
+});
 
-        $otpCode->used_at = now();
-        $otpCode->saveOrFail();
+it('scopes the code-request cooldown per target', function () {
+    $rateLimiter = new AuthenticationCodeRateLimiter();
 
-        $user = $otpCode->user;
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
 
-        $panel = Filament::getPanel('admin');
+    $rateLimiter->recordCodeRequest($user, 'otp-login');
 
-        Auth::guard($panel->getAuthGuard())->login($user);
+    // Same person, different scope: not throttled.
+    $rateLimiter->ensureCanRequestCode($user, 'km-portal');
 
-        return redirect()->intended($panel->getHomeUrl());
-    }
-}
+    // Different person, same scope: not throttled.
+    $rateLimiter->ensureCanRequestCode($otherUser, 'otp-login');
+})->throwsNoExceptions();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1437

### Technical Description

> Added `AuthenticationCodeRateLimiter` to manage rate limiting for authentication code requests and validation.
> Introduced `ValidAuthenticationCode` rule to validate authentication codes against the rate limiter.
> Updated `GenerateOtpLoginCodeController` and `VerifyOtpLoginCodeController` to utilize the new rate limiter.
> Enhanced `KnowledgeManagementPortalRequestAuthenticationController` to invalidate previous authentication codes when a new request is made.
> Implemented throttling for repeated authentication requests in both API and web routes.
> Created tests for the new rate limiting functionality and validation rules.
> Refactored existing tests to ensure they align with the new authentication flow.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
