### PR TITLE
[AIDAPP-1469]: Users have reported being unable to access the milestone creation action for projects despite having the expected permissions to do so

### DIFF
--- a/app-modules/project/src/Filament/Actions/CreateProjectMilestoneAction.php
+++ b/app-modules/project/src/Filament/Actions/CreateProjectMilestoneAction.php
@@ -37,6 +37,7 @@
 namespace AidingApp\Project\Filament\Actions;
 
 use AidingApp\Project\Models\Project;
+use AidingApp\Project\Models\ProjectMilestone;
 use AidingApp\Project\Models\ProjectMilestoneStatus;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
@@ -55,7 +56,7 @@ class CreateProjectMilestoneAction
             ->label('Milestone')
             ->icon('heroicon-m-plus')
             ->color('primary')
-            ->authorize('create', $project)
+            ->authorize(fn (): bool => auth()->user()->can('create', [ProjectMilestone::class, $project]))
             ->slideOver()
             ->modalHeading('Create Project Milestone')
             ->schema(static::formSchema())

--- a/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectFilesWidget.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectFilesWidget.php
@@ -130,7 +130,7 @@ class ProjectFilesWidget extends TableWidget
                 Action::make('download')
                     ->icon('heroicon-m-arrow-down-on-square')
                     ->color('info')
-                    ->authorize('view')
+                    ->authorize(fn (ProjectFile $record): bool => auth()->user()->can('view', $record))
                     ->visible(fn (ProjectFile $record): bool => filled($record->getMedia('file')->first()?->getPathRelativeToRoot()))
                     ->action(
                         fn (ProjectFile $record) => Storage::disk('s3')
@@ -145,7 +145,7 @@ class ProjectFilesWidget extends TableWidget
             ->headerActions([
                 Action::make('manageFiles')
                     ->label('Manage')
-                    ->authorize('create', $this->record)
+                    ->authorize(fn (): bool => auth()->user()->can('create', [ProjectFile::class, $this->record]))
                     ->color('gray')
                     ->url(fn (): string => ProjectResource::getUrl('manage-files', ['record' => $this->record])),
             ]);

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
@@ -378,6 +378,48 @@ it('can create a milestone through the project milestones widget create action',
     expect($project->milestones()->where('title', $milestone->title)->exists())->toBeTrue();
 });
 
+it('shows the create milestone action to users who can update the project', function () {
+    $manager = User::factory()->create();
+    $manager->givePermissionTo('project.view-any');
+    $manager->givePermissionTo('project.*.view');
+    $manager->givePermissionTo('project.*.update');
+
+    $project = Project::factory()->create();
+    $project->managerUsers()->attach($manager);
+
+    actingAs($manager);
+
+    Pipeline::factory()
+        ->for($project)
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    livewire(ProjectWorkPipelineWidget::class, [
+        'record' => $project,
+    ])
+        ->assertTableActionVisible('createMilestone');
+});
+
+it('hides the create milestone action from users who cannot update the project', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('project.view-any');
+    $user->givePermissionTo('project.*.view');
+
+    actingAs($user);
+
+    $project = Project::factory()->create();
+
+    Pipeline::factory()
+        ->for($project)
+        ->has(PipelineStage::factory()->count(1), 'stages')
+        ->create();
+
+    livewire(ProjectWorkPipelineWidget::class, [
+        'record' => $project,
+    ])
+        ->assertTableActionHidden('createMilestone');
+});
+
 it('auto-selects the first pipeline on mount in the project work pipeline widget', function () {
     asSuperAdmin();
 
@@ -1105,6 +1147,38 @@ it('can list files in the project files widget', function () {
         'record' => $project,
     ])
         ->assertCanSeeTableRecords($files);
+});
+
+it('shows the manage files action to users who can update the project', function () {
+    $manager = User::factory()->create();
+    $manager->givePermissionTo('project.view-any');
+    $manager->givePermissionTo('project.*.view');
+    $manager->givePermissionTo('project.*.update');
+
+    $project = Project::factory()->create();
+    $project->managerUsers()->attach($manager);
+
+    actingAs($manager);
+
+    livewire(ProjectFilesWidget::class, [
+        'record' => $project,
+    ])
+        ->assertTableActionVisible('manageFiles');
+});
+
+it('hides the manage files action from users who cannot update the project', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('project.view-any');
+    $user->givePermissionTo('project.*.view');
+
+    actingAs($user);
+
+    $project = Project::factory()->create();
+
+    livewire(ProjectFilesWidget::class, [
+        'record' => $project,
+    ])
+        ->assertTableActionHidden('manageFiles');
 });
 
 it('calculates progress as 0 when the project has no pipeline entries', function () {


### PR DESCRIPTION
## Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1469

### Technical Description

Fixes a bug in access control for some of the project relationship components.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
