### PR TITLE
[AIDAPP-1496]: Some users have reported broken file download links for Service Request uploads

### DIFF
--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -44,6 +44,7 @@ use AidingApp\Engagement\Exceptions\SesS3InboundServiceRequestTypeNotFound;
 use AidingApp\Engagement\Exceptions\SesS3InboundSpamOrVirusDetected;
 use AidingApp\Engagement\Exceptions\UnableToDetectTenantFromSesS3EmailPayload;
 use AidingApp\Engagement\Exceptions\UnableToRetrieveContentFromSesS3EmailPayload;
+use AidingApp\Engagement\Models\EngagementResponse;
 use AidingApp\Engagement\Models\UnmatchedInboundCommunication;
 use AidingApp\Engagement\Notifications\IneligibleContactSesS3InboundEmailServiceRequestNotification;
 use AidingApp\Notification\Models\OutboundEmailMessageId;
@@ -54,6 +55,7 @@ use AidingApp\ServiceManagement\Enums\EmailAutomaticCreationContactCreateConditi
 use AidingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AidingApp\ServiceManagement\Models\ServiceRequest;
 use AidingApp\ServiceManagement\Models\ServiceRequestStatus;
+use AidingApp\ServiceManagement\Models\ServiceRequestUpdate;
 use AidingApp\ServiceManagement\Models\TenantServiceRequestTypeDomain;
 use App\Models\Tenant;
 use Aws\Crypto\KmsMaterialsProviderV3;
@@ -321,27 +323,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                 ]);
 
                 collect($parser->getAttachments())->each(function (Attachment $attachment) use ($unmatchedCommunication) {
-                    try {
-                        if (
-                            ($attachment->getContentDisposition() === 'inline')
-                            && filled(trim($contentId = $attachment->getContentID(), '<>'))
-                        ) {
-                            $unmatchedCommunication->addMediaFromStream($attachment->getStream())
-                                ->withCustomProperties(['cid' => trim($contentId, '<>')])
-                                ->setName($attachment->getFilename())
-                                ->setFileName($attachment->getFilename())
-                                ->toMediaCollection('inline_attachments');
-
-                            return;
-                        }
-
-                        $unmatchedCommunication->addMediaFromStream($attachment->getStream())
-                            ->setName($attachment->getFilename())
-                            ->setFileName($attachment->getFilename())
-                            ->toMediaCollection('attachments');
-                    } catch (Throwable $throw) {
-                        report($throw);
-                    }
+                    $this->storeAttachmentMedia($unmatchedCommunication, $attachment, 'attachments');
                 });
 
                 return;
@@ -358,28 +340,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                     ]);
 
                 collect($parser->getAttachments())->each(function (Attachment $attachment) use ($engagementResponse, $contact) {
-                    try {
-                        if (
-                            ($attachment->getContentDisposition() === 'inline')
-                            && filled(trim($contentId = $attachment->getContentID(), '<>'))
-                        ) {
-                            $engagementResponse->addMediaFromStream($attachment->getStream())
-                                ->withCustomProperties(['cid' => trim($contentId, '<>')])
-                                ->setName($attachment->getFilename())
-                                ->setFileName($attachment->getFilename())
-                                ->toMediaCollection('inline_attachments');
-
-                            return;
-                        }
-
-                        $engagementResponse->addMediaFromStream($attachment->getStream())
-                            ->setName($attachment->getFilename())
-                            ->setFileName($attachment->getFilename())
-                            ->createdBy($contact)
-                            ->toMediaCollection('attachments');
-                    } catch (Throwable $throw) {
-                        report($throw);
-                    }
+                    $this->storeAttachmentMedia($engagementResponse, $attachment, 'attachments', $contact);
                 });
             });
         });
@@ -428,28 +389,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
             ]);
 
             foreach ($parser->getAttachments() as $attachment) {
-                try {
-                    if (
-                        ($attachment->getContentDisposition() === 'inline')
-                        && filled(trim($contentId = $attachment->getContentID(), '<>'))
-                    ) {
-                        $serviceRequestUpdate->addMediaFromStream($attachment->getStream())
-                            ->withCustomProperties(['cid' => trim($contentId, '<>')])
-                            ->setName($attachment->getFilename())
-                            ->setFileName($attachment->getFilename())
-                            ->toMediaCollection('inline_attachments');
-
-                        continue;
-                    }
-
-                    $serviceRequestUpdate->addMediaFromStream($attachment->getStream())
-                        ->setName($attachment->getFilename())
-                        ->setFileName($attachment->getFilename())
-                        ->createdBy($serviceRequest->respondent)
-                        ->toMediaCollection('uploads');
-                } catch (Throwable $throw) {
-                    report($throw);
-                }
+                $this->storeAttachmentMedia($serviceRequestUpdate, $attachment, 'uploads', $serviceRequest->respondent);
             }
         });
     }
@@ -621,28 +561,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                 );
 
                 foreach ($parser->getAttachments() as $attachment) {
-                    try {
-                        if (
-                            ($attachment->getContentDisposition() === 'inline')
-                            && filled(trim($contentId = $attachment->getContentID(), '<>'))
-                        ) {
-                            $serviceRequest->addMediaFromStream($attachment->getStream())
-                                ->withCustomProperties(['cid' => trim($contentId, '<>')])
-                                ->setName($attachment->getFilename())
-                                ->setFileName($attachment->getFilename())
-                                ->toMediaCollection('inline_attachments');
-
-                            continue;
-                        }
-
-                        $serviceRequest->addMediaFromStream($attachment->getStream())
-                            ->setName($attachment->getFilename())
-                            ->setFileName($attachment->getFilename())
-                            ->createdBy($contact)
-                            ->toMediaCollection('uploads');
-                    } catch (Throwable $throw) {
-                        report($throw);
-                    }
+                    $this->storeAttachmentMedia($serviceRequest, $attachment, 'uploads', $contact);
                 }
             });
         });
@@ -814,27 +733,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
             ]);
 
             collect($parser->getAttachments())->each(function (Attachment $attachment) use ($unmatchedCommunication) {
-                try {
-                    if (
-                        ($attachment->getContentDisposition() === 'inline')
-                        && filled(trim($contentId = $attachment->getContentID(), '<>'))
-                    ) {
-                        $unmatchedCommunication->addMediaFromStream($attachment->getStream())
-                            ->withCustomProperties(['cid' => trim($contentId, '<>')])
-                            ->setName($attachment->getFilename())
-                            ->setFileName($attachment->getFilename())
-                            ->toMediaCollection('inline_attachments');
-
-                        return;
-                    }
-
-                    $unmatchedCommunication->addMediaFromStream($attachment->getStream())
-                        ->setName($attachment->getFilename())
-                        ->setFileName($attachment->getFilename())
-                        ->toMediaCollection('attachments');
-                } catch (Throwable $throw) {
-                    report($throw);
-                }
+                $this->storeAttachmentMedia($unmatchedCommunication, $attachment, 'attachments');
             });
         });
     }
@@ -898,5 +797,45 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
     protected function moveFile(string $destination): void
     {
         Storage::disk('s3-inbound-email')->move($this->emailFilePath, $destination . '/' . $this->emailFilePath);
+    }
+
+    /**
+     * Store an email attachment on the model, following the media-library convention that the display
+     * name carries no extension (the extension lives only in the file name).
+     */
+    private function storeAttachmentMedia(
+        UnmatchedInboundCommunication|EngagementResponse|ServiceRequestUpdate|ServiceRequest $model,
+        Attachment $attachment,
+        string $collection,
+        ?Contact $createdBy = null,
+    ): void {
+        try {
+            $fileName = $attachment->getFilename();
+
+            if (
+                ($attachment->getContentDisposition() === 'inline')
+                && filled(trim($contentId = $attachment->getContentID(), '<>'))
+            ) {
+                $model->addMediaFromStream($attachment->getStream())
+                    ->withCustomProperties(['cid' => trim($contentId, '<>')])
+                    ->usingName(pathinfo($fileName, PATHINFO_FILENAME))
+                    ->usingFileName($fileName)
+                    ->toMediaCollection('inline_attachments');
+
+                return;
+            }
+
+            $fileAdder = $model->addMediaFromStream($attachment->getStream())
+                ->usingName(pathinfo($fileName, PATHINFO_FILENAME))
+                ->usingFileName($fileName);
+
+            if ($createdBy !== null) {
+                $fileAdder->createdBy($createdBy);
+            }
+
+            $fileAdder->toMediaCollection($collection);
+        } catch (Throwable $throw) {
+            report($throw);
+        }
     }
 }

--- a/app-modules/engagement/tests/Landlord/Jobs/ProcessSesS3InboundEmailTest.php
+++ b/app-modules/engagement/tests/Landlord/Jobs/ProcessSesS3InboundEmailTest.php
@@ -2840,8 +2840,10 @@ describe('Service request reply threading', function () {
 
             expect($media)->toHaveCount(2);
             expect($media->first()->file_name)->toBe('SampleJPGImage_1mbmb.jpg');
+            expect($media->first()->name)->toBe('SampleJPGImage_1mbmb');
             expect($media->first()->extension)->toBe('jpg');
             expect($media->last()->file_name)->toBe('SampleJPGImage_50kbmb.jpg');
+            expect($media->last()->name)->toBe('SampleJPGImage_50kbmb');
             expect($media->last()->extension)->toBe('jpg');
 
             $inlineAttachments = $serviceRequestUpdate->getMedia('inline_attachments');

--- a/app-modules/service-management/src/Filament/Widgets/ServiceRequestMediaTable.php
+++ b/app-modules/service-management/src/Filament/Widgets/ServiceRequestMediaTable.php
@@ -81,7 +81,16 @@ class ServiceRequestMediaTable extends TableWidget
             ->columns([
                 TextColumn::make('display_name')
                     ->label('File Name')
-                    ->getStateUsing(fn (Media $record): string => $record->name . '.' . pathinfo($record->file_name, PATHINFO_EXTENSION))
+                    ->getStateUsing(function (Media $record): string {
+                        $extension = pathinfo($record->file_name, PATHINFO_EXTENSION);
+
+                        // Some ingestion paths store the extension in the name; don't append it twice.
+                        if ($extension === '' || str_ends_with(mb_strtolower($record->name), '.' . mb_strtolower($extension))) {
+                            return $record->name;
+                        }
+
+                        return $record->name . '.' . $extension;
+                    })
                     ->searchable(
                         query: fn (Builder $query, string $search) => $query->whereRaw('LOWER(name) LIKE ?', ['%' . strtolower($search) . '%'])
                     )

--- a/app-modules/service-management/src/Http/Controllers/ServiceRequestMediaDownloadController.php
+++ b/app-modules/service-management/src/Http/Controllers/ServiceRequestMediaDownloadController.php
@@ -48,7 +48,7 @@ class ServiceRequestMediaDownloadController extends Controller
         return redirect(
             $media->getTemporaryUrl(
                 expiration: now()->addMinute(),
-                options: ['ResponseContentDisposition' => 'attachment; filename="' . $media->file_name . '"']
+                options: ['ResponseContentDisposition' => $media->attachmentContentDisposition()]
             )
         );
     }

--- a/app-modules/service-management/tests/Tenant/Filament/Widgets/ServiceRequestMediaTableTest.php
+++ b/app-modules/service-management/tests/Tenant/Filament/Widgets/ServiceRequestMediaTableTest.php
@@ -66,6 +66,47 @@ describe('ServiceRequest', function () {
             ->assertCanSeeTableRecords($serviceRequest->getMedia('uploads'));
     });
 
+    test('appends the extension to the display name when the name has none', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        $serviceRequest = ServiceRequest::factory()->create();
+        $media = $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('report.png'))
+            ->usingName('report')
+            ->usingFileName('report.png')
+            ->toMediaCollection('uploads');
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->assertSuccessful()
+            ->assertTableColumnStateSet('display_name', 'report.png', record: $media);
+    });
+
+    test('does not double the extension when the name already includes it', function () {
+        Storage::fake('s3');
+
+        asSuperAdmin();
+
+        // Mirrors email-ingested media, where the name was stored with its extension.
+        $serviceRequest = ServiceRequest::factory()->create();
+        $media = $serviceRequest
+            ->addMedia(UploadedFile::fake()->image('Screenshot.jpg'))
+            ->usingName('Screenshot.jpg')
+            ->usingFileName('Screenshot.jpg')
+            ->toMediaCollection('uploads');
+
+        livewire(ServiceRequestMediaTable::class, [
+            'record' => $serviceRequest,
+            'collectionName' => 'uploads',
+        ])
+            ->assertSuccessful()
+            ->assertTableColumnStateSet('display_name', 'Screenshot.jpg', record: $media);
+    });
+
     test('shows uploader name for a User', function () {
         Storage::fake('s3');
 

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -41,7 +41,9 @@ use App\Observers\MediaObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Str;
 use Spatie\MediaLibrary\MediaCollections\Models\Media as SpatieMedia;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 
 /**
  * @mixin IdeHelperMedia
@@ -55,6 +57,28 @@ class Media extends SpatieMedia
     public function createdBy(): MorphTo
     {
         return $this->morphTo('createdBy');
+    }
+
+    /**
+     * Build an RFC 6266 `attachment` Content-Disposition value safe to pass to S3.
+     *
+     * S3 rejects `response-content-disposition` values that are not representable in
+     * ISO-8859-1 (e.g. a file name containing a narrow no-break space), so the real
+     * UTF-8 name is carried in the RFC 5987 `filename*` parameter alongside an ASCII fallback.
+     */
+    public function attachmentContentDisposition(): string
+    {
+        $fallback = Str::of($this->file_name)
+            ->ascii()
+            ->replace(['%', '/', '\\', '"'], '')
+            ->trim()
+            ->toString();
+
+        return HeaderUtils::makeDisposition(
+            HeaderUtils::DISPOSITION_ATTACHMENT,
+            $this->file_name,
+            $fallback !== '' ? $fallback : 'download',
+        );
     }
 
     public function getCreatedByNameAttribute(): string

--- a/resources/views/filament/infolists/components/code-entry.blade.php
+++ b/resources/views/filament/infolists/components/code-entry.blade.php
@@ -43,6 +43,5 @@
     <pre
         class="ring-gray-950/10 whitespace-pre-wrap rounded bg-gray-50 p-4 shadow-sm dark:bg-gray-950 dark:ring-white/20"
     >
-{{ $state }}</pre
-    >
+{{ $state }}</pre>
 </x-dynamic-component>

--- a/resources/views/filament/infolists/components/code-entry.blade.php
+++ b/resources/views/filament/infolists/components/code-entry.blade.php
@@ -43,5 +43,6 @@
     <pre
         class="ring-gray-950/10 whitespace-pre-wrap rounded bg-gray-50 p-4 shadow-sm dark:bg-gray-950 dark:ring-white/20"
     >
-{{ $state }}</pre>
+{{ $state }}</pre
+    >
 </x-dynamic-component>

--- a/tests/Tenant/Models/MediaTest.php
+++ b/tests/Tenant/Models/MediaTest.php
@@ -34,22 +34,31 @@
 </COPYRIGHT>
 */
 
-namespace AidingApp\KnowledgeBase\Http\Controllers;
-
-use AidingApp\KnowledgeBase\Http\Requests\KnowledgeBaseArticleMediaDownloadRequest;
-use App\Http\Controllers\Controller;
 use App\Models\Media;
-use Illuminate\Http\RedirectResponse;
 
-class KnowledgeBaseArticleMediaDownloadController extends Controller
-{
-    public function __invoke(KnowledgeBaseArticleMediaDownloadRequest $request, Media $media): RedirectResponse
-    {
-        return redirect(
-            $media->getTemporaryUrl(
-                expiration: now()->addMinute(),
-                options: ['ResponseContentDisposition' => $media->attachmentContentDisposition()]
-            )
-        );
-    }
-}
+describe('attachmentContentDisposition', function () {
+    it('builds an ISO-8859-1 safe disposition for a file name that is not Latin-1 representable', function () {
+        // macOS screenshots use a narrow no-break space (U+202F) before AM/PM, which S3 rejects in the header.
+        $media = new Media();
+        $media->file_name = "Screenshot-2026-09-08-at-7.48.39\u{202F}PM.jpg";
+
+        $disposition = $media->attachmentContentDisposition();
+
+        expect(mb_check_encoding($disposition, 'ISO-8859-1'))->toBeTrue()
+            ->and($disposition)->toStartWith('attachment;')
+            ->and($disposition)->toContain("filename*=utf-8''")
+            ->and(rawurldecode($disposition))->toContain($media->file_name);
+    });
+
+    it('builds a simple disposition for an ASCII file name', function () {
+        $media = new Media();
+        $media->file_name = 'report.png';
+
+        $disposition = $media->attachmentContentDisposition();
+
+        expect(mb_check_encoding($disposition, 'ISO-8859-1'))->toBeTrue()
+            ->and($disposition)->toStartWith('attachment;')
+            ->and($disposition)->toContain('report.png')
+            ->and($disposition)->not->toContain('filename*');
+    });
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1496

### Technical Description

Resolves issues with files that have spaces in their names. This breaks download links.

Also prevents email ingestion from including the extension in the friendly name, which was causing in some places for it to output twice. Also added guards against displaying it twice in places that do so now. Opted to NOT do a data migration to fix ones with the ext currently in the name since we have the shim.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
