### PR TITLE
[AIDAPP-1488]: Remove the manage access button for projects as it is duplicative to the Access tab functionality

### DIFF
--- a/app-modules/project/resources/views/filament/resources/projects/widgets/project-dashboard-header-widget.blade.php
+++ b/app-modules/project/resources/views/filament/resources/projects/widgets/project-dashboard-header-widget.blade.php
@@ -81,10 +81,6 @@
                     </div>
 
                     <div class="flex flex-wrap items-center gap-2">
-                        @if ($this->manageAccessAction->isVisible())
-                            {{ $this->manageAccessAction }}
-                        @endif
-
                         @if ($this->editProjectAction->isVisible())
                             {{ $this->editProjectAction }}
                         @endif

--- a/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectDashboardHeaderWidget.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Widgets/ProjectDashboardHeaderWidget.php
@@ -36,7 +36,6 @@
 
 namespace AidingApp\Project\Filament\Resources\Projects\Widgets;
 
-use AidingApp\Project\Filament\Actions\ProjectManageAccessAction;
 use AidingApp\Project\Filament\Resources\Projects\ProjectResource;
 use AidingApp\Project\Models\Project;
 use AidingApp\Project\Models\Scopes\WithProgressCounts;
@@ -73,13 +72,6 @@ class ProjectDashboardHeaderWidget extends Widget implements HasActions, HasSche
             ->extraAttributes(['class' => 'grow'])
             ->authorize(fn (): bool => auth()->user()->can('update', $this->record))
             ->url(fn (): string => ProjectResource::getUrl('edit', ['record' => $this->record]));
-    }
-
-    public function manageAccessAction(): Action
-    {
-        return ProjectManageAccessAction::make('manageAccess')
-            ->extraAttributes(['class' => 'grow'])
-            ->record($this->record);
     }
 
     public function getProgress(): int

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ViewProjectTest.php
@@ -1193,6 +1193,7 @@ it('calculates progress as 0 when the project has no pipeline entries', function
     livewire(ProjectDashboardHeaderWidget::class, [
         'record' => $project,
     ])
+        ->assertActionDoesNotExist('manageAccess')
         ->assertSee('Progress: 0%');
 });
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/AIDAPP-1488

### Technical Description

- Remove manage access action from `ProjectDashboardHeaderWidget` and update related tests

### Any deployment steps required?

No

### Cleanup Tasks

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/aidingapp/blob/main/README.md#contributing).
